### PR TITLE
Add external data integrations with caching and tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.server.content.negotiation)
     implementation(project(":storage"))
+    implementation(project(":integrations"))
+    implementation("io.micrometer:micrometer-registry-prometheus:${libs.versions.micrometer.get()}")
 }
 
 application {

--- a/app/src/main/kotlin/Application.kt
+++ b/app/src/main/kotlin/Application.kt
@@ -1,18 +1,21 @@
 package app
 
 import db.DatabaseFactory
+import health.healthRoutes
+import integrations.integrationsModule
+import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.contentnegotiation.*
-import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.routing.*
-import health.healthRoutes
 
 fun main() {
     embeddedServer(Netty, port = 8080) {
         install(ContentNegotiation) { json() }
         DatabaseFactory.init()
+        @Suppress("UNUSED_VARIABLE")
+        val integrations = integrationsModule()
         routing { healthRoutes() }
     }.start(wait = true)
 }

--- a/app/src/main/kotlin/integrations/IntegrationsModule.kt
+++ b/app/src/main/kotlin/integrations/IntegrationsModule.kt
@@ -1,0 +1,59 @@
+package integrations
+
+import cbr.CbrClient
+import coingecko.CoinGeckoClient
+import http.defaultHttpClient
+import io.ktor.client.HttpClient
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopping
+import io.ktor.server.config.configOrNull
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
+import io.ktor.util.AttributeKey
+import moex.MoexIssClient
+
+private val IntegrationsModuleKey = AttributeKey<IntegrationsModule>("IntegrationsModule")
+
+class IntegrationsModule(
+    val httpClient: HttpClient,
+    val meterRegistry: PrometheusMeterRegistry,
+    val moexClient: MoexIssClient,
+    val coinGeckoClient: CoinGeckoClient,
+    val cbrClient: CbrClient
+)
+
+fun Application.integrationsModule(): IntegrationsModule {
+    if (attributes.contains(IntegrationsModuleKey)) {
+        return attributes[IntegrationsModuleKey]
+    }
+    val config = environment.config
+    val integrationsConfig = config.configOrNull("integrations")
+    val appName = integrationsConfig?.propertyOrNull("appName")?.getString() ?: "newsbot/dev"
+    val moexBaseUrl = integrationsConfig?.configOrNull("moex")?.propertyOrNull("baseUrl")?.getString()
+        ?: "https://iss.moex.com"
+    val coinGeckoBaseUrl = integrationsConfig?.configOrNull("coingecko")?.propertyOrNull("baseUrl")?.getString()
+        ?: "https://api.coingecko.com"
+    val cbrBaseUrl = integrationsConfig?.configOrNull("cbr")?.propertyOrNull("baseUrl")?.getString()
+        ?: "https://www.cbr.ru"
+
+    val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT).also {
+        it.config().commonTags("component", "integrations")
+    }
+    val httpClient = defaultHttpClient(appName)
+
+    val module = IntegrationsModule(
+        httpClient = httpClient,
+        meterRegistry = meterRegistry,
+        moexClient = MoexIssClient(httpClient, moexBaseUrl, meterRegistry),
+        coinGeckoClient = CoinGeckoClient(httpClient, coinGeckoBaseUrl, meterRegistry),
+        cbrClient = CbrClient(httpClient, cbrBaseUrl, meterRegistry)
+    )
+    attributes.put(IntegrationsModuleKey, module)
+
+    environment.monitor.subscribe(ApplicationStopping) {
+        meterRegistry.close()
+        httpClient.close()
+    }
+
+    return module
+}

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -18,3 +18,23 @@ db {
   driver = "org.postgresql.Driver"
   schema = "public"
 }
+
+integrations {
+  appName = "newsbot/0.1.0"
+  appName = ${?INTEGRATIONS_APP_NAME}
+
+  moex {
+    baseUrl = "https://iss.moex.com"
+    baseUrl = ${?MOEX_BASE_URL}
+  }
+
+  coingecko {
+    baseUrl = "https://api.coingecko.com"
+    baseUrl = ${?COINGECKO_BASE_URL}
+  }
+
+  cbr {
+    baseUrl = "https://www.cbr.ru"
+    baseUrl = ${?CBR_BASE_URL}
+  }
+}

--- a/integrations/build.gradle.kts
+++ b/integrations/build.gradle.kts
@@ -1,1 +1,36 @@
-// Integrations module build script placeholder
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    compilerOptions {
+        allWarningsAsErrors.set(true)
+        jvmTarget.set(JvmTarget.JVM_21)
+        freeCompilerArgs.addAll("-Xjsr305=strict", "-progressive")
+    }
+}
+
+val ktorVersion = libs.versions.ktor.get()
+val coroutinesVersion = libs.versions.coroutines.get()
+val micrometerVersion = libs.versions.micrometer.get()
+
+dependencies {
+    implementation("io.ktor:ktor-client-core-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-client-logging:$ktorVersion")
+    implementation("io.ktor:ktor-client-encoding:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+    implementation(libs.serialization.json)
+    implementation(libs.micrometer.core)
+    implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
+
+    testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+}

--- a/integrations/src/main/kotlin/cache/TtlCache.kt
+++ b/integrations/src/main/kotlin/cache/TtlCache.kt
@@ -1,0 +1,71 @@
+package cache
+
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CompletableDeferred
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
+
+class TtlCache<K : Any, V : Any>(
+    private val clock: Clock = Clock.systemUTC()
+) {
+    private data class Entry<V>(val value: V, val expiresAt: Instant) {
+        fun isExpired(now: Instant): Boolean = now.isAfter(expiresAt)
+    }
+
+    private val store = ConcurrentHashMap<K, Entry<V>>()
+    private val inFlight = ConcurrentHashMap<K, CompletableDeferred<V>>()
+
+    suspend fun getOrPut(key: K, ttl: Duration, loader: suspend () -> V): V {
+        val now = clock.instant()
+        store[key]?.let { entry ->
+            if (!entry.isExpired(now)) {
+                return entry.value
+            }
+            store.remove(key, entry)
+        }
+
+        inFlight[key]?.let { existing ->
+            return existing.await()
+        }
+
+        val deferred = CompletableDeferred<V>()
+        val previous = inFlight.putIfAbsent(key, deferred)
+        if (previous != null) {
+            return previous.await()
+        }
+
+        try {
+            val value = loader()
+            val expiresAt = expiryInstant(ttl)
+            if (expiresAt != null) {
+                store[key] = Entry(value, expiresAt)
+            }
+            deferred.complete(value)
+            return value
+        } catch (t: Throwable) {
+            deferred.completeExceptionally(t)
+            throw t
+        } finally {
+            inFlight.remove(key, deferred)
+        }
+    }
+
+    fun invalidate(key: K) {
+        store.remove(key)
+    }
+
+    fun clear() {
+        store.clear()
+    }
+
+    private fun expiryInstant(ttl: Duration): Instant? {
+        if (ttl <= ZERO) {
+            return null
+        }
+        val millis = ttl.inWholeMilliseconds
+        val expiresIn = if (millis <= 0L) 0L else millis
+        return clock.instant().plusMillis(expiresIn)
+    }
+}

--- a/integrations/src/main/kotlin/cbr/CbrClient.kt
+++ b/integrations/src/main/kotlin/cbr/CbrClient.kt
@@ -1,0 +1,137 @@
+package cbr
+
+import cache.TtlCache
+import http.HttpClientError
+import http.HttpMetricsRecorder
+import http.HttpResult
+import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.micrometer.core.instrument.MeterRegistry
+import java.io.StringReader
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import javax.xml.parsers.ParserConfigurationException
+import javax.xml.parsers.DocumentBuilderFactory
+import java.io.IOException
+import org.w3c.dom.Element
+import org.xml.sax.InputSource
+import org.xml.sax.SAXException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+
+class CbrClient(
+    private val httpClient: HttpClient,
+    private val baseUrl: String,
+    meterRegistry: MeterRegistry,
+    private val clock: Clock = Clock.systemUTC()
+) {
+    private val metrics = HttpMetricsRecorder(meterRegistry, "cbr", javaClass.name)
+    private val cache = TtlCache<String, List<CbrRate>>(clock)
+
+    suspend fun getXmlDaily(date: LocalDate?): HttpResult<List<CbrRate>> {
+        val cacheKey = date?.toString() ?: "latest"
+        return runCatching {
+            cache.getOrPut(cacheKey, DAILY_TTL) {
+                metrics.record("xmlDaily") {
+                    requestXmlDaily(date)
+                }
+            }
+        }
+    }
+
+    private suspend fun requestXmlDaily(date: LocalDate?): List<CbrRate> {
+        val response = httpClient.get("$baseUrl/scripts/XML_daily.asp") {
+            accept(ContentType.Application.Xml)
+            if (date != null) {
+                parameter("date_req", date.format(CBR_REQUEST_FORMAT))
+            }
+        }.bodyAsText()
+        return parseXml(response)
+    }
+
+    private fun parseXml(xml: String): List<CbrRate> {
+        val builder = try {
+            documentBuilderFactory.newDocumentBuilder()
+        } catch (ex: ParserConfigurationException) {
+            throw HttpClientError.UnexpectedError(null, ex)
+        }
+        val document = try {
+            builder.parse(InputSource(StringReader(xml)))
+        } catch (ex: SAXException) {
+            throw HttpClientError.DeserializationError("Failed to parse CBR XML", ex)
+        } catch (ex: IOException) {
+            throw HttpClientError.DeserializationError("Failed to read CBR XML", ex)
+        }
+        val root = document.documentElement ?: throw HttpClientError.DeserializationError("Empty CBR XML payload")
+        val asOfInstant = parseAsOf(root.getAttribute("Date"))
+        val nodes = root.getElementsByTagName("Valute")
+        val result = mutableListOf<CbrRate>()
+        for (i in 0 until nodes.length) {
+            val element = nodes.item(i) as? Element ?: continue
+            val code = element.textContentOf("CharCode")?.uppercase()
+                ?: throw HttpClientError.DeserializationError("Missing CharCode in CBR payload")
+            val nominalText = element.textContentOf("Nominal")
+                ?: throw HttpClientError.DeserializationError("Missing Nominal for $code")
+            val nominal = nominalText.toBigDecimalOrNull()
+                ?: throw HttpClientError.DeserializationError("Invalid nominal '$nominalText' for $code")
+            if (nominal.compareTo(BigDecimal.ZERO) == 0) {
+                throw HttpClientError.DeserializationError("Nominal is zero for $code")
+            }
+            val valueText = element.textContentOf("Value")
+                ?: throw HttpClientError.DeserializationError("Missing Value for $code")
+            val value = valueText.replace(',', '.').toBigDecimalOrNull()
+                ?: throw HttpClientError.DeserializationError("Invalid value '$valueText' for $code")
+            val rate = value.divide(nominal, 8, RoundingMode.HALF_UP)
+            result += CbrRate(code, rate, asOfInstant)
+        }
+        return result
+    }
+
+    private fun Element.textContentOf(tag: String): String? = getElementsByTagName(tag)
+        .item(0)
+        ?.textContent
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+
+    private fun parseAsOf(raw: String?): Instant {
+        if (raw.isNullOrBlank()) {
+            return clock.instant()
+        }
+        val date = try {
+            LocalDate.parse(raw, CBR_RESPONSE_FORMAT)
+        } catch (ex: DateTimeParseException) {
+            throw HttpClientError.DeserializationError("Invalid CBR date '$raw'", ex)
+        }
+        return date.atStartOfDay(MOSCOW_ZONE).toInstant()
+    }
+
+    companion object {
+        private val MOSCOW_ZONE: ZoneId = ZoneId.of("Europe/Moscow")
+        private val CBR_REQUEST_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+        private val CBR_RESPONSE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+        private val DAILY_TTL: Duration = 1.days
+        private val documentBuilderFactory: DocumentBuilderFactory = DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = false
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            setFeature("http://xml.org/sax/features/external-general-entities", false)
+            setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        }
+    }
+}
+
+data class CbrRate(
+    val currencyCode: String,
+    val rateRub: BigDecimal,
+    val asOf: Instant
+)

--- a/integrations/src/main/kotlin/coingecko/CoinGeckoClient.kt
+++ b/integrations/src/main/kotlin/coingecko/CoinGeckoClient.kt
@@ -1,0 +1,193 @@
+package coingecko
+
+import cache.TtlCache
+import http.HttpClientError
+import http.HttpMetricsRecorder
+import http.HttpResult
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.micrometer.core.instrument.MeterRegistry
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.Duration as JavaDuration
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class CoinGeckoClient(
+    private val httpClient: HttpClient,
+    private val baseUrl: String,
+    meterRegistry: MeterRegistry,
+    private val clock: Clock = Clock.systemUTC(),
+    private val minRequestInterval: Duration = 1.seconds
+) {
+    private val metrics = HttpMetricsRecorder(meterRegistry, "coingecko", javaClass.name)
+    private val priceCache = TtlCache<String, Map<String, Map<String, BigDecimal>>>(clock)
+    private val chartCache = TtlCache<String, MarketChart>(clock)
+    private val rateMutex = Mutex()
+    private var lastRequestAt: Instant? = null
+
+    suspend fun getSimplePrice(ids: List<String>, vs: List<String>): HttpResult<Map<String, Map<String, BigDecimal>>> {
+        if (ids.isEmpty()) {
+            return Result.failure(HttpClientError.ValidationError("ids must not be empty"))
+        }
+        if (ids.size > MAX_SIMPLE_PRICE_IDS) {
+            return Result.failure(HttpClientError.ValidationError("ids limit is $MAX_SIMPLE_PRICE_IDS"))
+        }
+        if (vs.isEmpty()) {
+            return Result.failure(HttpClientError.ValidationError("vs currencies must not be empty"))
+        }
+        if (vs.size > MAX_SIMPLE_PRICE_CURRENCIES) {
+            return Result.failure(HttpClientError.ValidationError("vs currencies limit is $MAX_SIMPLE_PRICE_CURRENCIES"))
+        }
+        val normalizedIds = ids.map { it.trim().lowercase() }.filter { it.isNotEmpty() }
+        if (normalizedIds.isEmpty()) {
+            return Result.failure(HttpClientError.ValidationError("ids must contain non-blank values"))
+        }
+        val normalizedVs = vs.map { it.trim().lowercase() }.filter { it.isNotEmpty() }
+        if (normalizedVs.isEmpty()) {
+            return Result.failure(HttpClientError.ValidationError("vs currencies must contain non-blank values"))
+        }
+        val idsParam = normalizedIds.joinToString(",")
+        val vsParam = normalizedVs.joinToString(",")
+        val cacheKey = "$idsParam|$vsParam"
+        return runCatching {
+            priceCache.getOrPut(cacheKey, SIMPLE_PRICE_TTL) {
+                metrics.record("simplePrice") {
+                    rateLimited {
+                        requestSimplePrice(idsParam, vsParam)
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun getMarketChart(id: String, vs: String, days: Int): HttpResult<MarketChart> {
+        if (id.isBlank()) {
+            return Result.failure(HttpClientError.ValidationError("id must not be blank"))
+        }
+        if (vs.isBlank()) {
+            return Result.failure(HttpClientError.ValidationError("vs currency must not be blank"))
+        }
+        if (days <= 0 || days > MAX_MARKET_CHART_DAYS) {
+            return Result.failure(HttpClientError.ValidationError("days must be in 1..$MAX_MARKET_CHART_DAYS"))
+        }
+        val normalizedId = id.trim().lowercase()
+        val normalizedVs = vs.trim().lowercase()
+        val cacheKey = listOf(normalizedId, normalizedVs, days.toString()).joinToString(":")
+        return runCatching {
+            chartCache.getOrPut(cacheKey, MARKET_CHART_TTL) {
+                metrics.record("marketChart") {
+                    rateLimited {
+                        requestMarketChart(normalizedId, normalizedVs, days)
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun requestSimplePrice(ids: String, vs: String): Map<String, Map<String, BigDecimal>> {
+        val payloadElement: JsonElement = httpClient.get("$baseUrl/api/v3/simple/price") {
+            parameter("ids", ids)
+            parameter("vs_currencies", vs)
+        }.body()
+        val payload = payloadElement.asJsonObjectOrNull()
+            ?: throw HttpClientError.DeserializationError("Expected JSON object for simple price response")
+        return payload.entries.associate { (asset, value) ->
+            val priceObject = value as? JsonObject
+                ?: throw HttpClientError.DeserializationError("Expected JSON object for $asset simple price response")
+            val prices = priceObject.entries.associate { (currency, priceElement) ->
+                currency to priceElement.toBigDecimalOrThrow("$asset:$currency")
+            }
+            asset to prices
+        }
+    }
+
+    private suspend fun requestMarketChart(id: String, vs: String, days: Int): MarketChart {
+        val raw: CoinGeckoMarketChartRaw = httpClient.get("$baseUrl/api/v3/coins/$id/market_chart") {
+            parameter("vs_currency", vs)
+            parameter("days", days)
+        }.body()
+        return raw.toDomain()
+    }
+
+    private suspend fun <T> rateLimited(block: suspend () -> T): T = rateMutex.withLock {
+        val now = clock.instant()
+        val last = lastRequestAt
+        val minMillis = minRequestInterval.inWholeMilliseconds
+        if (last != null && minMillis > 0) {
+            val elapsed = JavaDuration.between(last, now).toMillis()
+            val waitMillis = minMillis - elapsed
+            if (waitMillis > 0) {
+                delay(waitMillis)
+            }
+        }
+        val result = block()
+        lastRequestAt = clock.instant()
+        result
+    }
+
+    companion object {
+        private const val MAX_SIMPLE_PRICE_IDS = 50
+        private const val MAX_SIMPLE_PRICE_CURRENCIES = 10
+        private const val MAX_MARKET_CHART_DAYS = 365
+        private val SIMPLE_PRICE_TTL: Duration = 15.seconds
+        private val MARKET_CHART_TTL: Duration = 30.seconds
+    }
+}
+
+@Serializable
+private data class CoinGeckoMarketChartRaw(
+    val prices: List<List<JsonElement>> = emptyList(),
+    @SerialName("market_caps") val marketCaps: List<List<JsonElement>> = emptyList(),
+    @SerialName("total_volumes") val totalVolumes: List<List<JsonElement>> = emptyList()
+) {
+    fun toDomain(): MarketChart = MarketChart(
+        prices = prices.map { it.toChartPoint("prices") },
+        marketCaps = marketCaps.map { it.toChartPoint("market_caps") },
+        totalVolumes = totalVolumes.map { it.toChartPoint("total_volumes") }
+    )
+
+    private fun List<JsonElement>.toChartPoint(section: String): ChartPoint {
+        if (size < 2) {
+            throw HttpClientError.DeserializationError("Invalid entry in $section section")
+        }
+        val timestampValue = this[0].jsonPrimitive.contentOrNull?.trim()
+            ?: throw HttpClientError.DeserializationError("Missing timestamp in $section section")
+        val timestamp = timestampValue.toLongOrNull()
+            ?: throw HttpClientError.DeserializationError("Invalid timestamp '$timestampValue' in $section section")
+        val price = this[1].toBigDecimalOrThrow(section)
+        return ChartPoint(Instant.ofEpochMilli(timestamp), price)
+    }
+}
+
+data class MarketChart(
+    val prices: List<ChartPoint>,
+    val marketCaps: List<ChartPoint>,
+    val totalVolumes: List<ChartPoint>
+)
+
+data class ChartPoint(val timestamp: Instant, val value: BigDecimal)
+
+private fun JsonElement.toBigDecimalOrThrow(label: String): BigDecimal {
+    val primitive = jsonPrimitive
+    val raw = primitive.contentOrNull?.trim()?.takeIf { it.isNotEmpty() }
+        ?: throw HttpClientError.DeserializationError("Missing numeric value for $label")
+    val normalized = raw.replace(',', '.')
+    return normalized.toBigDecimalOrNull()
+        ?: throw HttpClientError.DeserializationError("Invalid numeric value '$raw' for $label")
+}
+
+private fun JsonElement.asJsonObjectOrNull(): JsonObject? = this as? JsonObject

--- a/integrations/src/main/kotlin/http/HttpClients.kt
+++ b/integrations/src/main/kotlin/http/HttpClients.kt
@@ -1,0 +1,205 @@
+package http
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.plugins.cache.HttpCache
+import io.ktor.client.plugins.compression.ContentEncoding
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.logging.SIMPLE
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import java.io.IOException
+import java.time.Duration
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerializationException
+import org.slf4j.LoggerFactory
+import kotlin.math.pow
+
+fun defaultHttpClient(appName: String): HttpClient = HttpClient(CIO) {
+    configureDefaultHttpClient(appName)
+}
+
+internal fun defaultHttpClient(appName: String, engineFactory: HttpClientEngineFactory<*>): HttpClient =
+    HttpClient(engineFactory) {
+        configureDefaultHttpClient(appName)
+    }
+
+internal fun HttpClientConfig<*>.configureDefaultHttpClient(appName: String) {
+    expectSuccess = true
+
+    install(HttpTimeout) {
+        connectTimeoutMillis = Duration.ofSeconds(5).toMillis()
+        requestTimeoutMillis = Duration.ofSeconds(15).toMillis()
+        socketTimeoutMillis = Duration.ofSeconds(15).toMillis()
+    }
+
+    install(HttpRequestRetry) {
+        maxRetries = 3
+        retryIf(maxRetries) { _, response ->
+            response.status == HttpStatusCode.TooManyRequests || response.status.value >= 500
+        }
+        retryOnExceptionIf { _, cause -> cause is IOException }
+        delayMillis(respectRetryAfterHeader = false) { attempt ->
+            val headerDelay = response?.headers?.get(HttpHeaders.RetryAfter)?.let { parseRetryAfterMillis(it) }
+            headerDelay ?: calculateExponentialDelay(attempt)
+        }
+    }
+
+    install(ContentNegotiation) {
+        json(
+            kotlinx.serialization.json.Json {
+                ignoreUnknownKeys = true
+                explicitNulls = false
+                encodeDefaults = false
+            }
+        )
+    }
+
+    install(ContentEncoding)
+    install(HttpCache)
+    install(Logging) {
+        logger = Logger.SIMPLE
+        level = LogLevel.INFO
+    }
+
+    install(DefaultRequest) {
+        header(HttpHeaders.UserAgent, "$appName (Ktor)")
+    }
+}
+
+sealed class HttpClientError(message: String, cause: Throwable? = null) : RuntimeException(message, cause) {
+    abstract val category: String
+    open val metricsTag: String get() = category
+
+    data class HttpStatusError(val status: HttpStatusCode, val requestUrl: String, val origin: Throwable? = null) :
+        HttpClientError("HTTP ${status.value} for $requestUrl", origin) {
+        override val category: String = "http"
+        override val metricsTag: String get() = status.value.toString()
+    }
+
+    data class TimeoutError(val requestUrl: String?, val origin: Throwable) :
+        HttpClientError("Request timed out for ${requestUrl ?: "unknown"}", origin) {
+        override val category: String = "timeout"
+    }
+
+    data class NetworkError(val requestUrl: String?, val origin: Throwable) :
+        HttpClientError("Network error for ${requestUrl ?: "unknown"}", origin) {
+        override val category: String = "network"
+    }
+
+    data class DeserializationError(val details: String, val origin: Throwable? = null) :
+        HttpClientError("Failed to deserialize response: $details", origin) {
+        override val category: String = "deserialization"
+    }
+
+    data class UnexpectedError(val requestUrl: String?, val origin: Throwable) :
+        HttpClientError("Unexpected error for ${requestUrl ?: "unknown"}", origin) {
+        override val category: String = "unexpected"
+    }
+
+    data class ValidationError(val details: String) : HttpClientError(details) {
+        override val category: String = "validation"
+    }
+}
+
+internal fun Throwable.toHttpClientError(): HttpClientError = when (this) {
+    is HttpClientError -> this
+    is HttpRequestTimeoutException -> HttpClientError.TimeoutError(null, this)
+    is ResponseException -> {
+        val requestUrl = runCatching { response.call.request.url.toString() }.getOrNull() ?: "unknown"
+        HttpClientError.HttpStatusError(response.status, requestUrl, this)
+    }
+    is SerializationException -> HttpClientError.DeserializationError(message ?: "serialization error", this)
+    is IOException -> HttpClientError.NetworkError(null, this)
+    else -> HttpClientError.UnexpectedError(null, this)
+}
+
+private const val REQUEST_COUNTER = "integrations.http.client.requests"
+private const val ERROR_COUNTER = "integrations.http.client.errors"
+private const val DURATION_TIMER = "integrations.http.client.duration"
+
+internal class HttpMetricsRecorder(
+    private val registry: MeterRegistry,
+    private val clientName: String,
+    loggerName: String
+) {
+    private val logger = LoggerFactory.getLogger(loggerName)
+
+    suspend fun <T> record(operation: String, block: suspend () -> T): T {
+        registry.counter(REQUEST_COUNTER, "client", clientName, "operation", operation).increment()
+        val sample = Timer.start(registry)
+        return try {
+            val result = block()
+            sample.stop(timer(operation, "success"))
+            result
+        } catch (t: Throwable) {
+            if (t is CancellationException) {
+                sample.stop(timer(operation, "cancelled"))
+                throw t
+            }
+            val error = t.toHttpClientError()
+            sample.stop(timer(operation, "failure"))
+            registry.counter(
+                ERROR_COUNTER,
+                "client",
+                clientName,
+                "operation",
+                operation,
+                "code",
+                error.metricsTag
+            ).increment()
+            logger.warn("{} request '{}' failed: {}", clientName, operation, error.message)
+            throw error
+        }
+    }
+
+    private fun timer(operation: String, outcome: String): Timer = registry.timer(
+        DURATION_TIMER,
+        "client",
+        clientName,
+        "operation",
+        operation,
+        "outcome",
+        outcome
+    )
+}
+
+typealias HttpResult<T> = Result<T>
+
+private fun parseRetryAfterMillis(headerValue: String): Long? {
+    headerValue.toLongOrNull()?.let { seconds ->
+        return TimeUnit.SECONDS.toMillis(seconds.coerceAtLeast(0))
+    }
+    return try {
+        val retryInstant = ZonedDateTime.parse(headerValue, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant()
+        val now = Instant.now()
+        val diff = Duration.between(now, retryInstant).toMillis()
+        if (diff > 0) diff else 0L
+    } catch (_: DateTimeParseException) {
+        null
+    }
+}
+
+private fun calculateExponentialDelay(attempt: Int): Long {
+    val base = 200.0
+    return (base * 2.0.pow((attempt - 1).coerceAtLeast(0))).toLong()
+}

--- a/integrations/src/main/kotlin/moex/MoexIssClient.kt
+++ b/integrations/src/main/kotlin/moex/MoexIssClient.kt
@@ -1,0 +1,275 @@
+package moex
+
+import cache.TtlCache
+import http.HttpClientError
+import http.HttpMetricsRecorder
+import http.HttpResult
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.micrometer.core.instrument.MeterRegistry
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.contentOrNull
+
+class MoexIssClient(
+    private val httpClient: HttpClient,
+    private val baseUrl: String,
+    meterRegistry: MeterRegistry,
+    private val clock: Clock = Clock.systemUTC()
+) {
+    private val metrics = HttpMetricsRecorder(meterRegistry, "moex", javaClass.name)
+    private val securitiesCache = TtlCache<String, MoexSecuritiesResponse>(clock)
+    private val candlesCache = TtlCache<String, MoexCandlesResponse>(clock)
+    private val statusCache = TtlCache<String, MoexStatusResponse>(clock)
+
+    suspend fun getSecuritiesTqbr(securities: List<String>): HttpResult<MoexSecuritiesResponse> {
+        if (securities.isEmpty()) {
+            return Result.failure(HttpClientError.ValidationError("securities list must not be empty"))
+        }
+        val normalized = securities.map { it.trim().uppercase() }.filter { it.isNotEmpty() }
+        if (normalized.isEmpty()) {
+            return Result.failure(HttpClientError.ValidationError("securities list must contain non-blank values"))
+        }
+        val cacheKey = normalized.sorted().joinToString(",")
+        return runCatching {
+            securitiesCache.getOrPut(cacheKey, SECURITIES_TTL) {
+                metrics.record("securities") {
+                    requestSecurities(cacheKey)
+                }
+            }
+        }
+    }
+
+    suspend fun getCandlesDaily(ticker: String, from: LocalDate, till: LocalDate): HttpResult<MoexCandlesResponse> {
+        if (ticker.isBlank()) {
+            return Result.failure(HttpClientError.ValidationError("ticker must not be blank"))
+        }
+        if (from.isAfter(till)) {
+            return Result.failure(HttpClientError.ValidationError("from date must not be after till date"))
+        }
+        val normalizedTicker = ticker.trim().uppercase()
+        val cacheKey = listOf(normalizedTicker, from.toString(), till.toString()).joinToString(":")
+        return runCatching {
+            candlesCache.getOrPut(cacheKey, CANDLES_TTL) {
+                metrics.record("candles") {
+                    requestCandles(normalizedTicker, from, till)
+                }
+            }
+        }
+    }
+
+    suspend fun getMarketStatus(): HttpResult<MoexStatusResponse> = runCatching {
+        statusCache.getOrPut("status", STATUS_TTL) {
+            metrics.record("marketStatus") {
+                requestMarketStatus()
+            }
+        }
+    }
+
+    private suspend fun requestSecurities(key: String): MoexSecuritiesResponse {
+        val response: MoexSecuritiesRaw = httpClient.get("$baseUrl/iss/engines/stock/markets/shares/boards/TQBR/securities.json") {
+            parameter("securities", key)
+            parameter("iss.meta", "off")
+        }.body()
+        return response.toDomain()
+    }
+
+    private suspend fun requestCandles(ticker: String, from: LocalDate, till: LocalDate): MoexCandlesResponse {
+        val response: MoexCandlesRaw = httpClient.get("$baseUrl/iss/engines/stock/markets/shares/securities/$ticker/candles.json") {
+            parameter("interval", "24")
+            parameter("from", from.toString())
+            parameter("till", till.toString())
+            parameter("iss.meta", "off")
+        }.body()
+        return response.toDomain()
+    }
+
+    private suspend fun requestMarketStatus(): MoexStatusResponse {
+        val response: MoexStatusRaw = httpClient.get("$baseUrl/iss/engines/stock/markets/shares/marketstatus.json") {
+            parameter("iss.meta", "off")
+        }.body()
+        return response.toDomain()
+    }
+
+    companion object {
+        private val MOSCOW_ZONE: ZoneId = ZoneId.of("Europe/Moscow")
+        private val MOEX_DATE_TIME: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        private val MOEX_DATE: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        private val SECURITIES_TTL: Duration = 30.seconds
+        private val CANDLES_TTL: Duration = 30.seconds
+        private val STATUS_TTL: Duration = 10.seconds
+    }
+
+    private fun parseInstant(value: String): Instant {
+        val trimmed = value.trim()
+        try {
+            return Instant.parse(trimmed)
+        } catch (_: DateTimeParseException) {
+            // ignored
+        }
+        try {
+            val local = LocalDateTime.parse(trimmed, MOEX_DATE_TIME)
+            return local.atZone(MOSCOW_ZONE).toInstant()
+        } catch (_: DateTimeParseException) {
+            // ignored
+        }
+        try {
+            val date = LocalDate.parse(trimmed, MOEX_DATE)
+            return date.atStartOfDay(MOSCOW_ZONE).toInstant()
+        } catch (ex: DateTimeParseException) {
+            throw HttpClientError.DeserializationError("Unable to parse timestamp '$value'", ex)
+        }
+    }
+
+    private fun MoexTableDto.asRecords(): List<Map<String, JsonElement?>> = data.map { row ->
+        columns.mapIndexed { index, column ->
+            column.uppercase() to row.getOrNull(index)
+        }.toMap()
+    }
+
+    private fun Map<String, JsonElement?>.string(vararg keys: String): String? = keys.asSequence()
+        .mapNotNull { key ->
+            get(key.uppercase())?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        }
+        .firstOrNull()
+
+    private fun Map<String, JsonElement?>.decimal(vararg keys: String): BigDecimal? = string(*keys)?.let { raw ->
+        raw.replace(',', '.').toBigDecimalOrNull()
+    }
+
+    private fun Map<String, JsonElement?>.int(vararg keys: String): Int? = string(*keys)?.toIntOrNull()
+
+    private fun Map<String, JsonElement?>.instantOrNull(vararg keys: String): Instant? = string(*keys)?.let { parseInstant(it) }
+
+    private fun Map<String, JsonElement?>.booleanOrNull(vararg keys: String): Boolean? = keys.asSequence()
+        .mapNotNull { key -> get(key.uppercase())?.jsonPrimitive?.booleanOrNull }
+        .firstOrNull()
+
+    private fun MoexSecuritiesRaw.toDomain(): MoexSecuritiesResponse {
+        val records = securities.asRecords()
+        if (securities.columns.none { it.equals("SECID", ignoreCase = true) }) {
+            throw HttpClientError.DeserializationError("SECID column is missing in MOEX securities payload")
+        }
+        val items = records.mapNotNull { record ->
+            val code = record.string("SECID") ?: return@mapNotNull null
+            MoexSecurity(
+                code = code,
+                shortName = record.string("SHORTNAME"),
+                boardId = record.string("BOARDID"),
+                lotSize = record.int("LOTSIZE"),
+                currency = record.string("FACEUNIT"),
+                prevClosePrice = record.decimal("PREVPRICE"),
+                marketPrice = record.decimal("LAST"),
+                active = record.booleanOrNull("ISSUESIZEPLACED"),
+                type = record.string("SECTYPE")
+            )
+        }
+        return MoexSecuritiesResponse(items)
+    }
+
+    private fun MoexCandlesRaw.toDomain(): MoexCandlesResponse {
+        val records = candles.asRecords()
+        val candlesList = records.map { record ->
+            MoexCandle(
+                open = record.decimal("OPEN") ?: throw HttpClientError.DeserializationError("Missing OPEN in candle"),
+                close = record.decimal("CLOSE") ?: throw HttpClientError.DeserializationError("Missing CLOSE in candle"),
+                high = record.decimal("HIGH") ?: throw HttpClientError.DeserializationError("Missing HIGH in candle"),
+                low = record.decimal("LOW") ?: throw HttpClientError.DeserializationError("Missing LOW in candle"),
+                value = record.decimal("VALUE"),
+                volume = record.decimal("VOLUME"),
+                begin = record.instantOrNull("BEGIN") ?: throw HttpClientError.DeserializationError("Missing BEGIN in candle"),
+                end = record.instantOrNull("END") ?: throw HttpClientError.DeserializationError("Missing END in candle")
+            )
+        }
+        return MoexCandlesResponse(candlesList)
+    }
+
+    private fun MoexStatusRaw.toDomain(): MoexStatusResponse {
+        val table = marketStatus ?: marketData ?: MoexTableDto()
+        val records = table.asRecords()
+        val statuses = records.map { record ->
+            MoexMarketStatus(
+                boardId = record.string("BOARDID", "BOARD"),
+                market = record.string("MARKET"),
+                state = record.string("STATE", "MARKETSTATE", "TRADE_STATUS"),
+                title = record.string("TITLE", "NAME"),
+                startTime = record.instantOrNull("BEGIN", "STARTTIME", "FROM"),
+                endTime = record.instantOrNull("END", "TILL", "ENDTIME"),
+                isTrading = record.string("TRADINGSESSION", "IS_TRADING")?.let { it == "1" || it.equals("true", true) }
+            )
+        }
+        return MoexStatusResponse(statuses)
+    }
+}
+
+@Serializable
+private data class MoexTableDto(
+    val columns: List<String> = emptyList(),
+    val data: List<List<JsonElement>> = emptyList()
+)
+
+@Serializable
+private data class MoexSecuritiesRaw(val securities: MoexTableDto = MoexTableDto())
+
+@Serializable
+private data class MoexCandlesRaw(val candles: MoexTableDto = MoexTableDto())
+
+@Serializable
+private data class MoexStatusRaw(
+    @SerialName("marketstatus") val marketStatus: MoexTableDto? = null,
+    @SerialName("marketdata") val marketData: MoexTableDto? = null
+)
+
+data class MoexSecuritiesResponse(val securities: List<MoexSecurity>)
+
+data class MoexSecurity(
+    val code: String,
+    val shortName: String?,
+    val boardId: String?,
+    val lotSize: Int?,
+    val currency: String?,
+    val prevClosePrice: BigDecimal?,
+    val marketPrice: BigDecimal?,
+    val active: Boolean?,
+    val type: String?
+)
+
+data class MoexCandlesResponse(val candles: List<MoexCandle>)
+
+data class MoexCandle(
+    val open: BigDecimal,
+    val close: BigDecimal,
+    val high: BigDecimal,
+    val low: BigDecimal,
+    val value: BigDecimal?,
+    val volume: BigDecimal?,
+    val begin: Instant,
+    val end: Instant
+)
+
+data class MoexStatusResponse(val statuses: List<MoexMarketStatus>)
+
+data class MoexMarketStatus(
+    val boardId: String?,
+    val market: String?,
+    val state: String?,
+    val title: String?,
+    val startTime: Instant?,
+    val endTime: Instant?,
+    val isTrading: Boolean?
+)

--- a/integrations/src/test/kotlin/TestHttpClientFactory.kt
+++ b/integrations/src/test/kotlin/TestHttpClientFactory.kt
@@ -1,0 +1,18 @@
+package testutils
+
+import http.configureDefaultHttpClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+
+fun testHttpClient(
+    appName: String = "newsbot/test",
+    handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData
+): HttpClient = HttpClient(MockEngine) {
+    configureDefaultHttpClient(appName)
+    engine {
+        addHandler(handler)
+    }
+}

--- a/integrations/src/test/kotlin/cbr/CbrClientTest.kt
+++ b/integrations/src/test/kotlin/cbr/CbrClientTest.kt
@@ -1,0 +1,181 @@
+package cbr
+
+import http.HttpClientError
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import java.math.BigDecimal
+import java.time.LocalDate
+import testutils.testHttpClient
+
+private const val BASE_URL = "https://mock.cbr"
+
+class CbrClientTest : FunSpec({
+    test("getXmlDaily parses XML response") {
+        val registry = SimpleMeterRegistry()
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ValCurs Date="20.05.2024" name="Foreign Currency Market">
+              <Valute ID="R01235">
+                <CharCode>USD</CharCode>
+                <Nominal>1</Nominal>
+                <Value>90,1234</Value>
+              </Valute>
+            </ValCurs>
+        """.trimIndent()
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            respond(
+                content = xml,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Xml.toString()))
+            )
+        }
+        val cbrClient = CbrClient(client, BASE_URL, registry)
+        try {
+            val result = cbrClient.getXmlDaily(LocalDate.parse("2024-05-20"))
+            result.isSuccess shouldBe true
+            val rates = result.getOrThrow()
+            rates.first().currencyCode shouldBe "USD"
+            rates.first().rateRub shouldBe BigDecimal("90.12340000")
+            callCount shouldBe 1
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getXmlDaily retries on 429 responses") {
+        val registry = SimpleMeterRegistry()
+        val xml = """
+            <ValCurs Date="20.05.2024">
+              <Valute><CharCode>USD</CharCode><Nominal>1</Nominal><Value>90,00</Value></Valute>
+            </ValCurs>
+        """.trimIndent()
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            if (callCount < 3) {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.TooManyRequests,
+                    headers = headersOf(
+                        HttpHeaders.ContentType to listOf(ContentType.Application.Xml.toString()),
+                        HttpHeaders.RetryAfter to listOf("0")
+                    )
+                )
+            } else {
+                respond(
+                    content = xml,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Xml.toString()))
+                )
+            }
+        }
+        val cbrClient = CbrClient(client, BASE_URL, registry)
+        try {
+            val result = cbrClient.getXmlDaily(null)
+            result.isSuccess shouldBe true
+            callCount shouldBe 3
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getXmlDaily retries on server errors") {
+        val registry = SimpleMeterRegistry()
+        val xml = """
+            <ValCurs Date="20.05.2024">
+              <Valute><CharCode>USD</CharCode><Nominal>1</Nominal><Value>90,00</Value></Valute>
+            </ValCurs>
+        """.trimIndent()
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            if (callCount < 3) {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.BadGateway,
+                    headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Xml.toString()))
+                )
+            } else {
+                respond(
+                    content = xml,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Xml.toString()))
+                )
+            }
+        }
+        val cbrClient = CbrClient(client, BASE_URL, registry)
+        try {
+            val result = cbrClient.getXmlDaily(null)
+            result.isSuccess shouldBe true
+            callCount shouldBe 3
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getXmlDaily caches latest response") {
+        val registry = SimpleMeterRegistry()
+        val xml = """
+            <ValCurs Date="20.05.2024">
+              <Valute><CharCode>USD</CharCode><Nominal>1</Nominal><Value>90,00</Value></Valute>
+            </ValCurs>
+        """.trimIndent()
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            respond(
+                content = xml,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Xml.toString()))
+            )
+        }
+        val cbrClient = CbrClient(client, BASE_URL, registry)
+        try {
+            val first = cbrClient.getXmlDaily(null)
+            val second = cbrClient.getXmlDaily(null)
+            first.isSuccess shouldBe true
+            second.isSuccess shouldBe true
+            callCount shouldBe 1
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getXmlDaily fails on malformed XML") {
+        val registry = SimpleMeterRegistry()
+        val xml = """
+            <ValCurs Date="20.05.2024">
+              <Valute><CharCode>USD</CharCode><Nominal>0</Nominal><Value>text</Value></Valute>
+            </ValCurs>
+        """.trimIndent()
+        val client = testHttpClient { _ ->
+            respond(
+                content = xml,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Xml.toString())
+            )
+        }
+        val cbrClient = CbrClient(client, BASE_URL, registry)
+        try {
+            val result = cbrClient.getXmlDaily(null)
+            result.isSuccess shouldBe false
+            result.exceptionOrNull().shouldBeInstanceOf<HttpClientError.DeserializationError>()
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+})

--- a/integrations/src/test/kotlin/coingecko/CoinGeckoClientTest.kt
+++ b/integrations/src/test/kotlin/coingecko/CoinGeckoClientTest.kt
@@ -1,0 +1,198 @@
+package coingecko
+
+import http.HttpClientError
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import java.math.BigDecimal
+import testutils.testHttpClient
+
+private const val BASE_URL = "https://mock.coingecko"
+
+class CoinGeckoClientTest : FunSpec({
+    test("getSimplePrice returns parsed prices") {
+        val registry = SimpleMeterRegistry()
+        val json = """
+            {"bitcoin":{"usd": "100000.0", "rub": "9000000.0"}}
+        """.trimIndent()
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            respond(
+                content = json,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val coinGeckoClient = CoinGeckoClient(client, BASE_URL, registry)
+        try {
+            val result = coinGeckoClient.getSimplePrice(listOf("bitcoin"), listOf("usd", "rub"))
+            result.isSuccess shouldBe true
+            val prices = result.getOrThrow()
+            prices.shouldContainKey("bitcoin")
+            prices.getValue("bitcoin").getValue("usd") shouldBe BigDecimal("100000.0")
+            callCount shouldBe 1
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getSimplePrice retries when rate limited") {
+        val registry = SimpleMeterRegistry()
+        val json = """{"bitcoin":{"usd":"1"}}"""
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            if (callCount < 3) {
+                respond(
+                    content = "{}",
+                    status = HttpStatusCode.TooManyRequests,
+                    headers = headersOf(
+                        HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()),
+                        HttpHeaders.RetryAfter to listOf("0")
+                    )
+                )
+            } else {
+                respond(
+                    content = json,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+                )
+            }
+        }
+        val coinGeckoClient = CoinGeckoClient(client, BASE_URL, registry)
+        try {
+            val result = coinGeckoClient.getSimplePrice(listOf("bitcoin"), listOf("usd"))
+            result.isSuccess shouldBe true
+            callCount shouldBe 3
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getSimplePrice retries on server errors") {
+        val registry = SimpleMeterRegistry()
+        val json = """{"bitcoin":{"usd":"1"}}"""
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            if (callCount < 3) {
+                respond(
+                    content = "{}",
+                    status = HttpStatusCode.BadGateway,
+                    headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+                )
+            } else {
+                respond(
+                    content = json,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+                )
+            }
+        }
+        val coinGeckoClient = CoinGeckoClient(client, BASE_URL, registry)
+        try {
+            val result = coinGeckoClient.getSimplePrice(listOf("bitcoin"), listOf("usd"))
+            result.isSuccess shouldBe true
+            callCount shouldBe 3
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getSimplePrice uses cache for repeated requests") {
+        val registry = SimpleMeterRegistry()
+        val json = """{"bitcoin":{"usd":"1"}}"""
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            respond(
+                content = json,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val coinGeckoClient = CoinGeckoClient(client, BASE_URL, registry)
+        try {
+            val first = coinGeckoClient.getSimplePrice(listOf("bitcoin"), listOf("usd"))
+            val second = coinGeckoClient.getSimplePrice(listOf("bitcoin"), listOf("usd"))
+            first.isSuccess shouldBe true
+            second.isSuccess shouldBe true
+            callCount shouldBe 1
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getSimplePrice fails for malformed payload") {
+        val registry = SimpleMeterRegistry()
+        val client = testHttpClient { _ ->
+            respond(
+                content = "[]",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val coinGeckoClient = CoinGeckoClient(client, BASE_URL, registry)
+        try {
+            val result = coinGeckoClient.getSimplePrice(listOf("bitcoin"), listOf("usd"))
+            result.isSuccess shouldBe false
+            result.exceptionOrNull().shouldBeInstanceOf<HttpClientError.DeserializationError>()
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getSimplePrice rejects invalid arguments") {
+        val registry = SimpleMeterRegistry()
+        val client = testHttpClient { error("should not be called") }
+        val coinGeckoClient = CoinGeckoClient(client, BASE_URL, registry)
+        try {
+            val result = coinGeckoClient.getSimplePrice(emptyList(), listOf("usd"))
+            result.isSuccess shouldBe false
+            result.exceptionOrNull().shouldBeInstanceOf<HttpClientError.ValidationError>()
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getMarketChart parses chart data") {
+        val registry = SimpleMeterRegistry()
+        val json = """
+            {
+              "prices": [["1716200000000","100.0"]],
+              "market_caps": [["1716200000000","200.0"]],
+              "total_volumes": [["1716200000000","300.0"]]
+            }
+        """.trimIndent()
+        val client = testHttpClient { _ ->
+            respond(
+                content = json,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val coinGeckoClient = CoinGeckoClient(client, BASE_URL, registry)
+        try {
+            val result = coinGeckoClient.getMarketChart("bitcoin", "usd", 30)
+            result.isSuccess shouldBe true
+            result.getOrThrow().prices.first().value shouldBe BigDecimal("100.0")
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+})

--- a/integrations/src/test/kotlin/moex/MoexIssClientTest.kt
+++ b/integrations/src/test/kotlin/moex/MoexIssClientTest.kt
@@ -1,0 +1,177 @@
+package moex
+
+import http.HttpClientError
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import java.math.BigDecimal
+import java.time.LocalDate
+import testutils.testHttpClient
+
+private const val BASE_URL = "https://mock.moex"
+
+class MoexIssClientTest : FunSpec({
+    test("getSecuritiesTqbr returns parsed securities") {
+        val registry = SimpleMeterRegistry()
+        val responseJson = """
+            {
+              "securities": {
+                "columns": ["SECID","SHORTNAME","BOARDID","LOTSIZE","FACEUNIT","PREVPRICE","LAST","SECTYPE","ISSUESIZEPLACED"],
+                "data": [
+                  ["SBER","Sberbank","TQBR","10","RUB","250.10","251.00","share","1"],
+                  ["GAZP","Gazprom","TQBR","10","RUB","150.00","151.50","share","0"]
+                ]
+              }
+            }
+        """.trimIndent()
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            respond(
+                content = responseJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val moexClient = MoexIssClient(client, BASE_URL, registry)
+        try {
+            val result = moexClient.getSecuritiesTqbr(listOf("SBER", "GAZP"))
+            result.isSuccess shouldBe true
+            val securities = result.getOrThrow().securities
+            securities.shouldHaveSize(2)
+            securities.first { it.code == "SBER" }.marketPrice shouldBe BigDecimal("251.00")
+            callCount shouldBe 1
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getSecuritiesTqbr retries on 429 responses") {
+        val registry = SimpleMeterRegistry()
+        val successJson = """
+            {"securities":{"columns":["SECID"],"data":[["SBER"]]}}
+        """.trimIndent()
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            if (callCount < 3) {
+                respond(
+                    content = "{}",
+                    status = HttpStatusCode.TooManyRequests,
+                    headers = headersOf(
+                        HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()),
+                        HttpHeaders.RetryAfter to listOf("0")
+                    )
+                )
+            } else {
+                respond(
+                    content = successJson,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+                )
+            }
+        }
+        val moexClient = MoexIssClient(client, BASE_URL, registry)
+        try {
+            val result = moexClient.getSecuritiesTqbr(listOf("SBER"))
+            result.isSuccess shouldBe true
+            callCount shouldBe 3
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getCandlesDaily retries on server errors") {
+        val registry = SimpleMeterRegistry()
+        val candlesJson = """
+            {"candles":{"columns":["OPEN","CLOSE","HIGH","LOW","VALUE","VOLUME","BEGIN","END"],
+            "data":[["10.00","10.50","10.75","9.90","1000","5000","2024-05-20 10:00:00","2024-05-20 18:40:00"]]}}
+        """.trimIndent()
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            if (callCount < 3) {
+                respond(
+                    content = "{}",
+                    status = HttpStatusCode.InternalServerError,
+                    headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+                )
+            } else {
+                respond(
+                    content = candlesJson,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+                )
+            }
+        }
+        val moexClient = MoexIssClient(client, BASE_URL, registry)
+        try {
+            val result = moexClient.getCandlesDaily("SBER", LocalDate.parse("2024-05-20"), LocalDate.parse("2024-05-21"))
+            result.isSuccess shouldBe true
+            result.getOrThrow().candles.first().open shouldBe BigDecimal("10.00")
+            callCount shouldBe 3
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getMarketStatus uses cache between calls") {
+        val registry = SimpleMeterRegistry()
+        val statusJson = """
+            {"marketstatus":{"columns":["BOARDID","STATE"],"data":[["TQBR","OPEN"]]}}
+        """.trimIndent()
+        var callCount = 0
+        val client = testHttpClient { _ ->
+            callCount++
+            respond(
+                content = statusJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val moexClient = MoexIssClient(client, BASE_URL, registry)
+        try {
+            val first = moexClient.getMarketStatus()
+            val second = moexClient.getMarketStatus()
+            first.isSuccess shouldBe true
+            second.isSuccess shouldBe true
+            callCount shouldBe 1
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+
+    test("getSecuritiesTqbr fails on malformed payload") {
+        val registry = SimpleMeterRegistry()
+        val malformedJson = """
+            {"securities":{"columns":["SHORTNAME"],"data":[["Broken"]]}}
+        """.trimIndent()
+        val client = testHttpClient { _ ->
+            respond(
+                content = malformedJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val moexClient = MoexIssClient(client, BASE_URL, registry)
+        try {
+            val result = moexClient.getSecuritiesTqbr(listOf("SBER"))
+            result.isSuccess shouldBe false
+            result.exceptionOrNull().shouldBeInstanceOf<HttpClientError.DeserializationError>()
+        } finally {
+            client.close()
+            registry.close()
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- add a shared Ktor HTTP client with retry/backoff, metrics, and TTL caching support for integrations
- implement MOEX, CoinGecko, and CBR clients plus wiring in the app including configuration and Prometheus registry
- add Micrometer dependency updates and MockEngine-based tests covering success, retry, caching, and error cases

## Testing
- ./gradlew :integrations:test

------
https://chatgpt.com/codex/tasks/task_e_68ca91405ccc832196908d3a6b87734a