### PR TITLE
Fix Flyway migration discovery for Gradle task

### DIFF
--- a/.env.db.example
+++ b/.env.db.example
@@ -1,0 +1,8 @@
+# Хостовая машина (Gradle/Flyway запускаются с хоста)
+DATABASE_URL=jdbc:postgresql://localhost:5432/newsbot
+DATABASE_USER=app
+DATABASE_PASS=app_pass
+DATABASE_SCHEMA=public
+
+# Если Gradle запускается в Dev-container'е и БД на хосте — используйте:
+# DATABASE_URL=jdbc:postgresql://host.docker.internal:5432/newsbot

--- a/deploy/compose/postgres/docker-compose.yml
+++ b/deploy/compose/postgres/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: newsbot-postgres
+    environment:
+      POSTGRES_DB: newsbot
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app_pass
+      TZ: UTC
+    ports:
+      - "5432:5432"
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+      - ./init:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER} -h 127.0.0.1 -p 5432 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+    restart: unless-stopped
+
+volumes:
+  dbdata:

--- a/deploy/compose/postgres/init/001-enable-extensions.sql
+++ b/deploy/compose/postgres/init/001-enable-extensions.sql
@@ -1,0 +1,2 @@
+-- Выполнится только на самом первом старте (когда datadir пуст)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -45,6 +45,6 @@ configure<FlywayExtension> {
     user = System.getenv("DATABASE_USER") ?: "app"
     password = System.getenv("DATABASE_PASS") ?: "app_pass"
     schemas = arrayOf(System.getenv("DATABASE_SCHEMA") ?: "public")
-    locations = arrayOf("classpath:db/migration")
+    locations = arrayOf("filesystem:src/main/resources/db/migration")
     configurations = arrayOf("flyway")
 }


### PR DESCRIPTION
## Summary
- point the Flyway Gradle plugin at the filesystem migration directory so the SQL files are discovered during local runs

## Testing
- ./gradlew :storage:flywayMigrate -i --console plain

------
https://chatgpt.com/codex/tasks/task_e_68c9613540708321928e1a63fd073b60