### PR TITLE
Implement position calculation strategies

### DIFF
--- a/app/src/main/kotlin/io/ktor/server/config/ConfigExtensions.kt
+++ b/app/src/main/kotlin/io/ktor/server/config/ConfigExtensions.kt
@@ -1,0 +1,8 @@
+package io.ktor.server.config
+
+fun ApplicationConfig.configOrNull(path: String): ApplicationConfig? =
+    try {
+        config(path)
+    } catch (_: ApplicationConfigurationException) {
+        null
+    }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,7 @@
 dependencies {
     implementation(libs.serialization.json)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.property)
+    testImplementation(libs.coroutines.core)
 }

--- a/core/src/main/kotlin/portfolio/errors/PortfolioError.kt
+++ b/core/src/main/kotlin/portfolio/errors/PortfolioError.kt
@@ -1,0 +1,14 @@
+package portfolio.errors
+
+sealed interface PortfolioError {
+    val message: String
+
+    data class Validation(override val message: String) : PortfolioError
+    data class NotFound(override val message: String) : PortfolioError
+    data class External(
+        override val message: String,
+        val cause: Throwable? = null
+    ) : PortfolioError
+}
+
+typealias DomainResult<T> = Result<T>

--- a/core/src/main/kotlin/portfolio/model/DateRange.kt
+++ b/core/src/main/kotlin/portfolio/model/DateRange.kt
@@ -1,0 +1,22 @@
+package portfolio.model
+
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DateRange(
+    @Contextual val from: LocalDate,
+    @Contextual val to: LocalDate
+) {
+    init {
+        require(!from.isAfter(to)) { "Start date must not be after end date" }
+    }
+
+    operator fun contains(date: LocalDate): Boolean = !date.isBefore(from) && !date.isAfter(to)
+
+    val lengthInDays: Long get() = ChronoUnit.DAYS.between(from, to) + 1
+
+    fun overlaps(other: DateRange): Boolean = from <= other.to && other.from <= to
+}

--- a/core/src/main/kotlin/portfolio/model/Money.kt
+++ b/core/src/main/kotlin/portfolio/model/Money.kt
@@ -1,0 +1,59 @@
+package portfolio.model
+
+import java.math.BigDecimal
+import java.util.Locale
+import kotlin.ConsistentCopyVisibility
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@ConsistentCopyVisibility
+@Serializable
+data class Money internal constructor(
+    @Contextual val amount: BigDecimal,
+    val currency: String
+) {
+    init {
+        require(isNormalized(amount)) { "Amount scale must be normalized" }
+        require(CURRENCY_REGEX.matches(currency)) { "Currency must be a valid ISO 4217 code" }
+    }
+
+    operator fun plus(other: Money): Money {
+        ensureSameCurrency(other)
+        return of(amount + other.amount, currency)
+    }
+
+    operator fun minus(other: Money): Money {
+        ensureSameCurrency(other)
+        return of(amount - other.amount, currency)
+    }
+
+    operator fun times(multiplier: BigDecimal): Money = of(amount.multiply(multiplier), currency)
+
+    operator fun times(multiplier: Long): Money = times(BigDecimal.valueOf(multiplier))
+
+    operator fun times(multiplier: Int): Money = times(multiplier.toLong())
+
+    operator fun unaryMinus(): Money = of(amount.negate(), currency)
+
+    private fun ensureSameCurrency(other: Money) {
+        require(currency == other.currency) { "Currency mismatch: $currency != ${other.currency}" }
+    }
+
+    companion object {
+        private val CURRENCY_REGEX = Regex("^[A-Z]{3}$")
+
+        fun of(amount: BigDecimal, currency: String): Money {
+            val normalizedCurrency = currency.trim().uppercase(Locale.ROOT)
+            require(CURRENCY_REGEX.matches(normalizedCurrency)) { "Currency must be a valid ISO 4217 code" }
+            val normalizedAmount = normalize(amount)
+            return Money(normalizedAmount, normalizedCurrency)
+        }
+
+        private fun normalize(amount: BigDecimal): BigDecimal {
+            val stripped = amount.stripTrailingZeros()
+            return if (stripped.scale() < 0) stripped.setScale(0) else stripped
+        }
+
+        internal fun isNormalized(amount: BigDecimal): Boolean = amount == normalize(amount)
+    }
+}

--- a/core/src/main/kotlin/portfolio/model/PortfolioReport.kt
+++ b/core/src/main/kotlin/portfolio/model/PortfolioReport.kt
@@ -1,0 +1,17 @@
+package portfolio.model
+
+import java.time.Instant
+import java.util.UUID
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PortfolioReport(
+    @Contextual val portfolioId: UUID,
+    val period: DateRange,
+    val valuationMethod: ValuationMethod,
+    val positions: List<PositionView>,
+    val trades: List<TradeView>,
+    val valuations: List<ValuationDaily>,
+    @Contextual val generatedAt: Instant
+)

--- a/core/src/main/kotlin/portfolio/model/PositionView.kt
+++ b/core/src/main/kotlin/portfolio/model/PositionView.kt
@@ -1,0 +1,15 @@
+package portfolio.model
+
+import java.math.BigDecimal
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PositionView(
+    val instrumentId: Long,
+    val instrumentName: String,
+    @Contextual val quantity: BigDecimal,
+    val valuation: Money,
+    val averageCost: Money?,
+    val valuationMethod: ValuationMethod
+)

--- a/core/src/main/kotlin/portfolio/model/TradeView.kt
+++ b/core/src/main/kotlin/portfolio/model/TradeView.kt
@@ -1,0 +1,17 @@
+package portfolio.model
+
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TradeView(
+    @Contextual val tradeId: UUID,
+    val instrumentId: Long,
+    @Contextual val tradeDate: LocalDate,
+    @Contextual val quantity: BigDecimal,
+    val price: Money,
+    val notional: Money
+)

--- a/core/src/main/kotlin/portfolio/model/ValuationDaily.kt
+++ b/core/src/main/kotlin/portfolio/model/ValuationDaily.kt
@@ -1,0 +1,13 @@
+package portfolio.model
+
+import java.time.LocalDate
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ValuationDaily(
+    @Contextual val date: LocalDate,
+    val totalValue: Money,
+    val unrealizedPnl: Money?,
+    val realizedPnl: Money?
+)

--- a/core/src/main/kotlin/portfolio/model/ValuationMethod.kt
+++ b/core/src/main/kotlin/portfolio/model/ValuationMethod.kt
@@ -1,0 +1,9 @@
+package portfolio.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class ValuationMethod {
+    FIFO,
+    AVERAGE
+}

--- a/core/src/main/kotlin/portfolio/service/PositionCalc.kt
+++ b/core/src/main/kotlin/portfolio/service/PositionCalc.kt
@@ -1,0 +1,202 @@
+package portfolio.service
+
+import java.math.BigDecimal
+import java.math.MathContext
+import portfolio.model.Money
+
+interface PositionCalc {
+    data class Lot(
+        val quantity: BigDecimal,
+        val costBasis: Money
+    ) {
+        init {
+            require(quantity >= BigDecimal.ZERO) { "Lot quantity cannot be negative" }
+        }
+
+        val averagePrice: Money?
+            get() = if (quantity.compareTo(BigDecimal.ZERO) == 0) {
+                null
+            } else {
+                Money.of(costBasis.amount.divide(quantity, MATH_CONTEXT), costBasis.currency)
+            }
+    }
+
+    data class Position(
+        val quantity: BigDecimal,
+        val costBasis: Money,
+        val lots: List<Lot> = emptyList()
+    ) {
+        init {
+            require(quantity >= BigDecimal.ZERO) { "Position quantity cannot be negative" }
+            require(lots.all { it.costBasis.currency == costBasis.currency }) {
+                "Lot currency must match position currency"
+            }
+        }
+
+        val currency: String = costBasis.currency
+
+        val averagePrice: Money?
+            get() = if (quantity.compareTo(BigDecimal.ZERO) == 0) {
+                null
+            } else {
+                Money.of(costBasis.amount.divide(quantity, MATH_CONTEXT), currency)
+            }
+
+        companion object {
+            fun empty(currency: String): Position = Position(
+                BigDecimal.ZERO,
+                Money.of(BigDecimal.ZERO, currency),
+                emptyList()
+            )
+        }
+    }
+
+    data class Result(
+        val position: Position,
+        val realizedPnl: Money
+    )
+
+    fun applyBuy(
+        position: Position,
+        quantity: BigDecimal,
+        price: Money,
+        fees: Money = Money.of(BigDecimal.ZERO, price.currency)
+    ): Result
+
+    fun applySell(
+        position: Position,
+        quantity: BigDecimal,
+        price: Money,
+        fees: Money = Money.of(BigDecimal.ZERO, price.currency)
+    ): Result
+
+    class AverageCostCalc : PositionCalc {
+        override fun applyBuy(
+            position: Position,
+            quantity: BigDecimal,
+            price: Money,
+            fees: Money
+        ): Result {
+            validateInputs(position, quantity, price, fees)
+            require(quantity > BigDecimal.ZERO) { "Buy quantity must be positive" }
+
+            val totalCost = price * quantity + fees
+            val newQuantity = position.quantity + quantity
+            val newCostBasis = position.costBasis + totalCost
+            val updatedPosition = Position(newQuantity, newCostBasis)
+            return Result(updatedPosition, zero(price.currency))
+        }
+
+        override fun applySell(
+            position: Position,
+            quantity: BigDecimal,
+            price: Money,
+            fees: Money
+        ): Result {
+            validateInputs(position, quantity, price, fees)
+            require(quantity > BigDecimal.ZERO) { "Sell quantity must be positive" }
+            require(position.quantity >= quantity) { "Cannot sell more than current quantity" }
+
+            val proceeds = price * quantity
+            val costSoldAmount = position.costBasis.amount.multiply(quantity).divide(position.quantity, MATH_CONTEXT)
+            val costSold = Money.of(costSoldAmount, price.currency)
+            val newQuantity = position.quantity - quantity
+            val newCostBasis = if (newQuantity.compareTo(BigDecimal.ZERO) == 0) {
+                zero(price.currency)
+            } else {
+                position.costBasis - costSold
+            }
+            val realized = proceeds - costSold - fees
+            val updatedPosition = Position(newQuantity, newCostBasis)
+            return Result(updatedPosition, realized)
+        }
+    }
+
+    class FifoCalc : PositionCalc {
+        override fun applyBuy(
+            position: Position,
+            quantity: BigDecimal,
+            price: Money,
+            fees: Money
+        ): Result {
+            validateInputs(position, quantity, price, fees)
+            require(quantity > BigDecimal.ZERO) { "Buy quantity must be positive" }
+
+            val totalCost = price * quantity + fees
+            val newLot = Lot(quantity, totalCost)
+            val newQuantity = position.quantity + quantity
+            val newCostBasis = position.costBasis + totalCost
+            val updatedLots = position.lots + newLot
+            val updatedPosition = Position(newQuantity, newCostBasis, updatedLots)
+            return Result(updatedPosition, zero(price.currency))
+        }
+
+        override fun applySell(
+            position: Position,
+            quantity: BigDecimal,
+            price: Money,
+            fees: Money
+        ): Result {
+            validateInputs(position, quantity, price, fees)
+            require(quantity > BigDecimal.ZERO) { "Sell quantity must be positive" }
+            require(position.quantity >= quantity) { "Cannot sell more than current quantity" }
+
+            var remaining = quantity
+            var costSoldAmount = BigDecimal.ZERO
+            val updatedLots = mutableListOf<Lot>()
+
+            for (lot in position.lots) {
+                if (remaining <= BigDecimal.ZERO) {
+                    updatedLots += lot
+                    continue
+                }
+                if (lot.quantity <= BigDecimal.ZERO) {
+                    continue
+                }
+
+                val lotQuantityToClose = if (lot.quantity <= remaining) lot.quantity else remaining
+                val lotShare = lot.costBasis.amount.multiply(lotQuantityToClose).divide(lot.quantity, MATH_CONTEXT)
+                costSoldAmount = costSoldAmount + lotShare
+                val remainingQuantityInLot = lot.quantity - lotQuantityToClose
+                if (remainingQuantityInLot > BigDecimal.ZERO) {
+                    val remainingCost = lot.costBasis.amount - lotShare
+                    val updatedLot = Lot(
+                        remainingQuantityInLot,
+                        Money.of(remainingCost, lot.costBasis.currency)
+                    )
+                    updatedLots += updatedLot
+                }
+                remaining -= lotQuantityToClose
+            }
+
+            require(remaining.compareTo(BigDecimal.ZERO) == 0) { "Insufficient lots to close quantity" }
+
+            val costSold = Money.of(costSoldAmount, price.currency)
+            val proceeds = price * quantity
+            val realized = proceeds - costSold - fees
+            val newQuantity = position.quantity - quantity
+            val newCostBasis = if (newQuantity.compareTo(BigDecimal.ZERO) == 0) {
+                zero(price.currency)
+            } else {
+                Money.of(position.costBasis.amount - costSoldAmount, price.currency)
+            }
+            val lotsAfterSale = if (newQuantity.compareTo(BigDecimal.ZERO) == 0) emptyList() else updatedLots
+            val updatedPosition = Position(newQuantity, newCostBasis, lotsAfterSale)
+            return Result(updatedPosition, realized)
+        }
+    }
+
+    companion object {
+        private val MATH_CONTEXT: MathContext = MathContext.DECIMAL128
+
+        private fun validateInputs(position: Position, quantity: BigDecimal, price: Money, fees: Money) {
+            require(quantity >= BigDecimal.ZERO) { "Quantity cannot be negative" }
+            require(fees.currency == price.currency) { "Fee currency must match price currency" }
+            require(fees.amount >= BigDecimal.ZERO) { "Fees cannot be negative" }
+            require(price.currency == position.costBasis.currency) { "Currency mismatch with position" }
+            require(fees.currency == position.costBasis.currency) { "Currency mismatch with position fees" }
+        }
+
+        private fun zero(currency: String): Money = Money.of(BigDecimal.ZERO, currency)
+    }
+}

--- a/core/src/test/kotlin/portfolio/MoneyTest.kt
+++ b/core/src/test/kotlin/portfolio/MoneyTest.kt
@@ -1,0 +1,81 @@
+package portfolio
+
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import portfolio.model.Money
+
+class MoneyTest {
+    @Test
+    fun `creates money with normalized scale and uppercase currency`() {
+        val money = Money.of(BigDecimal("10.00"), "usd")
+
+        assertEquals(BigDecimal("10"), money.amount)
+        assertEquals(0, money.amount.scale())
+        assertEquals("USD", money.currency)
+    }
+
+    @Test
+    fun `adds money in the same currency`() {
+        val first = Money.of(BigDecimal("10.10"), "USD")
+        val second = Money.of(BigDecimal("5.20"), "USD")
+
+        val result = first + second
+
+        assertEquals(BigDecimal("15.3"), result.amount)
+        assertEquals("USD", result.currency)
+    }
+
+    @Test
+    fun `subtraction keeps scale normalized`() {
+        val first = Money.of(BigDecimal("100.000"), "USD")
+        val second = Money.of(BigDecimal("40.50"), "USD")
+
+        val result = first - second
+
+        assertEquals(BigDecimal("59.5"), result.amount)
+    }
+
+    @Test
+    fun `multiplication by big decimal keeps scale normalized`() {
+        val money = Money.of(BigDecimal("10"), "USD")
+
+        val result = money * BigDecimal("2.50")
+
+        assertEquals(BigDecimal("25"), result.amount)
+    }
+
+    @Test
+    fun `multiplication by integer delegates to big decimal multiplier`() {
+        val money = Money.of(BigDecimal("7.5"), "USD")
+
+        val result = money * 3
+
+        assertEquals(BigDecimal("22.5"), result.amount)
+    }
+
+    @Test
+    fun `fails when currencies do not match`() {
+        val usd = Money.of(BigDecimal.ONE, "USD")
+        val eur = Money.of(BigDecimal.ONE, "EUR")
+
+        assertFailsWith<IllegalArgumentException> { usd + eur }
+        assertFailsWith<IllegalArgumentException> { usd - eur }
+    }
+
+    @Test
+    fun `fails when currency code is invalid`() {
+        assertFailsWith<IllegalArgumentException> { Money.of(BigDecimal.ONE, "US") }
+        assertFailsWith<IllegalArgumentException> { Money.of(BigDecimal.ONE, "usd1") }
+    }
+
+    @Test
+    fun `unary minus returns negated amount`() {
+        val money = Money.of(BigDecimal("12.34"), "USD")
+
+        val result = -money
+
+        assertEquals(BigDecimal("-12.34"), result.amount)
+    }
+}

--- a/core/src/test/kotlin/portfolio/PositionCalcTest.kt
+++ b/core/src/test/kotlin/portfolio/PositionCalcTest.kt
@@ -1,0 +1,251 @@
+package portfolio
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+import java.math.BigDecimal
+import java.math.MathContext
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import portfolio.model.Money
+import portfolio.service.PositionCalc
+
+class PositionCalcTest {
+    private val averageCalc = PositionCalc.AverageCostCalc()
+    private val fifoCalc = PositionCalc.FifoCalc()
+
+    @Test
+    fun averageCostScenario() {
+        var position = PositionCalc.Position.empty(CURRENCY)
+
+        val firstBuy = averageCalc.applyBuy(
+            position,
+            BigDecimal.TEN,
+            money("100"),
+            money("5")
+        )
+        assertEquals(BigDecimal.TEN, firstBuy.position.quantity)
+        assertEquals(money("1005"), firstBuy.position.costBasis)
+        assertEquals(money("0"), firstBuy.realizedPnl)
+
+        position = firstBuy.position
+
+        val secondBuy = averageCalc.applyBuy(
+            position,
+            BigDecimal("5"),
+            money("110"),
+            money("2")
+        )
+        assertEquals(BigDecimal("15"), secondBuy.position.quantity)
+        assertEquals(money("1557"), secondBuy.position.costBasis)
+        assertEquals(money("0"), secondBuy.realizedPnl)
+        assertEquals(money("103.8"), secondBuy.position.averagePrice)
+
+        position = secondBuy.position
+
+        val sell = averageCalc.applySell(
+            position,
+            BigDecimal("8"),
+            money("120"),
+            money("4")
+        )
+        assertEquals(BigDecimal("7"), sell.position.quantity)
+        assertEquals(money("726.6"), sell.position.costBasis)
+        assertEquals(money("125.6"), sell.realizedPnl)
+        assertEquals(money("103.8"), sell.position.averagePrice)
+    }
+
+    @Test
+    fun fifoScenarioWithPartialLots() {
+        var position = PositionCalc.Position.empty(CURRENCY)
+
+        val firstBuy = fifoCalc.applyBuy(
+            position,
+            BigDecimal.TEN,
+            money("100"),
+            money("5")
+        )
+        assertEquals(BigDecimal.TEN, firstBuy.position.quantity)
+        assertEquals(1, firstBuy.position.lots.size)
+        assertEquals(money("1005"), firstBuy.position.costBasis)
+
+        position = firstBuy.position
+
+        val secondBuy = fifoCalc.applyBuy(
+            position,
+            BigDecimal("5"),
+            money("110"),
+            money("2")
+        )
+        assertEquals(BigDecimal("15"), secondBuy.position.quantity)
+        assertEquals(2, secondBuy.position.lots.size)
+        assertEquals(money("1557"), secondBuy.position.costBasis)
+
+        position = secondBuy.position
+
+        val sell = fifoCalc.applySell(
+            position,
+            BigDecimal("8"),
+            money("120"),
+            money("4")
+        )
+        assertEquals(BigDecimal("7"), sell.position.quantity)
+        assertEquals(money("753"), sell.position.costBasis)
+        assertEquals(money("152"), sell.realizedPnl)
+        assertEquals(2, sell.position.lots.size)
+        assertEquals(BigDecimal("2"), sell.position.lots[0].quantity)
+        assertEquals(money("201"), sell.position.lots[0].costBasis)
+        assertEquals(BigDecimal("5"), sell.position.lots[1].quantity)
+        assertEquals(money("552"), sell.position.lots[1].costBasis)
+    }
+
+    @Test
+    fun fifoCrossLotSellClearsPosition() {
+        var position = PositionCalc.Position.empty(CURRENCY)
+
+        position = fifoCalc.applyBuy(position, BigDecimal("3"), money("50"), money("1")).position
+        position = fifoCalc.applyBuy(position, BigDecimal("4"), money("55"), money("1.20")).position
+
+        val sell = fifoCalc.applySell(position, BigDecimal("7"), money("60"), money("3"))
+        assertEquals(BigDecimal.ZERO, sell.position.quantity)
+        assertEquals(money("0"), sell.position.costBasis)
+        assertTrue(sell.position.lots.isEmpty())
+        assertEquals(money("44.8"), sell.realizedPnl)
+    }
+
+    @Test
+    fun averagePropertyInvariants() = runBlocking {
+        checkAll(operationSequencesArb) { specs ->
+            val operations = buildOperations(specs)
+            verifySequence(averageCalc, operations)
+        }
+    }
+
+    @Test
+    fun fifoPropertyInvariants() = runBlocking {
+        checkAll(operationSequencesArb) { specs ->
+            val operations = buildOperations(specs)
+            verifySequence(fifoCalc, operations)
+        }
+    }
+
+    private fun verifySequence(calc: PositionCalc, operations: List<Operation>) {
+        var position = PositionCalc.Position.empty(CURRENCY)
+        var totalRealized = zeroMoney()
+
+        operations.forEach { operation ->
+            val result = when (operation) {
+                is Operation.Buy -> calc.applyBuy(position, operation.quantity, operation.price, operation.fee)
+                is Operation.Sell -> calc.applySell(position, operation.quantity, operation.price, operation.fee)
+            }
+            assertTrue(result.position.quantity >= BigDecimal.ZERO)
+            position = result.position
+            totalRealized = totalRealized + result.realizedPnl
+        }
+
+        if (position.quantity > BigDecimal.ZERO) {
+            val expectedAverage = Money.of(
+                position.costBasis.amount.divide(position.quantity, MathContext.DECIMAL128),
+                CURRENCY
+            )
+            assertNotNull(position.averagePrice)
+            assertEquals(expectedAverage, position.averagePrice)
+        } else {
+            assertEquals(BigDecimal.ZERO, position.quantity)
+            assertNull(position.averagePrice)
+            assertEquals(zeroMoney(), position.costBasis)
+        }
+
+        val totalBuys = operations.filterIsInstance<Operation.Buy>().fold(zeroMoney()) { acc, buy ->
+            acc + buy.price * buy.quantity + buy.fee
+        }
+        val totalSellProceeds = operations.filterIsInstance<Operation.Sell>().fold(zeroMoney()) { acc, sell ->
+            acc + sell.price * sell.quantity
+        }
+        val totalSellFees = operations.filterIsInstance<Operation.Sell>().fold(zeroMoney()) { acc, sell ->
+            acc + sell.fee
+        }
+
+        assertEquals(BigDecimal.ZERO, position.quantity)
+        assertEquals(totalSellProceeds - totalSellFees - totalBuys, totalRealized)
+        if (calc is PositionCalc.FifoCalc) {
+            assertTrue(position.lots.isEmpty())
+        }
+    }
+
+    private fun buildOperations(specs: List<OperationSpec>): List<Operation> {
+        val operations = mutableListOf<Operation>()
+        var openQuantity = BigDecimal.ZERO
+        val closingTemplate = specs.lastOrNull()
+
+        specs.forEach { spec ->
+            val quantity = BigDecimal(spec.quantity.toLong())
+            val price = money(spec.price)
+            val fee = money(spec.fee)
+            if (spec.isBuy || openQuantity < quantity) {
+                operations += Operation.Buy(quantity, price, fee)
+                openQuantity += quantity
+            } else {
+                operations += Operation.Sell(quantity, price, fee)
+                openQuantity -= quantity
+            }
+        }
+
+        if (openQuantity > BigDecimal.ZERO) {
+            val price = money(closingTemplate?.price ?: BigDecimal("100"))
+            val fee = money(closingTemplate?.fee ?: BigDecimal.ZERO)
+            operations += Operation.Sell(openQuantity, price, fee)
+        }
+
+        return operations
+    }
+
+    private data class OperationSpec(
+        val isBuy: Boolean,
+        val quantity: Int,
+        val price: BigDecimal,
+        val fee: BigDecimal
+    )
+
+    private sealed interface Operation {
+        data class Buy(
+            val quantity: BigDecimal,
+            val price: Money,
+            val fee: Money
+        ) : Operation
+
+        data class Sell(
+            val quantity: BigDecimal,
+            val price: Money,
+            val fee: Money
+        ) : Operation
+    }
+
+    private fun zeroMoney(): Money = money(BigDecimal.ZERO)
+
+    private fun money(amount: String): Money = money(BigDecimal(amount))
+
+    private fun money(amount: BigDecimal): Money = Money.of(amount, CURRENCY)
+
+    private val operationSpecArb = Arb.bind(Arb.boolean(), Arb.int(1..10), Arb.int(1000..10000), Arb.int(0..500)) { isBuy, qty, price, fee ->
+        OperationSpec(
+            isBuy = isBuy,
+            quantity = qty,
+            price = BigDecimal.valueOf(price.toLong(), 2),
+            fee = BigDecimal.valueOf(fee.toLong(), 2)
+        )
+    }
+
+    private val operationSequencesArb = Arb.list(operationSpecArb, 3..12)
+
+    companion object {
+        private const val CURRENCY = "USD"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ serialization = "1.6.3"
 micrometer = "1.12.5"
 hikari = "5.1.0"
 postgres = "42.7.4"
+kotest = "5.9.1"
 
 
 [libraries]
@@ -29,6 +30,9 @@ serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-jso
 typesafe-config = { module = "com.typesafe:config", version = "1.4.3" }
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/integrations/build.gradle.kts
+++ b/integrations/build.gradle.kts
@@ -18,15 +18,15 @@ val coroutinesVersion = libs.versions.coroutines.get()
 val micrometerVersion = libs.versions.micrometer.get()
 
 dependencies {
-    implementation("io.ktor:ktor-client-core-jvm:$ktorVersion")
+    api("io.ktor:ktor-client-core-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-cio-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-client-logging:$ktorVersion")
     implementation("io.ktor:ktor-client-encoding:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation(libs.serialization.json)
-    implementation(libs.micrometer.core)
-    implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
+    api(libs.micrometer.core)
+    api("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
 
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("io.kotest:kotest-runner-junit5:5.9.1")

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -22,6 +22,7 @@ configurations {
 }
 
 dependencies {
+    implementation(project(":core"))
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)
@@ -38,6 +39,8 @@ dependencies {
     add("flyway", libs.postgresql)
     add("flyway", libs.flyway.postgresql)
     add("flyway", libs.flyway.core)
+
+    testImplementation("com.h2database:h2:2.2.224")
 }
 
 configure<FlywayExtension> {

--- a/storage/src/main/kotlin/repo/FxRateRepository.kt
+++ b/storage/src/main/kotlin/repo/FxRateRepository.kt
@@ -1,0 +1,59 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.time.Instant
+import model.FxRate
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import repo.mapper.setValues
+import repo.mapper.toColumnValues
+import repo.mapper.toDbTimestamp
+import repo.mapper.toFxRate
+import repo.tables.FxRatesTable
+
+class FxRateRepository {
+    suspend fun upsert(rate: FxRate): FxRate = dbQuery {
+        val predicate = (FxRatesTable.ccy eq rate.ccy) and (FxRatesTable.ts eq rate.ts.toDbTimestamp())
+        val updated = FxRatesTable.update({ predicate }) {
+            it.setValues(rate.toColumnValues())
+        }
+        if (updated == 0) {
+            FxRatesTable.insert {
+                it.setValues(rate.toColumnValues())
+            }
+        }
+        FxRatesTable.select { predicate }.single().toFxRate()
+    }
+
+    suspend fun findLatest(ccy: String): FxRate? = dbQuery {
+        FxRatesTable.select { FxRatesTable.ccy eq ccy }
+            .orderBy(FxRatesTable.ts, SortOrder.DESC)
+            .limit(1)
+            .singleOrNull()?.toFxRate()
+    }
+
+    suspend fun find(ccy: String, timestamp: Instant): FxRate? = dbQuery {
+        FxRatesTable.select {
+            (FxRatesTable.ccy eq ccy) and (FxRatesTable.ts eq timestamp.toDbTimestamp())
+        }.singleOrNull()?.toFxRate()
+    }
+
+    suspend fun list(ccy: String, limit: Int, offset: Long = 0): List<FxRate> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        FxRatesTable.select { FxRatesTable.ccy eq ccy }
+            .orderBy(FxRatesTable.ts, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toFxRate() }
+    }
+
+    suspend fun delete(ccy: String, timestamp: Instant): Boolean = dbQuery {
+        FxRatesTable.deleteWhere {
+            (FxRatesTable.ccy eq ccy) and (FxRatesTable.ts eq timestamp.toDbTimestamp())
+        } > 0
+    }
+}

--- a/storage/src/main/kotlin/repo/InstrumentRepository.kt
+++ b/storage/src/main/kotlin/repo/InstrumentRepository.kt
@@ -1,0 +1,115 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.or
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.isNull
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
+import repo.mapper.setValues
+import repo.mapper.toInstrumentAliasEntity
+import repo.mapper.toInstrumentEntity
+import repo.mapper.toColumnValues
+import repo.model.InstrumentAliasEntity
+import repo.model.InstrumentEntity
+import repo.model.InstrumentUpdate
+import repo.model.NewInstrument
+import repo.model.NewInstrumentAlias
+import repo.tables.InstrumentAliasesTable
+import repo.tables.InstrumentsTable
+
+class InstrumentRepository {
+    suspend fun createInstrument(newInstrument: NewInstrument): InstrumentEntity = dbQuery {
+        val statement = InstrumentsTable.insert {
+            it.setValues(newInstrument.toColumnValues())
+        }
+        statement.resultedValues?.singleOrNull()?.toInstrumentEntity()
+            ?: error("Failed to insert instrument")
+    }
+
+    suspend fun updateInstrument(instrumentId: Long, update: InstrumentUpdate): InstrumentEntity? = dbQuery {
+        val values = update.toColumnValues()
+        if (values.isEmpty()) {
+            return@dbQuery findById(instrumentId)
+        }
+        val updated = InstrumentsTable.update({ InstrumentsTable.instrumentId eq instrumentId }) {
+            it.setValues(values)
+        }
+        if (updated > 0) {
+            InstrumentsTable.select { InstrumentsTable.instrumentId eq instrumentId }
+                .singleOrNull()?.toInstrumentEntity()
+        } else {
+            null
+        }
+    }
+
+    suspend fun deleteInstrument(instrumentId: Long): Boolean = dbQuery {
+        InstrumentsTable.deleteWhere { InstrumentsTable.instrumentId eq instrumentId } > 0
+    }
+
+    suspend fun findById(instrumentId: Long): InstrumentEntity? = dbQuery {
+        InstrumentsTable.select { InstrumentsTable.instrumentId eq instrumentId }
+            .singleOrNull()?.toInstrumentEntity()
+    }
+
+    suspend fun findByIsin(isin: String): InstrumentEntity? = dbQuery {
+        InstrumentsTable.select { InstrumentsTable.isin eq isin }
+            .singleOrNull()?.toInstrumentEntity()
+    }
+
+    suspend fun findBySymbol(exchange: String, board: String?, symbol: String): InstrumentEntity? = dbQuery {
+        InstrumentsTable.select {
+            val boardCondition = board?.let { InstrumentsTable.board eq it } ?: InstrumentsTable.board.isNull()
+            (InstrumentsTable.exchange eq exchange) and boardCondition and (InstrumentsTable.symbol eq symbol)
+        }.singleOrNull()?.toInstrumentEntity()
+    }
+
+    suspend fun search(query: String, limit: Int, offset: Long = 0): List<InstrumentEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        val pattern = "%${query}%"
+        InstrumentsTable.select {
+            (InstrumentsTable.symbol like pattern) or (InstrumentsTable.exchange like pattern)
+        }
+            .orderBy(InstrumentsTable.symbol, SortOrder.ASC)
+            .limit(limit, offset)
+            .map { it.toInstrumentEntity() }
+    }
+
+    suspend fun listAliases(instrumentId: Long): List<InstrumentAliasEntity> = dbQuery {
+        InstrumentAliasesTable.select { InstrumentAliasesTable.instrumentId eq instrumentId }
+            .orderBy(InstrumentAliasesTable.alias, SortOrder.ASC)
+            .map { it.toInstrumentAliasEntity() }
+    }
+
+    suspend fun addAlias(newAlias: NewInstrumentAlias): InstrumentAliasEntity = dbQuery {
+        val statement = InstrumentAliasesTable.insert {
+            it.setValues(newAlias.toColumnValues())
+        }
+        statement.resultedValues?.singleOrNull()?.toInstrumentAliasEntity()
+            ?: error("Failed to insert instrument alias")
+    }
+
+    suspend fun removeAlias(aliasId: Long): Boolean = dbQuery {
+        InstrumentAliasesTable.deleteWhere { InstrumentAliasesTable.aliasId eq aliasId } > 0
+    }
+
+    suspend fun findAlias(alias: String, source: String): InstrumentAliasEntity? = dbQuery {
+        InstrumentAliasesTable.select {
+            (InstrumentAliasesTable.alias eq alias) and (InstrumentAliasesTable.sourceCol eq source)
+        }.singleOrNull()?.toInstrumentAliasEntity()
+    }
+
+    suspend fun listAll(limit: Int, offset: Long = 0): List<InstrumentEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        InstrumentsTable.selectAll()
+            .orderBy(InstrumentsTable.createdAt, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toInstrumentEntity() }
+    }
+}

--- a/storage/src/main/kotlin/repo/PortfolioRepository.kt
+++ b/storage/src/main/kotlin/repo/PortfolioRepository.kt
@@ -1,0 +1,83 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.util.UUID
+import org.jetbrains.exposed.sql.LowerCase
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
+import repo.mapper.setValues
+import repo.mapper.toColumnValues
+import repo.mapper.toPortfolioEntity
+import repo.model.NewPortfolio
+import repo.model.PortfolioEntity
+import repo.model.PortfolioUpdate
+import repo.tables.PortfoliosTable
+
+class PortfolioRepository {
+    suspend fun create(newPortfolio: NewPortfolio): PortfolioEntity = dbQuery {
+        val statement = PortfoliosTable.insert {
+            it.setValues(newPortfolio.toColumnValues())
+        }
+        statement.resultedValues?.singleOrNull()?.toPortfolioEntity()
+            ?: error("Failed to insert portfolio")
+    }
+
+    suspend fun findById(portfolioId: UUID): PortfolioEntity? = dbQuery {
+        PortfoliosTable.select { PortfoliosTable.portfolioId eq portfolioId }
+            .singleOrNull()?.toPortfolioEntity()
+    }
+
+    suspend fun findByUser(userId: Long, limit: Int, offset: Long = 0): List<PortfolioEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        PortfoliosTable.select { PortfoliosTable.userId eq userId }
+            .orderBy(PortfoliosTable.createdAt, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toPortfolioEntity() }
+    }
+
+    suspend fun listAll(limit: Int, offset: Long = 0): List<PortfolioEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        PortfoliosTable.selectAll()
+            .orderBy(PortfoliosTable.createdAt, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toPortfolioEntity() }
+    }
+
+    suspend fun searchByName(userId: Long, query: String, limit: Int, offset: Long = 0): List<PortfolioEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        val pattern = "%${query.lowercase()}%"
+        PortfoliosTable.select {
+            (PortfoliosTable.userId eq userId) and (LowerCase(PortfoliosTable.name) like pattern)
+        }
+            .orderBy(PortfoliosTable.name, SortOrder.ASC)
+            .limit(limit, offset)
+            .map { it.toPortfolioEntity() }
+    }
+
+    suspend fun update(portfolioId: UUID, update: PortfolioUpdate): PortfolioEntity? = dbQuery {
+        val values = update.toColumnValues()
+        if (values.isEmpty()) {
+            return@dbQuery findById(portfolioId)
+        }
+        val updated = PortfoliosTable.update({ PortfoliosTable.portfolioId eq portfolioId }) {
+            it.setValues(values)
+        }
+        if (updated > 0) {
+            PortfoliosTable.select { PortfoliosTable.portfolioId eq portfolioId }
+                .singleOrNull()?.toPortfolioEntity()
+        } else {
+            null
+        }
+    }
+
+    suspend fun delete(portfolioId: UUID): Boolean = dbQuery {
+        PortfoliosTable.deleteWhere { PortfoliosTable.portfolioId eq portfolioId } > 0
+    }
+}

--- a/storage/src/main/kotlin/repo/PositionRepository.kt
+++ b/storage/src/main/kotlin/repo/PositionRepository.kt
@@ -1,0 +1,52 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.util.UUID
+import model.PositionDto
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import repo.mapper.setValues
+import repo.mapper.toInsertValues
+import repo.mapper.toPositionDto
+import repo.mapper.toUpdateValues
+import repo.tables.PositionsTable
+
+class PositionRepository {
+    suspend fun save(position: PositionDto): PositionDto = dbQuery {
+        val predicate = (PositionsTable.portfolioId eq position.portfolioId) and
+            (PositionsTable.instrumentId eq position.instrumentId)
+        val updated = PositionsTable.update({ predicate }) {
+            it.setValues(position.toUpdateValues())
+        }
+        if (updated == 0) {
+            PositionsTable.insert {
+                it.setValues(position.toInsertValues())
+            }
+        }
+        PositionsTable.select { predicate }.single().toPositionDto()
+    }
+
+    suspend fun find(portfolioId: UUID, instrumentId: Long): PositionDto? = dbQuery {
+        val predicate = (PositionsTable.portfolioId eq portfolioId) and (PositionsTable.instrumentId eq instrumentId)
+        PositionsTable.select { predicate }.singleOrNull()?.toPositionDto()
+    }
+
+    suspend fun list(portfolioId: UUID, limit: Int, offset: Long = 0): List<PositionDto> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        PositionsTable.select { PositionsTable.portfolioId eq portfolioId }
+            .orderBy(PositionsTable.instrumentId, SortOrder.ASC)
+            .limit(limit, offset)
+            .map { it.toPositionDto() }
+    }
+
+    suspend fun delete(portfolioId: UUID, instrumentId: Long): Boolean = dbQuery {
+        PositionsTable.deleteWhere {
+            (PositionsTable.portfolioId eq portfolioId) and (PositionsTable.instrumentId eq instrumentId)
+        } > 0
+    }
+}

--- a/storage/src/main/kotlin/repo/TradeRepository.kt
+++ b/storage/src/main/kotlin/repo/TradeRepository.kt
@@ -1,0 +1,100 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.time.Instant
+import java.util.UUID
+import model.TradeDto
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.lessEq
+import repo.mapper.setValues
+import repo.mapper.toColumnValues
+import repo.mapper.toDbTimestamp
+import repo.mapper.toTradeDto
+import repo.model.NewTrade
+import repo.model.TradeUpdate
+import repo.tables.TradesTable
+
+class TradeRepository {
+    suspend fun createTrade(newTrade: NewTrade): TradeDto = dbQuery {
+        val statement = TradesTable.insert {
+            it.setValues(newTrade.toColumnValues())
+        }
+        statement.resultedValues?.singleOrNull()?.toTradeDto()
+            ?: error("Failed to insert trade")
+    }
+
+    suspend fun updateTrade(tradeId: Long, update: TradeUpdate): TradeDto? = dbQuery {
+        val values = update.toColumnValues()
+        if (values.isEmpty()) {
+            return@dbQuery findById(tradeId)
+        }
+        val updated = TradesTable.update({ TradesTable.tradeId eq tradeId }) {
+            it.setValues(values)
+        }
+        if (updated > 0) {
+            TradesTable.select { TradesTable.tradeId eq tradeId }
+                .singleOrNull()?.toTradeDto()
+        } else {
+            null
+        }
+    }
+
+    suspend fun deleteTrade(tradeId: Long): Boolean = dbQuery {
+        TradesTable.deleteWhere { TradesTable.tradeId eq tradeId } > 0
+    }
+
+    suspend fun findById(tradeId: Long): TradeDto? = dbQuery {
+        TradesTable.select { TradesTable.tradeId eq tradeId }
+            .singleOrNull()?.toTradeDto()
+    }
+
+    suspend fun findByExternalId(extId: String): TradeDto? = dbQuery {
+        TradesTable.select { TradesTable.extId eq extId }
+            .singleOrNull()?.toTradeDto()
+    }
+
+    suspend fun listByPortfolio(portfolioId: UUID, limit: Int, offset: Long = 0): List<TradeDto> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        TradesTable.select { TradesTable.portfolioId eq portfolioId }
+            .orderBy(TradesTable.datetime, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toTradeDto() }
+    }
+
+    suspend fun listByInstrument(instrumentId: Long, limit: Int, offset: Long = 0): List<TradeDto> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        TradesTable.select { TradesTable.instrumentId eq instrumentId }
+            .orderBy(TradesTable.datetime, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toTradeDto() }
+    }
+
+    suspend fun listByPeriod(
+        portfolioId: UUID,
+        from: Instant?,
+        to: Instant?,
+        limit: Int,
+        offset: Long = 0,
+    ): List<TradeDto> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        val condition = when {
+            from != null && to != null -> TradesTable.datetime.between(from.toDbTimestamp(), to.toDbTimestamp())
+            from != null -> TradesTable.datetime greaterEq from.toDbTimestamp()
+            to != null -> TradesTable.datetime lessEq to.toDbTimestamp()
+            else -> null
+        }
+        val op = condition?.let { (TradesTable.portfolioId eq portfolioId) and it } ?: (TradesTable.portfolioId eq portfolioId)
+        TradesTable.select { op }
+            .orderBy(TradesTable.datetime, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toTradeDto() }
+    }
+}

--- a/storage/src/main/kotlin/repo/ValuationRepository.kt
+++ b/storage/src/main/kotlin/repo/ValuationRepository.kt
@@ -1,0 +1,74 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.time.LocalDate
+import java.util.UUID
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.lessEq
+import portfolio.model.DateRange
+import repo.mapper.setValues
+import repo.mapper.toColumnValues
+import repo.mapper.toValuationDailyRecord
+import repo.model.NewValuationDaily
+import repo.model.ValuationDailyRecord
+import repo.tables.ValuationsDailyTable
+
+class ValuationRepository {
+    suspend fun upsert(record: NewValuationDaily): ValuationDailyRecord = dbQuery {
+        val predicate = (ValuationsDailyTable.portfolioId eq record.portfolioId) and
+            (ValuationsDailyTable.date eq record.date)
+        val updated = ValuationsDailyTable.update({ predicate }) {
+            it.setValues(record.toColumnValues())
+        }
+        if (updated == 0) {
+            ValuationsDailyTable.insert {
+                it.setValues(record.toColumnValues())
+            }
+        }
+        ValuationsDailyTable.select { predicate }.single().toValuationDailyRecord()
+    }
+
+    suspend fun find(portfolioId: UUID, date: LocalDate): ValuationDailyRecord? = dbQuery {
+        ValuationsDailyTable.select {
+            (ValuationsDailyTable.portfolioId eq portfolioId) and (ValuationsDailyTable.date eq date)
+        }.singleOrNull()?.toValuationDailyRecord()
+    }
+
+    suspend fun list(portfolioId: UUID, limit: Int, offset: Long = 0): List<ValuationDailyRecord> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        ValuationsDailyTable.select { ValuationsDailyTable.portfolioId eq portfolioId }
+            .orderBy(ValuationsDailyTable.date, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toValuationDailyRecord() }
+    }
+
+    suspend fun listRange(
+        portfolioId: UUID,
+        range: DateRange,
+        limit: Int,
+        offset: Long = 0,
+    ): List<ValuationDailyRecord> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        ValuationsDailyTable.select {
+            (ValuationsDailyTable.portfolioId eq portfolioId) and
+                (ValuationsDailyTable.date greaterEq range.from) and
+                (ValuationsDailyTable.date lessEq range.to)
+        }
+            .orderBy(ValuationsDailyTable.date, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toValuationDailyRecord() }
+    }
+
+    suspend fun delete(portfolioId: UUID, date: LocalDate): Boolean = dbQuery {
+        ValuationsDailyTable.deleteWhere {
+            (ValuationsDailyTable.portfolioId eq portfolioId) and (ValuationsDailyTable.date eq date)
+        } > 0
+    }
+}

--- a/storage/src/main/kotlin/repo/mapper/FxRateMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/FxRateMapper.kt
@@ -1,0 +1,20 @@
+package repo.mapper
+
+import model.FxRate
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.tables.FxRatesTable
+
+fun ResultRow.toFxRate(): FxRate = FxRate(
+    ccy = this[FxRatesTable.ccy],
+    ts = this[FxRatesTable.ts].toInstant(),
+    rateRub = this[FxRatesTable.rateRub],
+    source = this[FxRatesTable.sourceCol],
+)
+
+fun FxRate.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    FxRatesTable.ccy to ccy,
+    FxRatesTable.ts to ts.toDbTimestamp(),
+    FxRatesTable.rateRub to rateRub,
+    FxRatesTable.sourceCol to source,
+)

--- a/storage/src/main/kotlin/repo/mapper/InstrumentMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/InstrumentMapper.kt
@@ -1,0 +1,59 @@
+package repo.mapper
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.InstrumentAliasEntity
+import repo.model.InstrumentEntity
+import repo.model.InstrumentUpdate
+import repo.model.NewInstrument
+import repo.model.NewInstrumentAlias
+import repo.tables.InstrumentAliasesTable
+import repo.tables.InstrumentsTable
+
+fun ResultRow.toInstrumentEntity(): InstrumentEntity = InstrumentEntity(
+    instrumentId = this[InstrumentsTable.instrumentId],
+    clazz = this[InstrumentsTable.clazz],
+    exchange = this[InstrumentsTable.exchange],
+    board = this[InstrumentsTable.board],
+    symbol = this[InstrumentsTable.symbol],
+    isin = this[InstrumentsTable.isin],
+    cgId = this[InstrumentsTable.cgId],
+    currency = this[InstrumentsTable.currency],
+    createdAt = this[InstrumentsTable.createdAt].toInstant(),
+)
+
+fun NewInstrument.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    InstrumentsTable.clazz to clazz,
+    InstrumentsTable.exchange to exchange,
+    InstrumentsTable.board to board,
+    InstrumentsTable.symbol to symbol,
+    InstrumentsTable.isin to isin,
+    InstrumentsTable.cgId to cgId,
+    InstrumentsTable.currency to currency,
+    InstrumentsTable.createdAt to createdAt.toDbTimestamp(),
+)
+
+fun InstrumentUpdate.toColumnValues(): Map<Column<*>, Any?> {
+    val values = mutableMapOf<Column<*>, Any?>()
+    clazz?.let { values[InstrumentsTable.clazz] = it }
+    exchange?.let { values[InstrumentsTable.exchange] = it }
+    board?.let { values[InstrumentsTable.board] = it }
+    symbol?.let { values[InstrumentsTable.symbol] = it }
+    isin?.let { values[InstrumentsTable.isin] = it }
+    cgId?.let { values[InstrumentsTable.cgId] = it }
+    currency?.let { values[InstrumentsTable.currency] = it }
+    return values
+}
+
+fun ResultRow.toInstrumentAliasEntity(): InstrumentAliasEntity = InstrumentAliasEntity(
+    aliasId = this[InstrumentAliasesTable.aliasId],
+    instrumentId = this[InstrumentAliasesTable.instrumentId],
+    alias = this[InstrumentAliasesTable.alias],
+    source = this[InstrumentAliasesTable.sourceCol],
+)
+
+fun NewInstrumentAlias.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    InstrumentAliasesTable.instrumentId to instrumentId,
+    InstrumentAliasesTable.alias to alias,
+    InstrumentAliasesTable.sourceCol to source,
+)

--- a/storage/src/main/kotlin/repo/mapper/MapperExtensions.kt
+++ b/storage/src/main/kotlin/repo/mapper/MapperExtensions.kt
@@ -1,0 +1,16 @@
+package repo.mapper
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.statements.UpdateBuilder
+
+internal fun Instant.toDbTimestamp(): OffsetDateTime = OffsetDateTime.ofInstant(this, ZoneOffset.UTC)
+
+@Suppress("UNCHECKED_CAST")
+internal fun UpdateBuilder<*>.setValues(values: Map<Column<*>, Any?>) {
+    values.forEach { (column, value) ->
+        this[column as Column<Any?>] = value
+    }
+}

--- a/storage/src/main/kotlin/repo/mapper/PortfolioMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/PortfolioMapper.kt
@@ -1,0 +1,33 @@
+package repo.mapper
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.NewPortfolio
+import repo.model.PortfolioEntity
+import repo.model.PortfolioUpdate
+import repo.tables.PortfoliosTable
+
+fun ResultRow.toPortfolioEntity(): PortfolioEntity = PortfolioEntity(
+    portfolioId = this[PortfoliosTable.portfolioId],
+    userId = this[PortfoliosTable.userId],
+    name = this[PortfoliosTable.name],
+    baseCurrency = this[PortfoliosTable.baseCurrency],
+    isActive = this[PortfoliosTable.isActive],
+    createdAt = this[PortfoliosTable.createdAt].toInstant(),
+)
+
+fun NewPortfolio.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    PortfoliosTable.userId to userId,
+    PortfoliosTable.name to name,
+    PortfoliosTable.baseCurrency to baseCurrency,
+    PortfoliosTable.isActive to isActive,
+    PortfoliosTable.createdAt to createdAt.toDbTimestamp(),
+)
+
+fun PortfolioUpdate.toColumnValues(): Map<Column<*>, Any?> {
+    val values = mutableMapOf<Column<*>, Any?>()
+    name?.let { values[PortfoliosTable.name] = it }
+    baseCurrency?.let { values[PortfoliosTable.baseCurrency] = it }
+    isActive?.let { values[PortfoliosTable.isActive] = it }
+    return values
+}

--- a/storage/src/main/kotlin/repo/mapper/PositionMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/PositionMapper.kt
@@ -1,0 +1,31 @@
+package repo.mapper
+
+import model.PositionDto
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.tables.PositionsTable
+
+fun ResultRow.toPositionDto(): PositionDto = PositionDto(
+    portfolioId = this[PositionsTable.portfolioId],
+    instrumentId = this[PositionsTable.instrumentId],
+    qty = this[PositionsTable.qty],
+    avgPrice = this[PositionsTable.avgPrice],
+    avgPriceCcy = this[PositionsTable.avgPriceCcy],
+    updatedAt = this[PositionsTable.updatedAt].toInstant(),
+)
+
+fun PositionDto.toInsertValues(): Map<Column<*>, Any?> = mapOf(
+    PositionsTable.portfolioId to portfolioId,
+    PositionsTable.instrumentId to instrumentId,
+    PositionsTable.qty to qty,
+    PositionsTable.avgPrice to avgPrice,
+    PositionsTable.avgPriceCcy to avgPriceCcy,
+    PositionsTable.updatedAt to updatedAt.toDbTimestamp(),
+)
+
+fun PositionDto.toUpdateValues(): Map<Column<*>, Any?> = mapOf(
+    PositionsTable.qty to qty,
+    PositionsTable.avgPrice to avgPrice,
+    PositionsTable.avgPriceCcy to avgPriceCcy,
+    PositionsTable.updatedAt to updatedAt.toDbTimestamp(),
+)

--- a/storage/src/main/kotlin/repo/mapper/PriceMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/PriceMapper.kt
@@ -1,0 +1,22 @@
+package repo.mapper
+
+import model.PricePoint
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.tables.PricesTable
+
+fun ResultRow.toPricePoint(): PricePoint = PricePoint(
+    instrumentId = this[PricesTable.instrumentId],
+    ts = this[PricesTable.ts].toInstant(),
+    price = this[PricesTable.price],
+    ccy = this[PricesTable.ccy],
+    source = this[PricesTable.sourceCol],
+)
+
+fun PricePoint.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    PricesTable.instrumentId to instrumentId,
+    PricesTable.ts to ts.toDbTimestamp(),
+    PricesTable.price to price,
+    PricesTable.ccy to ccy,
+    PricesTable.sourceCol to source,
+)

--- a/storage/src/main/kotlin/repo/mapper/TradeMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/TradeMapper.kt
@@ -1,0 +1,64 @@
+package repo.mapper
+
+import model.TradeDto
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.NewTrade
+import repo.model.TradeUpdate
+import repo.tables.TradesTable
+
+fun ResultRow.toTradeDto(): TradeDto = TradeDto(
+    tradeId = this[TradesTable.tradeId],
+    portfolioId = this[TradesTable.portfolioId],
+    instrumentId = this[TradesTable.instrumentId],
+    datetime = this[TradesTable.datetime].toInstant(),
+    side = this[TradesTable.side],
+    quantity = this[TradesTable.quantity],
+    price = this[TradesTable.price],
+    priceCurrency = this[TradesTable.priceCurrency],
+    fee = this[TradesTable.fee],
+    feeCurrency = this[TradesTable.feeCurrency],
+    tax = this[TradesTable.tax],
+    taxCurrency = this[TradesTable.taxCurrency],
+    broker = this[TradesTable.broker],
+    note = this[TradesTable.note],
+    extId = this[TradesTable.extId],
+    createdAt = this[TradesTable.createdAt].toInstant(),
+)
+
+fun NewTrade.toColumnValues(): Map<Column<*>, Any?> {
+    val values = mutableMapOf<Column<*>, Any?>(
+        TradesTable.portfolioId to portfolioId,
+        TradesTable.instrumentId to instrumentId,
+        TradesTable.datetime to datetime.toDbTimestamp(),
+        TradesTable.side to side,
+        TradesTable.quantity to quantity,
+        TradesTable.price to price,
+        TradesTable.priceCurrency to priceCurrency,
+        TradesTable.fee to fee,
+        TradesTable.feeCurrency to feeCurrency,
+        TradesTable.createdAt to createdAt.toDbTimestamp(),
+    )
+    tax?.let { values[TradesTable.tax] = it }
+    taxCurrency?.let { values[TradesTable.taxCurrency] = it }
+    broker?.let { values[TradesTable.broker] = it }
+    note?.let { values[TradesTable.note] = it }
+    extId?.let { values[TradesTable.extId] = it }
+    return values
+}
+
+fun TradeUpdate.toColumnValues(): Map<Column<*>, Any?> {
+    val values = mutableMapOf<Column<*>, Any?>()
+    datetime?.let { values[TradesTable.datetime] = it.toDbTimestamp() }
+    side?.let { values[TradesTable.side] = it }
+    quantity?.let { values[TradesTable.quantity] = it }
+    price?.let { values[TradesTable.price] = it }
+    priceCurrency?.let { values[TradesTable.priceCurrency] = it }
+    fee?.let { values[TradesTable.fee] = it }
+    feeCurrency?.let { values[TradesTable.feeCurrency] = it }
+    tax?.let { values[TradesTable.tax] = it }
+    taxCurrency?.let { values[TradesTable.taxCurrency] = it }
+    broker?.let { values[TradesTable.broker] = it }
+    note?.let { values[TradesTable.note] = it }
+    return values
+}

--- a/storage/src/main/kotlin/repo/mapper/UserMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/UserMapper.kt
@@ -1,0 +1,18 @@
+package repo.mapper
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.NewUser
+import repo.model.UserEntity
+import repo.tables.UsersTable
+
+fun ResultRow.toUserEntity(): UserEntity = UserEntity(
+    userId = this[UsersTable.userId],
+    telegramUserId = this[UsersTable.tgUserId],
+    createdAt = this[UsersTable.createdAt].toInstant(),
+)
+
+fun NewUser.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    UsersTable.tgUserId to telegramUserId,
+    UsersTable.createdAt to createdAt.toDbTimestamp(),
+)

--- a/storage/src/main/kotlin/repo/mapper/ValuationMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/ValuationMapper.kt
@@ -1,0 +1,25 @@
+package repo.mapper
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.NewValuationDaily
+import repo.model.ValuationDailyRecord
+import repo.tables.ValuationsDailyTable
+
+fun ResultRow.toValuationDailyRecord(): ValuationDailyRecord = ValuationDailyRecord(
+    portfolioId = this[ValuationsDailyTable.portfolioId],
+    date = this[ValuationsDailyTable.date],
+    valueRub = this[ValuationsDailyTable.valueRub],
+    pnlDay = this[ValuationsDailyTable.pnlDay],
+    pnlTotal = this[ValuationsDailyTable.pnlTotal],
+    drawdown = this[ValuationsDailyTable.drawdown],
+)
+
+fun NewValuationDaily.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    ValuationsDailyTable.portfolioId to portfolioId,
+    ValuationsDailyTable.date to date,
+    ValuationsDailyTable.valueRub to valueRub,
+    ValuationsDailyTable.pnlDay to pnlDay,
+    ValuationsDailyTable.pnlTotal to pnlTotal,
+    ValuationsDailyTable.drawdown to drawdown,
+)

--- a/storage/src/main/kotlin/repo/model/InstrumentModels.kt
+++ b/storage/src/main/kotlin/repo/model/InstrumentModels.kt
@@ -1,0 +1,54 @@
+package repo.model
+
+import java.time.Instant
+
+/** Row model for the [repo.tables.InstrumentsTable]. */
+data class InstrumentEntity(
+    val instrumentId: Long,
+    val clazz: String,
+    val exchange: String,
+    val board: String?,
+    val symbol: String,
+    val isin: String?,
+    val cgId: String?,
+    val currency: String,
+    val createdAt: Instant,
+)
+
+/** Creation payload for instruments. */
+data class NewInstrument(
+    val clazz: String,
+    val exchange: String,
+    val board: String?,
+    val symbol: String,
+    val isin: String?,
+    val cgId: String?,
+    val currency: String,
+    val createdAt: Instant = Instant.now(),
+)
+
+/** Update payload for instruments. */
+data class InstrumentUpdate(
+    val clazz: String? = null,
+    val exchange: String? = null,
+    val board: String? = null,
+    val symbol: String? = null,
+    val isin: String? = null,
+    val cgId: String? = null,
+    val currency: String? = null,
+)
+
+/** Row model for the [repo.tables.InstrumentAliasesTable]. */
+data class InstrumentAliasEntity(
+    val aliasId: Long,
+    val instrumentId: Long,
+    val alias: String,
+    val source: String,
+)
+
+/** Creation payload for instrument aliases. */
+data class NewInstrumentAlias(
+    val instrumentId: Long,
+    val alias: String,
+    val source: String,
+)

--- a/storage/src/main/kotlin/repo/model/PortfolioModels.kt
+++ b/storage/src/main/kotlin/repo/model/PortfolioModels.kt
@@ -1,0 +1,30 @@
+package repo.model
+
+import java.time.Instant
+import java.util.UUID
+
+/** Row model for the [repo.tables.PortfoliosTable]. */
+data class PortfolioEntity(
+    val portfolioId: UUID,
+    val userId: Long,
+    val name: String,
+    val baseCurrency: String,
+    val isActive: Boolean,
+    val createdAt: Instant,
+)
+
+/** Payload for creating a new portfolio. */
+data class NewPortfolio(
+    val userId: Long,
+    val name: String,
+    val baseCurrency: String,
+    val isActive: Boolean = true,
+    val createdAt: Instant = Instant.now(),
+)
+
+/** Payload for updating a portfolio. */
+data class PortfolioUpdate(
+    val name: String? = null,
+    val baseCurrency: String? = null,
+    val isActive: Boolean? = null,
+)

--- a/storage/src/main/kotlin/repo/model/TradeModels.kt
+++ b/storage/src/main/kotlin/repo/model/TradeModels.kt
@@ -1,0 +1,39 @@
+package repo.model
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/** Payload for inserting new trades. */
+data class NewTrade(
+    val portfolioId: UUID,
+    val instrumentId: Long,
+    val datetime: Instant,
+    val side: String,
+    val quantity: BigDecimal,
+    val price: BigDecimal,
+    val priceCurrency: String,
+    val fee: BigDecimal,
+    val feeCurrency: String,
+    val tax: BigDecimal?,
+    val taxCurrency: String?,
+    val broker: String?,
+    val note: String?,
+    val extId: String?,
+    val createdAt: Instant = Instant.now(),
+)
+
+/** Payload for updating a trade. */
+data class TradeUpdate(
+    val datetime: Instant? = null,
+    val side: String? = null,
+    val quantity: BigDecimal? = null,
+    val price: BigDecimal? = null,
+    val priceCurrency: String? = null,
+    val fee: BigDecimal? = null,
+    val feeCurrency: String? = null,
+    val tax: BigDecimal? = null,
+    val taxCurrency: String? = null,
+    val broker: String? = null,
+    val note: String? = null,
+)

--- a/storage/src/main/kotlin/repo/model/UserModels.kt
+++ b/storage/src/main/kotlin/repo/model/UserModels.kt
@@ -1,0 +1,16 @@
+package repo.model
+
+import java.time.Instant
+
+/** Represents a persisted application user. */
+data class UserEntity(
+    val userId: Long,
+    val telegramUserId: Long?,
+    val createdAt: Instant,
+)
+
+/** Payload for creating a user row. */
+data class NewUser(
+    val telegramUserId: Long?,
+    val createdAt: Instant = Instant.now(),
+)

--- a/storage/src/main/kotlin/repo/model/ValuationModels.kt
+++ b/storage/src/main/kotlin/repo/model/ValuationModels.kt
@@ -1,0 +1,25 @@
+package repo.model
+
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+/** Row model for the [repo.tables.ValuationsDailyTable]. */
+data class ValuationDailyRecord(
+    val portfolioId: UUID,
+    val date: LocalDate,
+    val valueRub: BigDecimal,
+    val pnlDay: BigDecimal,
+    val pnlTotal: BigDecimal,
+    val drawdown: BigDecimal,
+)
+
+/** Creation payload for valuations. */
+data class NewValuationDaily(
+    val portfolioId: UUID,
+    val date: LocalDate,
+    val valueRub: BigDecimal,
+    val pnlDay: BigDecimal,
+    val pnlTotal: BigDecimal,
+    val drawdown: BigDecimal,
+)

--- a/storage/src/main/kotlin/repo/tables/FxRatesTable.kt
+++ b/storage/src/main/kotlin/repo/tables/FxRatesTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.FxRatesTable as DbFxRatesTable
+
+val FxRatesTable = DbFxRatesTable

--- a/storage/src/main/kotlin/repo/tables/InstrumentAliasesTable.kt
+++ b/storage/src/main/kotlin/repo/tables/InstrumentAliasesTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.InstrumentAliasesTable as DbInstrumentAliasesTable
+
+val InstrumentAliasesTable = DbInstrumentAliasesTable

--- a/storage/src/main/kotlin/repo/tables/InstrumentsTable.kt
+++ b/storage/src/main/kotlin/repo/tables/InstrumentsTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.InstrumentsTable as DbInstrumentsTable
+
+val InstrumentsTable = DbInstrumentsTable

--- a/storage/src/main/kotlin/repo/tables/PortfoliosTable.kt
+++ b/storage/src/main/kotlin/repo/tables/PortfoliosTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.PortfoliosTable as DbPortfoliosTable
+
+val PortfoliosTable = DbPortfoliosTable

--- a/storage/src/main/kotlin/repo/tables/PositionsTable.kt
+++ b/storage/src/main/kotlin/repo/tables/PositionsTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.PositionsTable as DbPositionsTable
+
+val PositionsTable = DbPositionsTable

--- a/storage/src/main/kotlin/repo/tables/PricesTable.kt
+++ b/storage/src/main/kotlin/repo/tables/PricesTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.PricesTable as DbPricesTable
+
+val PricesTable = DbPricesTable

--- a/storage/src/main/kotlin/repo/tables/TradesTable.kt
+++ b/storage/src/main/kotlin/repo/tables/TradesTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.TradesTable as DbTradesTable
+
+val TradesTable = DbTradesTable

--- a/storage/src/main/kotlin/repo/tables/UsersTable.kt
+++ b/storage/src/main/kotlin/repo/tables/UsersTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.UsersTable as DbUsersTable
+
+val UsersTable = DbUsersTable

--- a/storage/src/main/kotlin/repo/tables/ValuationsDailyTable.kt
+++ b/storage/src/main/kotlin/repo/tables/ValuationsDailyTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.ValuationsDailyTable as DbValuationsDailyTable
+
+val ValuationsDailyTable = DbValuationsDailyTable

--- a/storage/src/test/kotlin/repo/RepositorySignatureTest.kt
+++ b/storage/src/test/kotlin/repo/RepositorySignatureTest.kt
@@ -1,0 +1,73 @@
+package repo
+
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class RepositorySignatureTest {
+    @Test
+    fun `portfolio repository exposes expected API`() {
+        val functions = PortfolioRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(functions.containsAll(listOf("create", "findById", "findByUser", "listAll", "searchByName", "update", "delete")))
+    }
+
+    @Test
+    fun `instrument repository exposes expected API`() {
+        val functions = InstrumentRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(
+            functions.containsAll(
+                listOf(
+                    "createInstrument",
+                    "updateInstrument",
+                    "deleteInstrument",
+                    "findById",
+                    "findByIsin",
+                    "findBySymbol",
+                    "search",
+                    "listAliases",
+                    "addAlias",
+                    "removeAlias",
+                    "findAlias",
+                    "listAll",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `trade repository exposes expected API`() {
+        val functions = TradeRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(
+            functions.containsAll(
+                listOf(
+                    "createTrade",
+                    "updateTrade",
+                    "deleteTrade",
+                    "findById",
+                    "findByExternalId",
+                    "listByPortfolio",
+                    "listByInstrument",
+                    "listByPeriod",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `position repository exposes expected API`() {
+        val functions = PositionRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(functions.containsAll(listOf("save", "find", "list", "delete")))
+    }
+
+    @Test
+    fun `fx rate repository exposes expected API`() {
+        val functions = FxRateRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(functions.containsAll(listOf("upsert", "findLatest", "find", "list", "delete")))
+    }
+
+    @Test
+    fun `valuation repository exposes expected API`() {
+        val functions = ValuationRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(functions.containsAll(listOf("upsert", "find", "list", "listRange", "delete")))
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/FxRateMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/FxRateMapperTest.kt
@@ -1,0 +1,43 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import model.FxRate
+import repo.tables.FxRatesTable
+
+class FxRateMapperTest {
+    @Test
+    fun `maps result row to fx rate`() {
+        val ts = Instant.parse("2024-08-01T08:00:00Z")
+        val row = testResultRow(
+            FxRatesTable.ccy to "USD",
+            FxRatesTable.ts to OffsetDateTime.ofInstant(ts, ZoneOffset.UTC),
+            FxRatesTable.rateRub to BigDecimal("93.45"),
+            FxRatesTable.sourceCol to "cbr",
+        )
+
+        val rate = row.toFxRate()
+
+        assertEquals("USD", rate.ccy)
+        assertEquals(ts, rate.ts)
+        assertEquals(BigDecimal("93.45"), rate.rateRub.stripTrailingZeros())
+        assertEquals("cbr", rate.source)
+    }
+
+    @Test
+    fun `maps fx rate to column values`() {
+        val ts = Instant.parse("2024-08-01T08:00:00Z")
+        val rate = FxRate(ccy = "EUR", ts = ts, rateRub = BigDecimal("100.12"), source = "market")
+
+        val values = rate.toColumnValues()
+
+        assertEquals("EUR", values[FxRatesTable.ccy])
+        assertEquals(OffsetDateTime.ofInstant(ts, ZoneOffset.UTC), values[FxRatesTable.ts])
+        assertEquals(BigDecimal("100.12"), values[FxRatesTable.rateRub])
+        assertEquals("market", values[FxRatesTable.sourceCol])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/InstrumentMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/InstrumentMapperTest.kt
@@ -1,0 +1,102 @@
+package repo.mapper
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import repo.model.InstrumentUpdate
+import repo.model.NewInstrument
+import repo.model.NewInstrumentAlias
+import repo.tables.InstrumentAliasesTable
+import repo.tables.InstrumentsTable
+
+class InstrumentMapperTest {
+    @Test
+    fun `maps result row to instrument entity`() {
+        val createdAt = Instant.parse("2024-05-15T09:00:00Z")
+        val row = testResultRow(
+            InstrumentsTable.instrumentId to 10L,
+            InstrumentsTable.clazz to "stock",
+            InstrumentsTable.exchange to "MOEX",
+            InstrumentsTable.board to "TQBR",
+            InstrumentsTable.symbol to "SBER",
+            InstrumentsTable.isin to "RU0009029540",
+            InstrumentsTable.cgId to "cg-123",
+            InstrumentsTable.currency to "RUB",
+            InstrumentsTable.createdAt to OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC),
+        )
+
+        val entity = row.toInstrumentEntity()
+
+        assertEquals(10L, entity.instrumentId)
+        assertEquals("stock", entity.clazz)
+        assertEquals("MOEX", entity.exchange)
+        assertEquals("TQBR", entity.board)
+        assertEquals("SBER", entity.symbol)
+        assertEquals("RU0009029540", entity.isin)
+        assertEquals("cg-123", entity.cgId)
+        assertEquals("RUB", entity.currency)
+        assertEquals(createdAt, entity.createdAt)
+    }
+
+    @Test
+    fun `maps new instrument to column values`() {
+        val createdAt = Instant.parse("2024-05-15T09:00:00Z")
+        val payload = NewInstrument(
+            clazz = "bond",
+            exchange = "NYSE",
+            board = null,
+            symbol = "TSLA",
+            isin = null,
+            cgId = null,
+            currency = "USD",
+            createdAt = createdAt,
+        )
+
+        val values = payload.toColumnValues()
+
+        assertEquals("bond", values[InstrumentsTable.clazz])
+        assertEquals("NYSE", values[InstrumentsTable.exchange])
+        assertEquals(null, values[InstrumentsTable.board])
+        assertEquals("TSLA", values[InstrumentsTable.symbol])
+        assertEquals(null, values[InstrumentsTable.isin])
+        assertEquals("USD", values[InstrumentsTable.currency])
+        assertEquals(OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC), values[InstrumentsTable.createdAt])
+    }
+
+    @Test
+    fun `maps instrument update`() {
+        val update = InstrumentUpdate(clazz = "etf", symbol = "FXUS")
+
+        val values = update.toColumnValues()
+
+        assertEquals(2, values.size)
+        assertEquals("etf", values[InstrumentsTable.clazz])
+        assertEquals("FXUS", values[InstrumentsTable.symbol])
+        assertFalse(values.containsKey(InstrumentsTable.currency))
+    }
+
+    @Test
+    fun `maps instrument alias`() {
+        val row = testResultRow(
+            InstrumentAliasesTable.aliasId to 5L,
+            InstrumentAliasesTable.instrumentId to 10L,
+            InstrumentAliasesTable.alias to "SBERP",
+            InstrumentAliasesTable.sourceCol to "manual",
+        )
+
+        val alias = row.toInstrumentAliasEntity()
+
+        assertEquals(5L, alias.aliasId)
+        assertEquals(10L, alias.instrumentId)
+        assertEquals("SBERP", alias.alias)
+        assertEquals("manual", alias.source)
+
+        val insertValues = NewInstrumentAlias(instrumentId = 20L, alias = "GAZP", source = "import").toColumnValues()
+        assertEquals(20L, insertValues[InstrumentAliasesTable.instrumentId])
+        assertEquals("GAZP", insertValues[InstrumentAliasesTable.alias])
+        assertEquals("import", insertValues[InstrumentAliasesTable.sourceCol])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/PortfolioMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/PortfolioMapperTest.kt
@@ -1,0 +1,64 @@
+package repo.mapper
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import repo.model.NewPortfolio
+import repo.model.PortfolioUpdate
+import repo.tables.PortfoliosTable
+
+class PortfolioMapperTest {
+    @Test
+    fun `maps result row to portfolio entity`() {
+        val portfolioId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+        val createdAt = Instant.parse("2024-01-02T00:00:00Z")
+        val row = testResultRow(
+            PortfoliosTable.portfolioId to portfolioId,
+            PortfoliosTable.userId to 77L,
+            PortfoliosTable.name to "Retirement",
+            PortfoliosTable.baseCurrency to "USD",
+            PortfoliosTable.isActive to true,
+            PortfoliosTable.createdAt to OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC),
+        )
+
+        val entity = row.toPortfolioEntity()
+
+        assertEquals(portfolioId, entity.portfolioId)
+        assertEquals(77L, entity.userId)
+        assertEquals("Retirement", entity.name)
+        assertEquals("USD", entity.baseCurrency)
+        assertTrue(entity.isActive)
+        assertEquals(createdAt, entity.createdAt)
+    }
+
+    @Test
+    fun `maps new portfolio to insert values`() {
+        val createdAt = Instant.parse("2024-01-02T00:00:00Z")
+        val payload = NewPortfolio(userId = 7L, name = "Growth", baseCurrency = "EUR", isActive = false, createdAt = createdAt)
+
+        val values = payload.toColumnValues()
+
+        assertEquals(7L, values[PortfoliosTable.userId])
+        assertEquals("Growth", values[PortfoliosTable.name])
+        assertEquals("EUR", values[PortfoliosTable.baseCurrency])
+        assertEquals(false, values[PortfoliosTable.isActive])
+        assertEquals(OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC), values[PortfoliosTable.createdAt])
+    }
+
+    @Test
+    fun `maps portfolio update to column values`() {
+        val update = PortfolioUpdate(name = "Income", baseCurrency = null, isActive = true)
+
+        val values = update.toColumnValues()
+
+        assertEquals(2, values.size)
+        assertEquals("Income", values[PortfoliosTable.name])
+        assertEquals(true, values[PortfoliosTable.isActive])
+        assertFalse(values.containsKey(PortfoliosTable.baseCurrency))
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/PositionMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/PositionMapperTest.kt
@@ -1,0 +1,58 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import repo.tables.PositionsTable
+import model.PositionDto
+
+class PositionMapperTest {
+    @Test
+    fun `maps result row to position dto`() {
+        val portfolioId = UUID.fromString("10000000-0000-0000-0000-000000000000")
+        val updatedAt = Instant.parse("2024-06-01T10:00:00Z")
+        val row = testResultRow(
+            PositionsTable.portfolioId to portfolioId,
+            PositionsTable.instrumentId to 55L,
+            PositionsTable.qty to BigDecimal("15.5"),
+            PositionsTable.avgPrice to BigDecimal("123.45"),
+            PositionsTable.avgPriceCcy to "USD",
+            PositionsTable.updatedAt to OffsetDateTime.ofInstant(updatedAt, ZoneOffset.UTC),
+        )
+
+        val dto = row.toPositionDto()
+
+        assertEquals(portfolioId, dto.portfolioId)
+        assertEquals(55L, dto.instrumentId)
+        assertEquals(0, BigDecimal("15.5").compareTo(dto.qty))
+        assertEquals(0, BigDecimal("123.45").compareTo(dto.avgPrice))
+        assertEquals("USD", dto.avgPriceCcy)
+        assertEquals(updatedAt, dto.updatedAt)
+    }
+
+    @Test
+    fun `maps position dto to insert values`() {
+        val dto = PositionDto(
+            portfolioId = UUID.fromString("10000000-0000-0000-0000-000000000000"),
+            instrumentId = 5L,
+            qty = BigDecimal("1.0"),
+            avgPrice = null,
+            avgPriceCcy = null,
+            updatedAt = Instant.parse("2024-06-01T10:00:00Z"),
+        )
+
+        val insertValues = dto.toInsertValues()
+
+        assertEquals(dto.portfolioId, insertValues[PositionsTable.portfolioId])
+        assertEquals(null, insertValues[PositionsTable.avgPrice])
+        assertEquals(OffsetDateTime.ofInstant(dto.updatedAt, ZoneOffset.UTC), insertValues[PositionsTable.updatedAt])
+
+        val updateValues = dto.toUpdateValues()
+        assertEquals(BigDecimal("1.0"), updateValues[PositionsTable.qty])
+        assertEquals(null, updateValues[PositionsTable.avgPriceCcy])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/PriceMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/PriceMapperTest.kt
@@ -1,0 +1,45 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import model.PricePoint
+import repo.tables.PricesTable
+
+class PriceMapperTest {
+    @Test
+    fun `maps result row to price point`() {
+        val ts = Instant.parse("2024-07-01T12:30:00Z")
+        val row = testResultRow(
+            PricesTable.instrumentId to 5L,
+            PricesTable.ts to OffsetDateTime.ofInstant(ts, ZoneOffset.UTC),
+            PricesTable.price to BigDecimal("321.45"),
+            PricesTable.ccy to "USD",
+            PricesTable.sourceCol to "provider",
+        )
+
+        val point = row.toPricePoint()
+
+        assertEquals(5L, point.instrumentId)
+        assertEquals(ts, point.ts)
+        assertEquals(BigDecimal("321.45"), point.price.stripTrailingZeros())
+        assertEquals("USD", point.ccy)
+        assertEquals("provider", point.source)
+    }
+
+    @Test
+    fun `maps price point to column values`() {
+        val ts = Instant.parse("2024-07-01T12:30:00Z")
+        val point = PricePoint(instrumentId = 9L, ts = ts, price = BigDecimal("10.0"), ccy = "EUR", source = "manual")
+
+        val values = point.toColumnValues()
+
+        assertEquals(9L, values[PricesTable.instrumentId])
+        assertEquals(OffsetDateTime.ofInstant(ts, ZoneOffset.UTC), values[PricesTable.ts])
+        assertEquals(BigDecimal("10.0"), values[PricesTable.price])
+        assertEquals("manual", values[PricesTable.sourceCol])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/ResultRowTestFactory.kt
+++ b/storage/src/test/kotlin/repo/mapper/ResultRowTestFactory.kt
@@ -1,0 +1,21 @@
+package repo.mapper
+
+import java.util.LinkedHashMap
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.ResultRow
+
+private val testDatabase by lazy {
+    Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL", driver = "org.h2.Driver")
+}
+
+internal fun testResultRow(vararg pairs: Pair<Expression<*>, Any?>): ResultRow {
+    testDatabase
+    val fieldIndex = LinkedHashMap<Expression<*>, Int>(pairs.size)
+    val data = arrayOfNulls<Any?>(pairs.size)
+    pairs.forEachIndexed { index, (expression, value) ->
+        fieldIndex[expression] = index
+        data[index] = value
+    }
+    return ResultRow(fieldIndex, data)
+}

--- a/storage/src/test/kotlin/repo/mapper/TradeMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/TradeMapperTest.kt
@@ -1,0 +1,103 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import repo.model.NewTrade
+import repo.model.TradeUpdate
+import repo.tables.TradesTable
+
+class TradeMapperTest {
+    @Test
+    fun `maps result row to trade dto`() {
+        val tradeId = 11L
+        val portfolioId = UUID.fromString("00000000-0000-0000-0000-000000000111")
+        val instrumentId = 200L
+        val datetime = Instant.parse("2024-04-01T12:00:00Z")
+        val createdAt = Instant.parse("2024-04-02T12:00:00Z")
+        val row = testResultRow(
+            TradesTable.tradeId to tradeId,
+            TradesTable.portfolioId to portfolioId,
+            TradesTable.instrumentId to instrumentId,
+            TradesTable.datetime to OffsetDateTime.ofInstant(datetime, ZoneOffset.UTC),
+            TradesTable.side to "BUY",
+            TradesTable.quantity to BigDecimal("10.5"),
+            TradesTable.price to BigDecimal("150.25"),
+            TradesTable.priceCurrency to "USD",
+            TradesTable.fee to BigDecimal("1.23"),
+            TradesTable.feeCurrency to "USD",
+            TradesTable.tax to BigDecimal("0.45"),
+            TradesTable.taxCurrency to "USD",
+            TradesTable.broker to "TestBroker",
+            TradesTable.note to "note",
+            TradesTable.extId to "ext-1",
+            TradesTable.createdAt to OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC),
+        )
+
+        val dto = row.toTradeDto()
+
+        assertEquals(tradeId, dto.tradeId)
+        assertEquals(portfolioId, dto.portfolioId)
+        assertEquals(instrumentId, dto.instrumentId)
+        assertEquals(datetime, dto.datetime)
+        assertEquals("BUY", dto.side)
+        assertEquals(0, BigDecimal("10.5").compareTo(dto.quantity))
+        assertEquals(0, BigDecimal("150.25").compareTo(dto.price))
+        assertEquals("USD", dto.priceCurrency)
+        assertEquals(0, BigDecimal("1.23").compareTo(dto.fee))
+        assertEquals(0, BigDecimal("0.45").compareTo(dto.tax))
+        assertEquals("USD", dto.taxCurrency)
+        assertEquals("TestBroker", dto.broker)
+        assertEquals("note", dto.note)
+        assertEquals("ext-1", dto.extId)
+        assertEquals(createdAt, dto.createdAt)
+    }
+
+    @Test
+    fun `maps new trade to column values`() {
+        val portfolioId = UUID.fromString("00000000-0000-0000-0000-000000000999")
+        val datetime = Instant.parse("2024-04-01T12:00:00Z")
+        val createdAt = Instant.parse("2024-04-01T13:00:00Z")
+        val newTrade = NewTrade(
+            portfolioId = portfolioId,
+            instrumentId = 1L,
+            datetime = datetime,
+            side = "SELL",
+            quantity = BigDecimal.ONE,
+            price = BigDecimal.TEN,
+            priceCurrency = "USD",
+            fee = BigDecimal.ZERO,
+            feeCurrency = "USD",
+            tax = null,
+            taxCurrency = null,
+            broker = null,
+            note = null,
+            extId = null,
+            createdAt = createdAt,
+        )
+
+        val values = newTrade.toColumnValues()
+
+        assertEquals(portfolioId, values[TradesTable.portfolioId])
+        assertEquals(OffsetDateTime.ofInstant(datetime, ZoneOffset.UTC), values[TradesTable.datetime])
+        assertFalse(values.containsKey(TradesTable.tax))
+        assertFalse(values.containsKey(TradesTable.broker))
+        assertEquals(OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC), values[TradesTable.createdAt])
+    }
+
+    @Test
+    fun `maps trade update to column values`() {
+        val update = TradeUpdate(price = BigDecimal("99.9"), note = "updated")
+
+        val values = update.toColumnValues()
+
+        assertEquals(BigDecimal("99.9"), values[TradesTable.price])
+        assertEquals("updated", values[TradesTable.note])
+        assertFalse(values.containsKey(TradesTable.side))
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/UserMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/UserMapperTest.kt
@@ -1,0 +1,36 @@
+package repo.mapper
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import repo.model.NewUser
+import repo.tables.UsersTable
+
+class UserMapperTest {
+    @Test
+    fun `maps result row to user entity`() {
+        val createdAt = Instant.parse("2024-03-01T10:15:30Z")
+        val row = testResultRow(
+            UsersTable.userId to 1L,
+            UsersTable.tgUserId to 42L,
+            UsersTable.createdAt to OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC),
+        )
+
+        val entity = row.toUserEntity()
+
+        assertEquals(1L, entity.userId)
+        assertEquals(42L, entity.telegramUserId)
+        assertEquals(createdAt, entity.createdAt)
+    }
+
+    @Test
+    fun `maps new user to column values`() {
+        val createdAt = Instant.parse("2024-03-01T10:15:30Z")
+        val values = NewUser(telegramUserId = null, createdAt = createdAt).toColumnValues()
+
+        assertEquals(null, values[UsersTable.tgUserId])
+        assertEquals(OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC), values[UsersTable.createdAt])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/ValuationMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/ValuationMapperTest.kt
@@ -1,0 +1,53 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import repo.model.NewValuationDaily
+import repo.tables.ValuationsDailyTable
+
+class ValuationMapperTest {
+    @Test
+    fun `maps result row to valuation`() {
+        val portfolioId = UUID.fromString("20000000-0000-0000-0000-000000000000")
+        val date = LocalDate.of(2024, 9, 1)
+        val row = testResultRow(
+            ValuationsDailyTable.portfolioId to portfolioId,
+            ValuationsDailyTable.date to date,
+            ValuationsDailyTable.valueRub to BigDecimal("100000.12"),
+            ValuationsDailyTable.pnlDay to BigDecimal("150.00"),
+            ValuationsDailyTable.pnlTotal to BigDecimal("2500.50"),
+            ValuationsDailyTable.drawdown to BigDecimal("-50.25"),
+        )
+
+        val record = row.toValuationDailyRecord()
+
+        assertEquals(portfolioId, record.portfolioId)
+        assertEquals(date, record.date)
+        assertEquals(0, BigDecimal("100000.12").compareTo(record.valueRub))
+        assertEquals(0, BigDecimal("150.00").compareTo(record.pnlDay))
+        assertEquals(0, BigDecimal("2500.50").compareTo(record.pnlTotal))
+        assertEquals(0, BigDecimal("-50.25").compareTo(record.drawdown))
+    }
+
+    @Test
+    fun `maps valuation payload to column values`() {
+        val portfolioId = UUID.fromString("20000000-0000-0000-0000-000000000000")
+        val payload = NewValuationDaily(
+            portfolioId = portfolioId,
+            date = LocalDate.of(2024, 9, 2),
+            valueRub = BigDecimal("101000.00"),
+            pnlDay = BigDecimal("100.00"),
+            pnlTotal = BigDecimal("2600.50"),
+            drawdown = BigDecimal("-40.25"),
+        )
+
+        val values = payload.toColumnValues()
+
+        assertEquals(portfolioId, values[ValuationsDailyTable.portfolioId])
+        assertEquals(LocalDate.of(2024, 9, 2), values[ValuationsDailyTable.date])
+        assertEquals(BigDecimal("101000.00"), values[ValuationsDailyTable.valueRub])
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `PositionCalc` interface with average-cost and FIFO strategies that compute updated lots and realized P&L for buys and sells
- cover trade math with focused unit tests and Kotest-powered property tests for both valuation methods
- wire Kotest and coroutine dependencies to support the new property-based test suite

## Testing
- ./gradlew build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cc133bd4b4832192a0f7c62f88adc8