### PR TITLE
Add valuation service and unrealized PnL reporting

### DIFF
--- a/app/src/main/kotlin/io/ktor/server/config/ConfigExtensions.kt
+++ b/app/src/main/kotlin/io/ktor/server/config/ConfigExtensions.kt
@@ -1,0 +1,8 @@
+package io.ktor.server.config
+
+fun ApplicationConfig.configOrNull(path: String): ApplicationConfig? =
+    try {
+        config(path)
+    } catch (_: ApplicationConfigurationException) {
+        null
+    }

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -38,3 +38,10 @@ integrations {
     baseUrl = ${?CBR_BASE_URL}
   }
 }
+
+pricing {
+  preferClosePrice = true
+  preferClosePrice = ${?PRICING_PREFER_CLOSE_PRICE}
+  fallbackToLast = true
+  fallbackToLast = ${?PRICING_FALLBACK_TO_LAST}
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,8 @@
 dependencies {
     implementation(libs.serialization.json)
+    implementation(libs.coroutines.core)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.property)
+    testImplementation(libs.coroutines.core)
 }

--- a/core/src/main/kotlin/portfolio/errors/PortfolioError.kt
+++ b/core/src/main/kotlin/portfolio/errors/PortfolioError.kt
@@ -1,0 +1,16 @@
+package portfolio.errors
+
+sealed interface PortfolioError {
+    val message: String
+
+    data class Validation(override val message: String) : PortfolioError
+    data class NotFound(override val message: String) : PortfolioError
+    data class External(
+        override val message: String,
+        val cause: Throwable? = null
+    ) : PortfolioError
+}
+
+typealias DomainResult<T> = Result<T>
+
+class PortfolioException(val error: PortfolioError) : RuntimeException(error.message)

--- a/core/src/main/kotlin/portfolio/model/DateRange.kt
+++ b/core/src/main/kotlin/portfolio/model/DateRange.kt
@@ -1,0 +1,22 @@
+package portfolio.model
+
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DateRange(
+    @Contextual val from: LocalDate,
+    @Contextual val to: LocalDate
+) {
+    init {
+        require(!from.isAfter(to)) { "Start date must not be after end date" }
+    }
+
+    operator fun contains(date: LocalDate): Boolean = !date.isBefore(from) && !date.isAfter(to)
+
+    val lengthInDays: Long get() = ChronoUnit.DAYS.between(from, to) + 1
+
+    fun overlaps(other: DateRange): Boolean = from <= other.to && other.from <= to
+}

--- a/core/src/main/kotlin/portfolio/model/Money.kt
+++ b/core/src/main/kotlin/portfolio/model/Money.kt
@@ -1,0 +1,59 @@
+package portfolio.model
+
+import java.math.BigDecimal
+import java.util.Locale
+import kotlin.ConsistentCopyVisibility
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@ConsistentCopyVisibility
+@Serializable
+data class Money internal constructor(
+    @Contextual val amount: BigDecimal,
+    val currency: String
+) {
+    init {
+        require(isNormalized(amount)) { "Amount scale must be normalized" }
+        require(CURRENCY_REGEX.matches(currency)) { "Currency must be a valid ISO 4217 code" }
+    }
+
+    operator fun plus(other: Money): Money {
+        ensureSameCurrency(other)
+        return of(amount + other.amount, currency)
+    }
+
+    operator fun minus(other: Money): Money {
+        ensureSameCurrency(other)
+        return of(amount - other.amount, currency)
+    }
+
+    operator fun times(multiplier: BigDecimal): Money = of(amount.multiply(multiplier), currency)
+
+    operator fun times(multiplier: Long): Money = times(BigDecimal.valueOf(multiplier))
+
+    operator fun times(multiplier: Int): Money = times(multiplier.toLong())
+
+    operator fun unaryMinus(): Money = of(amount.negate(), currency)
+
+    private fun ensureSameCurrency(other: Money) {
+        require(currency == other.currency) { "Currency mismatch: $currency != ${other.currency}" }
+    }
+
+    companion object {
+        private val CURRENCY_REGEX = Regex("^[A-Z]{3}$")
+
+        fun of(amount: BigDecimal, currency: String): Money {
+            val normalizedCurrency = currency.trim().uppercase(Locale.ROOT)
+            require(CURRENCY_REGEX.matches(normalizedCurrency)) { "Currency must be a valid ISO 4217 code" }
+            val normalizedAmount = normalize(amount)
+            return Money(normalizedAmount, normalizedCurrency)
+        }
+
+        private fun normalize(amount: BigDecimal): BigDecimal {
+            val stripped = amount.stripTrailingZeros()
+            return if (stripped.scale() < 0) stripped.setScale(0) else stripped
+        }
+
+        internal fun isNormalized(amount: BigDecimal): Boolean = amount == normalize(amount)
+    }
+}

--- a/core/src/main/kotlin/portfolio/model/PortfolioReport.kt
+++ b/core/src/main/kotlin/portfolio/model/PortfolioReport.kt
@@ -1,0 +1,17 @@
+package portfolio.model
+
+import java.time.Instant
+import java.util.UUID
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PortfolioReport(
+    @Contextual val portfolioId: UUID,
+    val period: DateRange,
+    val valuationMethod: ValuationMethod,
+    val positions: List<PositionView>,
+    val trades: List<TradeView>,
+    val valuations: List<ValuationDaily>,
+    @Contextual val generatedAt: Instant
+)

--- a/core/src/main/kotlin/portfolio/model/PositionView.kt
+++ b/core/src/main/kotlin/portfolio/model/PositionView.kt
@@ -1,0 +1,16 @@
+package portfolio.model
+
+import java.math.BigDecimal
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PositionView(
+    val instrumentId: Long,
+    val instrumentName: String,
+    @Contextual val quantity: BigDecimal,
+    val valuation: Money,
+    val averageCost: Money?,
+    val valuationMethod: ValuationMethod,
+    val unrealizedPnl: Money,
+)

--- a/core/src/main/kotlin/portfolio/model/TradeSide.kt
+++ b/core/src/main/kotlin/portfolio/model/TradeSide.kt
@@ -1,0 +1,9 @@
+package portfolio.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class TradeSide {
+    BUY,
+    SELL,
+}

--- a/core/src/main/kotlin/portfolio/model/TradeView.kt
+++ b/core/src/main/kotlin/portfolio/model/TradeView.kt
@@ -1,0 +1,27 @@
+package portfolio.model
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TradeView(
+    @Contextual val tradeId: UUID,
+    @Contextual val portfolioId: UUID,
+    val instrumentId: Long,
+    @Contextual val tradeDate: LocalDate,
+    val side: TradeSide,
+    @Contextual val quantity: BigDecimal,
+    val price: Money,
+    val fee: Money = Money.of(BigDecimal.ZERO, price.currency),
+    val tax: Money? = null,
+    val notional: Money = price * quantity.abs(),
+    val broker: String? = null,
+    val note: String? = null,
+    val externalId: String? = null,
+    @Contextual val executedAt: Instant = tradeDate.atStartOfDay(ZoneOffset.UTC).toInstant(),
+)

--- a/core/src/main/kotlin/portfolio/model/ValuationDaily.kt
+++ b/core/src/main/kotlin/portfolio/model/ValuationDaily.kt
@@ -1,0 +1,15 @@
+package portfolio.model
+
+import java.math.BigDecimal
+import java.time.LocalDate
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ValuationDaily(
+    @Contextual val date: LocalDate,
+    val valueRub: Money,
+    val pnlDay: Money,
+    val pnlTotal: Money,
+    @Contextual val drawdown: BigDecimal,
+)

--- a/core/src/main/kotlin/portfolio/model/ValuationMethod.kt
+++ b/core/src/main/kotlin/portfolio/model/ValuationMethod.kt
@@ -1,0 +1,9 @@
+package portfolio.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class ValuationMethod {
+    FIFO,
+    AVERAGE
+}

--- a/core/src/main/kotlin/portfolio/service/CsvImportService.kt
+++ b/core/src/main/kotlin/portfolio/service/CsvImportService.kt
@@ -1,0 +1,526 @@
+package portfolio.service
+
+import java.io.Reader
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeParseException
+import java.util.Locale
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.ConsistentCopyVisibility
+import portfolio.errors.DomainResult
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+import portfolio.model.Money
+import portfolio.model.TradeSide
+import portfolio.model.TradeView
+import portfolio.model.ValuationMethod
+
+class CsvImportService(
+    private val instrumentResolver: InstrumentResolver,
+    private val tradeLookup: TradeLookup,
+    private val portfolioService: PortfolioService,
+) {
+    suspend fun import(
+        portfolioId: UUID,
+        reader: Reader,
+        valuationMethod: ValuationMethod,
+    ): DomainResult<ImportReport> = withContext(Dispatchers.IO) {
+        reader.buffered().use { buffered ->
+            val headerLine = buffered.readLine() ?: return@use DomainResult.success(ImportReport())
+            val header = parseHeader(headerLine)
+                ?: return@use failure(
+                    PortfolioError.Validation("CSV header must contain: ${EXPECTED_HEADER.joinToString(",")}"),
+                )
+
+            if (header != EXPECTED_HEADER) {
+                val actual = header.joinToString(",")
+                return@use failure(
+                    PortfolioError.Validation("Unexpected CSV header: $actual"),
+                )
+            }
+
+            var lineNumber = 1
+            var inserted = 0
+            var duplicates = 0
+            val failures = mutableListOf<ImportFailure>()
+            val seenExtIds = mutableSetOf<String>()
+            val seenSoftKeys = mutableSetOf<SoftTradeKey>()
+
+            for (line in buffered.lineSequence()) {
+                lineNumber += 1
+                if (line.isBlank()) continue
+
+                val columns = try {
+                    parseLine(line)
+                } catch (iae: IllegalArgumentException) {
+                    failures += ImportFailure(lineNumber, null, iae.message ?: "Invalid CSV row")
+                    continue
+                }
+
+                if (columns.size != header.size) {
+                    failures += ImportFailure(
+                        lineNumber,
+                        null,
+                        "Expected ${header.size} columns but found ${columns.size}",
+                    )
+                    continue
+                }
+
+                val rowValues = header.indices.associate { index ->
+                    header[index] to columns[index]
+                }
+
+                val parsed = parseRow(rowValues)
+                when (parsed) {
+                    is RowParseResult.Failure -> {
+                        failures += ImportFailure(lineNumber, parsed.extId, parsed.message)
+                    }
+                    is RowParseResult.Success -> {
+                        val row = parsed.value
+
+                        val instrumentResult = resolveInstrument(row)
+                        if (instrumentResult.isFailure) {
+                            failures += ImportFailure(
+                                lineNumber,
+                                row.extId,
+                                errorMessage(instrumentResult.exceptionOrNull()!!),
+                            )
+                            continue
+                        }
+
+                        val instrument = instrumentResult.getOrNull()
+                        if (instrument == null) {
+                            failures += ImportFailure(
+                                lineNumber,
+                                row.extId,
+                                "Instrument not found for ${row.ticker}",
+                            )
+                            continue
+                        }
+
+                        val extId = row.extId
+                        if (extId != null && seenExtIds.contains(extId)) {
+                            duplicates += 1
+                            continue
+                        }
+
+                        val softKey = SoftTradeKey.of(
+                            portfolioId = portfolioId,
+                            instrumentId = instrument.instrumentId,
+                            executedAt = row.executedAt,
+                            side = row.side,
+                            quantity = row.quantity,
+                            price = row.price,
+                        )
+
+                        if (seenSoftKeys.contains(softKey)) {
+                            duplicates += 1
+                            continue
+                        }
+
+                        if (extId != null) {
+                            val existsByExtId = tradeLookup.existsByExternalId(portfolioId, extId)
+                            if (existsByExtId.isFailure) {
+                                failures += ImportFailure(
+                                    lineNumber,
+                                    extId,
+                                    errorMessage(existsByExtId.exceptionOrNull()!!),
+                                )
+                                continue
+                            }
+                            if (existsByExtId.getOrThrow()) {
+                                seenExtIds += extId
+                                seenSoftKeys += softKey
+                                duplicates += 1
+                                continue
+                            }
+                        }
+
+                        val existsByKey = tradeLookup.existsBySoftKey(softKey)
+                        if (existsByKey.isFailure) {
+                            failures += ImportFailure(
+                                lineNumber,
+                                extId,
+                                errorMessage(existsByKey.exceptionOrNull()!!),
+                            )
+                            continue
+                        }
+                        if (existsByKey.getOrThrow()) {
+                            extId?.let { seenExtIds += it }
+                            seenSoftKeys += softKey
+                            duplicates += 1
+                            continue
+                        }
+
+                        val tradeView = buildTradeView(
+                            row = row,
+                            portfolioId = portfolioId,
+                            instrumentId = instrument.instrumentId,
+                        )
+
+                        val applied = portfolioService.applyTrade(tradeView, valuationMethod)
+                        if (applied.isSuccess) {
+                            inserted += 1
+                            seenSoftKeys += softKey
+                            extId?.let { seenExtIds += it }
+                        } else {
+                            failures += ImportFailure(
+                                lineNumber,
+                                extId,
+                                errorMessage(applied.exceptionOrNull()!!),
+                            )
+                        }
+                    }
+                }
+            }
+
+            DomainResult.success(
+                ImportReport(
+                    inserted = inserted,
+                    skippedDuplicates = duplicates,
+                    failed = failures,
+                ),
+            )
+        }
+    }
+
+    private fun buildTradeView(
+        row: ParsedTrade,
+        portfolioId: UUID,
+        instrumentId: Long,
+    ): TradeView {
+        val priceMoney = Money.of(row.price, row.currency)
+        val feeMoney = Money.of(row.fee, row.feeCurrency)
+        val taxMoney = row.tax?.let { Money.of(it, row.taxCurrency ?: row.currency) }
+        val tradeDate = LocalDate.ofInstant(row.executedAt, ZoneOffset.UTC)
+        return TradeView(
+            tradeId = UUID.randomUUID(),
+            portfolioId = portfolioId,
+            instrumentId = instrumentId,
+            tradeDate = tradeDate,
+            side = row.side,
+            quantity = row.quantity,
+            price = priceMoney,
+            fee = feeMoney,
+            tax = taxMoney,
+            broker = row.broker,
+            note = row.note,
+            externalId = row.extId,
+            executedAt = row.executedAt,
+        )
+    }
+
+    private suspend fun resolveInstrument(row: ParsedTrade): DomainResult<InstrumentRef?> {
+        row.exchange?.let { exchange ->
+            val result = instrumentResolver.findBySymbol(exchange, row.board, row.ticker)
+            if (result.isFailure) return result
+            val instrument = result.getOrNull()
+            if (instrument != null) {
+                return DomainResult.success(instrument)
+            }
+        }
+
+        row.aliasSource?.let { source ->
+            val result = instrumentResolver.findByAlias(row.ticker, source)
+            if (result.isFailure) return result
+            val instrument = result.getOrNull()
+            if (instrument != null) {
+                return DomainResult.success(instrument)
+            }
+        }
+
+        return DomainResult.success(null)
+    }
+
+    private fun parseHeader(line: String): List<String>? {
+        val values = try {
+            parseLine(line)
+        } catch (_: IllegalArgumentException) {
+            return null
+        }
+
+        if (values.isEmpty()) return null
+
+        return values.mapIndexed { index, raw ->
+            val trimmed = raw.trim()
+            val withoutBom = if (index == 0) trimmed.removePrefix("\uFEFF") else trimmed
+            withoutBom.lowercase(Locale.ROOT)
+        }
+    }
+
+    private fun parseRow(values: Map<String, String>): RowParseResult {
+        val extId = values["ext_id"].orEmpty().ifBlank { null }
+
+        val executedAt = parseInstant(values["datetime"]) ?: return RowParseResult.Failure(
+            extId,
+            "Invalid or missing datetime",
+        )
+
+        val ticker = values["ticker"].orEmpty().trim().uppercase(Locale.ROOT)
+        if (ticker.isEmpty()) {
+            return RowParseResult.Failure(extId, "Ticker is required")
+        }
+
+        val exchange = values["exchange"].orEmpty().trim().takeIf { it.isNotEmpty() }?.uppercase(Locale.ROOT)
+        val board = values["board"].orEmpty().trim().takeIf { it.isNotEmpty() }?.uppercase(Locale.ROOT)
+        val aliasSource = values["alias_source"].orEmpty().trim().takeIf { it.isNotEmpty() }?.uppercase(Locale.ROOT)
+
+        val sideRaw = values["side"].orEmpty().trim().uppercase(Locale.ROOT)
+        val side = try {
+            TradeSide.valueOf(sideRaw)
+        } catch (_: IllegalArgumentException) {
+            return RowParseResult.Failure(extId, "Unknown trade side: $sideRaw")
+        }
+
+        val quantity = parseDecimal(values["quantity"], positive = true)
+            ?: return RowParseResult.Failure(extId, "Quantity must be a positive decimal")
+
+        val price = parseDecimal(values["price"], positive = true)
+            ?: return RowParseResult.Failure(extId, "Price must be a positive decimal")
+
+        val currency = parseCurrency(values["currency"], default = null)
+            ?: return RowParseResult.Failure(extId, "Currency is required")
+
+        val fee = parseDecimal(values["fee"], positive = false) ?: BigDecimal.ZERO
+        if (fee < BigDecimal.ZERO) {
+            return RowParseResult.Failure(extId, "Fee cannot be negative")
+        }
+
+        val feeCurrency = parseCurrency(values["fee_currency"], default = currency)
+            ?: return RowParseResult.Failure(extId, "Fee currency is invalid")
+
+        val taxRaw = values["tax"]
+        val tax = parseDecimal(taxRaw, positive = false)
+        if (tax != null && tax < BigDecimal.ZERO) {
+            return RowParseResult.Failure(extId, "Tax cannot be negative")
+        }
+
+        val taxCurrency = if (tax != null) {
+            parseCurrency(values["tax_currency"], default = currency)
+                ?: return RowParseResult.Failure(extId, "Tax currency is invalid")
+        } else {
+            values["tax_currency"].orEmpty().trim().takeIf { it.isNotEmpty() }?.let {
+                parseCurrency(it, default = null)
+                    ?: return RowParseResult.Failure(extId, "Tax currency requires a tax amount")
+            }
+        }
+
+        val broker = values["broker"].orEmpty().trim().takeIf { it.isNotEmpty() }
+        val note = values["note"].orEmpty().trim().takeIf { it.isNotEmpty() }
+
+        if (exchange == null && aliasSource == null) {
+            return RowParseResult.Failure(extId, "Either exchange or alias_source must be provided for $ticker")
+        }
+
+        return RowParseResult.Success(
+            ParsedTrade(
+                extId = extId,
+                executedAt = executedAt,
+                ticker = ticker,
+                exchange = exchange,
+                board = board,
+                aliasSource = aliasSource,
+                side = side,
+                quantity = quantity,
+                price = price,
+                currency = currency,
+                fee = fee,
+                feeCurrency = feeCurrency,
+                tax = tax,
+                taxCurrency = taxCurrency,
+                broker = broker,
+                note = note,
+            ),
+        )
+    }
+
+    private fun parseInstant(raw: String?): Instant? {
+        val value = raw?.trim()
+        if (value.isNullOrEmpty()) return null
+        return try {
+            Instant.parse(value)
+        } catch (_: DateTimeParseException) {
+            null
+        }
+    }
+
+    private fun parseDecimal(raw: String?, positive: Boolean): BigDecimal? {
+        val value = raw?.trim()
+        if (value.isNullOrEmpty()) return null
+        val decimal = value.toBigDecimalOrNull() ?: return null
+        return if (positive && decimal <= BigDecimal.ZERO) {
+            null
+        } else {
+            normalizeDecimal(decimal)
+        }
+    }
+
+    private fun parseCurrency(raw: String?, default: String?): String? {
+        val value = raw?.trim()
+        if (value.isNullOrEmpty()) {
+            return default?.uppercase(Locale.ROOT)
+        }
+        val normalized = value.uppercase(Locale.ROOT)
+        return if (CURRENCY_REGEX.matches(normalized)) normalized else null
+    }
+
+    private fun parseLine(line: String): List<String> {
+        val result = mutableListOf<String>()
+        val current = StringBuilder()
+        var inQuotes = false
+        var index = 0
+        while (index < line.length) {
+            val char = line[index]
+            when {
+                char == '"' -> {
+                    if (inQuotes && index + 1 < line.length && line[index + 1] == '"') {
+                        current.append('"')
+                        index += 1
+                    } else {
+                        inQuotes = !inQuotes
+                    }
+                }
+                char == ',' && !inQuotes -> {
+                    result += current.toString()
+                    current.setLength(0)
+                }
+                else -> current.append(char)
+            }
+            index += 1
+        }
+        if (inQuotes) {
+            throw IllegalArgumentException("Unterminated quote in CSV row")
+        }
+        result += current.toString()
+        return result
+    }
+
+    private fun normalizeDecimal(value: BigDecimal): BigDecimal {
+        val stripped = value.stripTrailingZeros()
+        return if (stripped.scale() < 0) stripped.setScale(0) else stripped
+    }
+
+    private fun errorMessage(throwable: Throwable): String {
+        val portfolioError = (throwable as? PortfolioException)?.error
+        return portfolioError?.message ?: throwable.message ?: "Unknown error"
+    }
+
+    private fun failure(error: PortfolioError): DomainResult<Nothing> =
+        DomainResult.failure(PortfolioException(error))
+
+    private sealed interface RowParseResult {
+        data class Success(val value: ParsedTrade) : RowParseResult
+        data class Failure(val extId: String?, val message: String) : RowParseResult
+    }
+
+    data class ImportReport(
+        val inserted: Int = 0,
+        val skippedDuplicates: Int = 0,
+        val failed: List<ImportFailure> = emptyList(),
+    )
+
+    data class ImportFailure(
+        val lineNumber: Int,
+        val extId: String?,
+        val message: String,
+    )
+
+    @ConsistentCopyVisibility
+    data class SoftTradeKey private constructor(
+        val portfolioId: UUID,
+        val instrumentId: Long,
+        val executedAt: Instant,
+        val side: TradeSide,
+        val quantity: BigDecimal,
+        val price: BigDecimal,
+    ) {
+        companion object {
+            fun of(
+                portfolioId: UUID,
+                instrumentId: Long,
+                executedAt: Instant,
+                side: TradeSide,
+                quantity: BigDecimal,
+                price: BigDecimal,
+            ): SoftTradeKey = SoftTradeKey(
+                portfolioId = portfolioId,
+                instrumentId = instrumentId,
+                executedAt = executedAt,
+                side = side,
+                quantity = normalize(quantity),
+                price = normalize(price),
+            )
+
+            private fun normalize(value: BigDecimal): BigDecimal {
+                val stripped = value.stripTrailingZeros()
+                return if (stripped.scale() < 0) stripped.setScale(0) else stripped
+            }
+        }
+    }
+
+    data class ParsedTrade(
+        val extId: String?,
+        val executedAt: Instant,
+        val ticker: String,
+        val exchange: String?,
+        val board: String?,
+        val aliasSource: String?,
+        val side: TradeSide,
+        val quantity: BigDecimal,
+        val price: BigDecimal,
+        val currency: String,
+        val fee: BigDecimal,
+        val feeCurrency: String,
+        val tax: BigDecimal?,
+        val taxCurrency: String?,
+        val broker: String?,
+        val note: String?,
+    )
+
+    interface InstrumentResolver {
+        suspend fun findBySymbol(
+            exchange: String,
+            board: String?,
+            symbol: String,
+        ): DomainResult<InstrumentRef?>
+
+        suspend fun findByAlias(
+            alias: String,
+            source: String,
+        ): DomainResult<InstrumentRef?>
+    }
+
+    interface TradeLookup {
+        suspend fun existsByExternalId(portfolioId: UUID, externalId: String): DomainResult<Boolean>
+        suspend fun existsBySoftKey(key: SoftTradeKey): DomainResult<Boolean>
+    }
+
+    data class InstrumentRef(val instrumentId: Long)
+
+    companion object {
+        private val EXPECTED_HEADER = listOf(
+            "ext_id",
+            "datetime",
+            "ticker",
+            "exchange",
+            "board",
+            "alias_source",
+            "side",
+            "quantity",
+            "price",
+            "currency",
+            "fee",
+            "fee_currency",
+            "tax",
+            "tax_currency",
+            "broker",
+            "note",
+        )
+
+        private val CURRENCY_REGEX = Regex("^[A-Z]{3}$")
+    }
+}

--- a/core/src/main/kotlin/portfolio/service/FxRateService.kt
+++ b/core/src/main/kotlin/portfolio/service/FxRateService.kt
@@ -1,0 +1,133 @@
+package portfolio.service
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.Locale
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import model.FxRate
+import portfolio.errors.DomainResult
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+
+interface FxRateRepository {
+    suspend fun findOnOrBefore(ccy: String, timestamp: Instant): FxRate?
+}
+
+class FxRateService(
+    private val repository: FxRateRepository,
+    private val zoneId: ZoneId = ZoneOffset.UTC,
+) {
+    suspend fun rateOn(date: LocalDate, ccy: String, base: String = RUB): DomainResult<BigDecimal> {
+        val normalizedCurrency = normalizeCurrency(ccy)
+        val normalizedBase = normalizeCurrency(base)
+
+        val validationError = when {
+            !isValidCode(normalizedCurrency) -> PortfolioError.Validation("Unknown currency code: $ccy")
+            !isValidCode(normalizedBase) -> PortfolioError.Validation("Unknown base currency code: $base")
+            else -> null
+        }
+        if (validationError != null) {
+            return failure(validationError)
+        }
+
+        if (normalizedCurrency == normalizedBase) {
+            return DomainResult.success(BigDecimal.ONE)
+        }
+
+        val currencyRate = rateToRub(date, normalizedCurrency).fold(
+            onSuccess = { it },
+            onFailure = { return DomainResult.failure(it) },
+        )
+
+        if (normalizedBase == RUB) {
+            return DomainResult.success(currencyRate.value)
+        }
+
+        val baseRate = rateToRub(date, normalizedBase).fold(
+            onSuccess = { it },
+            onFailure = { return DomainResult.failure(it) },
+        )
+
+        if (baseRate.value.compareTo(BigDecimal.ZERO) == 0) {
+            return failure(
+                PortfolioError.Validation("FX rate for $normalizedBase equals zero and cannot be used for conversion"),
+            )
+        }
+
+        val cross = currencyRate.value.divide(baseRate.value, MathContext.DECIMAL128)
+        return DomainResult.success(normalize(cross))
+    }
+
+    private suspend fun rateToRub(date: LocalDate, currency: String): DomainResult<CachedRate> {
+        if (currency == RUB) {
+            return DomainResult.success(CachedRate(date, BigDecimal.ONE))
+        }
+
+        val cached = readCache(currency, date)
+        if (cached != null) {
+            return DomainResult.success(cached)
+        }
+
+        val rate = repository.findOnOrBefore(currency, endOfDay(date))
+            ?: return failure(PortfolioError.NotFound("No FX rate for $currency on or before $date"))
+
+        val asOf = rate.ts.atZone(zoneId).toLocalDate()
+        val entry = CachedRate(asOf = asOf, value = normalize(rate.rateRub))
+
+        storeInCache(currency, asOf, date, entry)
+        return DomainResult.success(entry)
+    }
+
+    private suspend fun readCache(currency: String, date: LocalDate): CachedRate? = mutex.withLock {
+        cache[currency]?.get(date)
+    }
+
+    private suspend fun storeInCache(currency: String, asOf: LocalDate, requested: LocalDate, entry: CachedRate) {
+        val start = if (asOf <= requested) asOf else requested
+        val end = if (asOf >= requested) asOf else requested
+        val dates = datesBetween(start, end)
+
+        mutex.withLock {
+            val currencyCache = cache.getOrPut(currency) { mutableMapOf() }
+            for (current in dates) {
+                currencyCache[current] = entry
+            }
+        }
+    }
+
+    private fun normalizeCurrency(value: String): String = value.trim().uppercase(Locale.ROOT)
+
+    private fun isValidCode(code: String): Boolean = CURRENCY_REGEX.matches(code)
+
+    private fun endOfDay(date: LocalDate): Instant = date.atTime(LocalTime.MAX).atZone(zoneId).toInstant()
+
+    private fun datesBetween(start: LocalDate, endInclusive: LocalDate): Sequence<LocalDate> {
+        if (start > endInclusive) return emptySequence()
+        return generateSequence(start) { previous ->
+            if (previous >= endInclusive) null else previous.plusDays(1)
+        }
+    }
+
+    private fun normalize(value: BigDecimal): BigDecimal {
+        val stripped = value.stripTrailingZeros()
+        return if (stripped.scale() < 0) stripped.setScale(0) else stripped
+    }
+
+    private fun <T> failure(error: PortfolioError): DomainResult<T> = DomainResult.failure(PortfolioException(error))
+
+    private data class CachedRate(val asOf: LocalDate, val value: BigDecimal)
+
+    private companion object {
+        private const val RUB = "RUB"
+        private val CURRENCY_REGEX = Regex("^[A-Z]{3}$")
+    }
+
+    private val mutex = Mutex()
+    private val cache = mutableMapOf<String, MutableMap<LocalDate, CachedRate>>()
+}

--- a/core/src/main/kotlin/portfolio/service/PortfolioService.kt
+++ b/core/src/main/kotlin/portfolio/service/PortfolioService.kt
@@ -1,0 +1,300 @@
+package portfolio.service
+
+import java.math.BigDecimal
+import java.time.Clock
+import java.math.MathContext
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import portfolio.errors.DomainResult
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+import portfolio.model.Money
+import portfolio.model.PositionView
+import portfolio.model.TradeSide
+import portfolio.model.TradeView
+import portfolio.model.ValuationMethod
+
+class PortfolioService(
+    private val storage: Storage,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    suspend fun applyTrade(trade: TradeView, method: ValuationMethod): DomainResult<Unit> {
+        val validationError = validateTrade(trade)
+        if (validationError != null) {
+            return failure(validationError)
+        }
+
+        val totalFees = totalFees(trade)
+        val quantity = trade.quantity
+
+        val mutex = portfolioLocks.computeIfAbsent(trade.portfolioId) { Mutex() }
+        val result = mutex.withLock {
+            storage.transaction {
+                processTrade(this, trade, method, quantity, totalFees)
+            }
+        }
+
+        return result.map { Unit }
+    }
+
+    suspend fun listPositions(
+        portfolioId: UUID,
+        on: LocalDate,
+        pricingService: PricingService,
+        fxRateService: FxRateService,
+    ): DomainResult<List<PositionView>> {
+        val storedResult = storage.listPositions(portfolioId)
+        if (storedResult.isFailure) {
+            return DomainResult.failure(storedResult.exceptionOrNull()!!)
+        }
+
+        val storedPositions = storedResult
+            .getOrDefault(emptyList())
+            .filter { it.portfolioId == portfolioId }
+        if (storedPositions.isEmpty()) {
+            return DomainResult.success(emptyList())
+        }
+
+        val views = mutableListOf<PositionView>()
+        for (position in storedPositions) {
+            if (position.quantity <= BigDecimal.ZERO) {
+                continue
+            }
+
+            val priceResult = pricingService.closeOrLast(position.instrumentId, on)
+            if (priceResult.isFailure) {
+                return DomainResult.failure(priceResult.exceptionOrNull()!!)
+            }
+            val price = priceResult.getOrThrow()
+            val valuation = price * position.quantity
+
+            val averageCost = position.averagePrice?.let { average ->
+                val converted = convertToCurrency(
+                    average,
+                    on,
+                    valuation.currency,
+                    fxRateService,
+                )
+                if (converted.isFailure) {
+                    return DomainResult.failure(converted.exceptionOrNull()!!)
+                }
+                converted.getOrThrow()
+            }
+
+            val unrealized = if (averageCost != null) {
+                val costBasis = averageCost * position.quantity
+                valuation - costBasis
+            } else {
+                zero(valuation.currency)
+            }
+
+            views += PositionView(
+                instrumentId = position.instrumentId,
+                instrumentName = position.instrumentName,
+                quantity = position.quantity,
+                valuation = valuation,
+                averageCost = averageCost,
+                valuationMethod = position.valuationMethod,
+                unrealizedPnl = unrealized,
+            )
+        }
+
+        return DomainResult.success(views)
+    }
+
+    private fun validateTrade(trade: TradeView): PortfolioError? {
+        if (trade.quantity <= BigDecimal.ZERO) {
+            return PortfolioError.Validation("Trade quantity must be positive")
+        }
+        if (trade.fee.currency != trade.price.currency) {
+            return PortfolioError.Validation("Fee currency must match trade currency")
+        }
+        if (trade.fee.amount < BigDecimal.ZERO) {
+            return PortfolioError.Validation("Fee amount cannot be negative")
+        }
+        val tax = trade.tax
+        if (tax != null) {
+            if (tax.currency != trade.price.currency) {
+                return PortfolioError.Validation("Tax currency must match trade currency")
+            }
+            if (tax.amount < BigDecimal.ZERO) {
+                return PortfolioError.Validation("Tax amount cannot be negative")
+            }
+        }
+        if (trade.notional.currency != trade.price.currency) {
+            return PortfolioError.Validation("Notional currency must match trade currency")
+        }
+        return null
+    }
+
+    private fun totalFees(trade: TradeView): Money {
+        val tax = trade.tax ?: zero(trade.price.currency)
+        return trade.fee + tax
+    }
+
+    private suspend fun processTrade(
+        transaction: Storage.Transaction,
+        trade: TradeView,
+        method: ValuationMethod,
+        quantity: BigDecimal,
+        fees: Money,
+    ): DomainResult<Money?> {
+        val loaded = transaction.loadPosition(trade.portfolioId, trade.instrumentId, method)
+        if (loaded.isFailure) {
+            return DomainResult.failure(loaded.exceptionOrNull()!!)
+        }
+        val stored = loaded.getOrNull()
+        val currentPosition = if (stored == null) {
+            PositionCalc.Position.empty(trade.price.currency)
+        } else {
+            val storedCurrency = stored.position.costBasis.currency
+            if (storedCurrency != trade.price.currency) {
+                return failure(
+                    PortfolioError.Validation(
+                        "Trade currency ${trade.price.currency} does not match position currency $storedCurrency",
+                    ),
+                )
+            }
+            stored.position
+        }
+
+        val calculator = calculators.getValue(method)
+        val outcome = try {
+            when (trade.side) {
+                TradeSide.BUY -> calculator.applyBuy(currentPosition, quantity, trade.price, fees)
+                TradeSide.SELL -> calculator.applySell(currentPosition, quantity, trade.price, fees)
+            }
+        } catch (iae: IllegalArgumentException) {
+            return failure(PortfolioError.Validation(iae.message ?: "Invalid trade input"))
+        }
+
+        val storedPosition = StoredPosition(
+            portfolioId = trade.portfolioId,
+            instrumentId = trade.instrumentId,
+            valuationMethod = method,
+            position = outcome.position,
+            updatedAt = clock.instant(),
+        )
+
+        val saveResult = transaction.savePosition(storedPosition)
+        if (saveResult.isFailure) {
+            return DomainResult.failure(saveResult.exceptionOrNull()!!)
+        }
+
+        val recordResult = transaction.recordTrade(
+                StoredTrade(
+                    tradeId = trade.tradeId,
+                    portfolioId = trade.portfolioId,
+                    instrumentId = trade.instrumentId,
+                    tradeDate = trade.tradeDate,
+                    executedAt = trade.executedAt,
+                    side = trade.side,
+                    quantity = quantity,
+                    price = trade.price,
+                    fee = trade.fee,
+                    tax = trade.tax,
+                    notional = trade.notional,
+                    valuationMethod = method,
+                    realizedPnl = if (trade.side == TradeSide.SELL) outcome.realizedPnl else null,
+                    broker = trade.broker,
+                    note = trade.note,
+                    externalId = trade.externalId,
+                ),
+        )
+        if (recordResult.isFailure) {
+            return DomainResult.failure(recordResult.exceptionOrNull()!!)
+        }
+
+        return DomainResult.success(if (trade.side == TradeSide.SELL) outcome.realizedPnl else null)
+    }
+
+    private fun failure(error: PortfolioError): DomainResult<Nothing> =
+        DomainResult.failure(PortfolioException(error))
+
+    private suspend fun convertToCurrency(
+        money: Money,
+        on: LocalDate,
+        targetCurrency: String,
+        fxRateService: FxRateService,
+    ): DomainResult<Money> {
+        if (money.currency == targetCurrency) {
+            return DomainResult.success(money)
+        }
+
+        val rateResult = fxRateService.rateOn(on, money.currency, targetCurrency)
+        if (rateResult.isFailure) {
+            return DomainResult.failure(rateResult.exceptionOrNull()!!)
+        }
+
+        val rate = rateResult.getOrThrow()
+        val convertedAmount = money.amount.multiply(rate, MathContext.DECIMAL128)
+        return DomainResult.success(Money.of(convertedAmount, targetCurrency))
+    }
+
+    interface Storage {
+        suspend fun <T> transaction(block: suspend Transaction.() -> DomainResult<T>): DomainResult<T>
+
+        suspend fun listPositions(portfolioId: UUID): DomainResult<List<PositionSummary>>
+
+        interface Transaction {
+            suspend fun loadPosition(
+                portfolioId: UUID,
+                instrumentId: Long,
+                method: ValuationMethod,
+            ): DomainResult<StoredPosition?>
+
+            suspend fun savePosition(position: StoredPosition): DomainResult<Unit>
+
+            suspend fun recordTrade(trade: StoredTrade): DomainResult<Unit>
+        }
+    }
+
+    data class StoredPosition(
+        val portfolioId: UUID,
+        val instrumentId: Long,
+        val valuationMethod: ValuationMethod,
+        val position: PositionCalc.Position,
+        val updatedAt: Instant,
+    )
+
+    data class StoredTrade(
+        val tradeId: UUID,
+        val portfolioId: UUID,
+        val instrumentId: Long,
+        val tradeDate: java.time.LocalDate,
+        val executedAt: Instant,
+        val side: TradeSide,
+        val quantity: BigDecimal,
+        val price: Money,
+        val fee: Money,
+        val tax: Money?,
+        val notional: Money,
+        val valuationMethod: ValuationMethod,
+        val realizedPnl: Money?,
+        val broker: String?,
+        val note: String?,
+        val externalId: String?,
+    )
+
+    data class PositionSummary(
+        val portfolioId: UUID,
+        val instrumentId: Long,
+        val instrumentName: String,
+        val quantity: BigDecimal,
+        val averagePrice: Money?,
+        val valuationMethod: ValuationMethod,
+    )
+
+    private fun zero(currency: String): Money = Money.of(BigDecimal.ZERO, currency)
+
+    private val calculators: Map<ValuationMethod, PositionCalc> = mapOf(
+        ValuationMethod.AVERAGE to PositionCalc.AverageCostCalc(),
+        ValuationMethod.FIFO to PositionCalc.FifoCalc(),
+    )
+
+    private val portfolioLocks = ConcurrentHashMap<UUID, Mutex>()
+}

--- a/core/src/main/kotlin/portfolio/service/PositionCalc.kt
+++ b/core/src/main/kotlin/portfolio/service/PositionCalc.kt
@@ -1,0 +1,202 @@
+package portfolio.service
+
+import java.math.BigDecimal
+import java.math.MathContext
+import portfolio.model.Money
+
+interface PositionCalc {
+    data class Lot(
+        val quantity: BigDecimal,
+        val costBasis: Money
+    ) {
+        init {
+            require(quantity >= BigDecimal.ZERO) { "Lot quantity cannot be negative" }
+        }
+
+        val averagePrice: Money?
+            get() = if (quantity.compareTo(BigDecimal.ZERO) == 0) {
+                null
+            } else {
+                Money.of(costBasis.amount.divide(quantity, MATH_CONTEXT), costBasis.currency)
+            }
+    }
+
+    data class Position(
+        val quantity: BigDecimal,
+        val costBasis: Money,
+        val lots: List<Lot> = emptyList()
+    ) {
+        init {
+            require(quantity >= BigDecimal.ZERO) { "Position quantity cannot be negative" }
+            require(lots.all { it.costBasis.currency == costBasis.currency }) {
+                "Lot currency must match position currency"
+            }
+        }
+
+        val currency: String = costBasis.currency
+
+        val averagePrice: Money?
+            get() = if (quantity.compareTo(BigDecimal.ZERO) == 0) {
+                null
+            } else {
+                Money.of(costBasis.amount.divide(quantity, MATH_CONTEXT), currency)
+            }
+
+        companion object {
+            fun empty(currency: String): Position = Position(
+                BigDecimal.ZERO,
+                Money.of(BigDecimal.ZERO, currency),
+                emptyList()
+            )
+        }
+    }
+
+    data class Result(
+        val position: Position,
+        val realizedPnl: Money
+    )
+
+    fun applyBuy(
+        position: Position,
+        quantity: BigDecimal,
+        price: Money,
+        fees: Money = Money.of(BigDecimal.ZERO, price.currency)
+    ): Result
+
+    fun applySell(
+        position: Position,
+        quantity: BigDecimal,
+        price: Money,
+        fees: Money = Money.of(BigDecimal.ZERO, price.currency)
+    ): Result
+
+    class AverageCostCalc : PositionCalc {
+        override fun applyBuy(
+            position: Position,
+            quantity: BigDecimal,
+            price: Money,
+            fees: Money
+        ): Result {
+            validateInputs(position, quantity, price, fees)
+            require(quantity > BigDecimal.ZERO) { "Buy quantity must be positive" }
+
+            val totalCost = price * quantity + fees
+            val newQuantity = position.quantity + quantity
+            val newCostBasis = position.costBasis + totalCost
+            val updatedPosition = Position(newQuantity, newCostBasis)
+            return Result(updatedPosition, zero(price.currency))
+        }
+
+        override fun applySell(
+            position: Position,
+            quantity: BigDecimal,
+            price: Money,
+            fees: Money
+        ): Result {
+            validateInputs(position, quantity, price, fees)
+            require(quantity > BigDecimal.ZERO) { "Sell quantity must be positive" }
+            require(position.quantity >= quantity) { "Cannot sell more than current quantity" }
+
+            val proceeds = price * quantity
+            val costSoldAmount = position.costBasis.amount.multiply(quantity).divide(position.quantity, MATH_CONTEXT)
+            val costSold = Money.of(costSoldAmount, price.currency)
+            val newQuantity = position.quantity - quantity
+            val newCostBasis = if (newQuantity.compareTo(BigDecimal.ZERO) == 0) {
+                zero(price.currency)
+            } else {
+                position.costBasis - costSold
+            }
+            val realized = proceeds - costSold - fees
+            val updatedPosition = Position(newQuantity, newCostBasis)
+            return Result(updatedPosition, realized)
+        }
+    }
+
+    class FifoCalc : PositionCalc {
+        override fun applyBuy(
+            position: Position,
+            quantity: BigDecimal,
+            price: Money,
+            fees: Money
+        ): Result {
+            validateInputs(position, quantity, price, fees)
+            require(quantity > BigDecimal.ZERO) { "Buy quantity must be positive" }
+
+            val totalCost = price * quantity + fees
+            val newLot = Lot(quantity, totalCost)
+            val newQuantity = position.quantity + quantity
+            val newCostBasis = position.costBasis + totalCost
+            val updatedLots = position.lots + newLot
+            val updatedPosition = Position(newQuantity, newCostBasis, updatedLots)
+            return Result(updatedPosition, zero(price.currency))
+        }
+
+        override fun applySell(
+            position: Position,
+            quantity: BigDecimal,
+            price: Money,
+            fees: Money
+        ): Result {
+            validateInputs(position, quantity, price, fees)
+            require(quantity > BigDecimal.ZERO) { "Sell quantity must be positive" }
+            require(position.quantity >= quantity) { "Cannot sell more than current quantity" }
+
+            var remaining = quantity
+            var costSoldAmount = BigDecimal.ZERO
+            val updatedLots = mutableListOf<Lot>()
+
+            for (lot in position.lots) {
+                if (remaining <= BigDecimal.ZERO) {
+                    updatedLots += lot
+                    continue
+                }
+                if (lot.quantity <= BigDecimal.ZERO) {
+                    continue
+                }
+
+                val lotQuantityToClose = if (lot.quantity <= remaining) lot.quantity else remaining
+                val lotShare = lot.costBasis.amount.multiply(lotQuantityToClose).divide(lot.quantity, MATH_CONTEXT)
+                costSoldAmount = costSoldAmount + lotShare
+                val remainingQuantityInLot = lot.quantity - lotQuantityToClose
+                if (remainingQuantityInLot > BigDecimal.ZERO) {
+                    val remainingCost = lot.costBasis.amount - lotShare
+                    val updatedLot = Lot(
+                        remainingQuantityInLot,
+                        Money.of(remainingCost, lot.costBasis.currency)
+                    )
+                    updatedLots += updatedLot
+                }
+                remaining -= lotQuantityToClose
+            }
+
+            require(remaining.compareTo(BigDecimal.ZERO) == 0) { "Insufficient lots to close quantity" }
+
+            val costSold = Money.of(costSoldAmount, price.currency)
+            val proceeds = price * quantity
+            val realized = proceeds - costSold - fees
+            val newQuantity = position.quantity - quantity
+            val newCostBasis = if (newQuantity.compareTo(BigDecimal.ZERO) == 0) {
+                zero(price.currency)
+            } else {
+                Money.of(position.costBasis.amount - costSoldAmount, price.currency)
+            }
+            val lotsAfterSale = if (newQuantity.compareTo(BigDecimal.ZERO) == 0) emptyList() else updatedLots
+            val updatedPosition = Position(newQuantity, newCostBasis, lotsAfterSale)
+            return Result(updatedPosition, realized)
+        }
+    }
+
+    companion object {
+        private val MATH_CONTEXT: MathContext = MathContext.DECIMAL128
+
+        private fun validateInputs(position: Position, quantity: BigDecimal, price: Money, fees: Money) {
+            require(quantity >= BigDecimal.ZERO) { "Quantity cannot be negative" }
+            require(fees.currency == price.currency) { "Fee currency must match price currency" }
+            require(fees.amount >= BigDecimal.ZERO) { "Fees cannot be negative" }
+            require(price.currency == position.costBasis.currency) { "Currency mismatch with position" }
+            require(fees.currency == position.costBasis.currency) { "Currency mismatch with position fees" }
+        }
+
+        private fun zero(currency: String): Money = Money.of(BigDecimal.ZERO, currency)
+    }
+}

--- a/core/src/main/kotlin/portfolio/service/PricingService.kt
+++ b/core/src/main/kotlin/portfolio/service/PricingService.kt
@@ -1,0 +1,123 @@
+package portfolio.service
+
+import java.time.LocalDate
+import java.util.Locale
+import portfolio.errors.DomainResult
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+import portfolio.model.Money
+
+class PricingService(
+    private val moexProvider: MoexPriceProvider,
+    private val coingeckoProvider: CoingeckoPriceProvider,
+    private val fxRateService: FxRateService,
+    private val config: Config = Config(),
+) {
+    suspend fun closeOrLast(instrumentId: Long, on: LocalDate): DomainResult<Money> {
+        for (priceType in priceTypes()) {
+            for (provider in providers) {
+                when (val outcome = fetch(provider, priceType, instrumentId, on)) {
+                    is FetchOutcome.Success -> return DomainResult.success(outcome.value)
+                    is FetchOutcome.Failure -> return DomainResult.failure(outcome.cause)
+                    FetchOutcome.Missing -> continue
+                }
+            }
+        }
+
+        return failure(
+            PortfolioError.NotFound("No price available for instrument $instrumentId on $on"),
+        )
+    }
+
+    private fun priceTypes(): List<PriceType> {
+        val primary = if (config.preferClosePrice) PriceType.CLOSE else PriceType.LAST
+        if (!config.fallbackToLast) return listOf(primary)
+
+        val secondary = if (primary == PriceType.CLOSE) PriceType.LAST else PriceType.CLOSE
+        return listOf(primary, secondary)
+    }
+
+    private suspend fun fetch(
+        provider: PriceProvider,
+        type: PriceType,
+        instrumentId: Long,
+        on: LocalDate,
+    ): FetchOutcome {
+        val rawResult = when (type) {
+            PriceType.CLOSE -> provider.closePrice(instrumentId, on)
+            PriceType.LAST -> provider.lastPrice(instrumentId, on)
+        }
+
+        rawResult.exceptionOrNull()?.let { throwable ->
+            val domainError = (throwable as? PortfolioException)?.error
+            return if (domainError is PortfolioError.NotFound) {
+                FetchOutcome.Missing
+            } else {
+                FetchOutcome.Failure(throwable)
+            }
+        }
+
+        val money = rawResult.getOrNull() ?: return FetchOutcome.Missing
+        val converted = convertToBase(money, on)
+        return if (converted.isSuccess) {
+            FetchOutcome.Success(converted.getOrThrow())
+        } else {
+            FetchOutcome.Failure(converted.exceptionOrNull()!!)
+        }
+    }
+
+    private suspend fun convertToBase(price: Money, on: LocalDate): DomainResult<Money> {
+        val baseCurrency = config.baseCurrency
+        if (price.currency == baseCurrency) {
+            return DomainResult.success(price)
+        }
+
+        val rateResult = fxRateService.rateOn(on, price.currency, baseCurrency)
+        return rateResult.fold(
+            onSuccess = { rate ->
+                val amountInBase = price.amount.multiply(rate)
+                DomainResult.success(Money.of(amountInBase, baseCurrency))
+            },
+            onFailure = { throwable -> DomainResult.failure(throwable) },
+        )
+    }
+
+    private fun <T> failure(error: PortfolioError): DomainResult<T> =
+        DomainResult.failure(PortfolioException(error))
+
+    class Config(
+        val preferClosePrice: Boolean = true,
+        val fallbackToLast: Boolean = true,
+        baseCurrency: String = DEFAULT_BASE_CURRENCY,
+    ) {
+        val baseCurrency: String = baseCurrency.trim().uppercase(Locale.ROOT)
+
+        init {
+            require(CURRENCY_REGEX.matches(this.baseCurrency)) { "Base currency must be a valid ISO 4217 code" }
+        }
+
+        companion object {
+            const val DEFAULT_BASE_CURRENCY: String = "RUB"
+            private val CURRENCY_REGEX = Regex("^[A-Z]{3}$")
+        }
+    }
+
+    private enum class PriceType { CLOSE, LAST }
+
+    private sealed interface FetchOutcome {
+        data class Success(val value: Money) : FetchOutcome
+        data class Failure(val cause: Throwable) : FetchOutcome
+        object Missing : FetchOutcome
+    }
+
+    private val providers: List<PriceProvider> = listOf(moexProvider, coingeckoProvider)
+}
+
+interface PriceProvider {
+    suspend fun closePrice(instrumentId: Long, on: LocalDate): DomainResult<Money?>
+    suspend fun lastPrice(instrumentId: Long, on: LocalDate): DomainResult<Money?>
+}
+
+interface MoexPriceProvider : PriceProvider
+
+interface CoingeckoPriceProvider : PriceProvider

--- a/core/src/main/kotlin/portfolio/service/ValuationService.kt
+++ b/core/src/main/kotlin/portfolio/service/ValuationService.kt
@@ -1,0 +1,169 @@
+package portfolio.service
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.time.LocalDate
+import java.util.UUID
+import portfolio.errors.DomainResult
+import portfolio.model.Money
+import portfolio.model.ValuationDaily
+
+class ValuationService(
+    private val storage: Storage,
+    private val pricingService: PricingService,
+    private val fxRateService: FxRateService,
+    private val baseCurrency: String = BASE_CURRENCY,
+) {
+    suspend fun revaluePortfolioOn(portfolioId: UUID, date: LocalDate): DomainResult<ValuationDaily> {
+        val positionsResult = storage.listPositions(portfolioId)
+        if (positionsResult.isFailure) {
+            return DomainResult.failure(positionsResult.exceptionOrNull()!!)
+        }
+        val positions = positionsResult.getOrDefault(emptyList())
+
+        var valuationCurrency = baseCurrency
+        var totalValue = BigDecimal.ZERO
+        var totalCost = BigDecimal.ZERO
+
+        for (position in positions) {
+            if (position.quantity <= BigDecimal.ZERO) continue
+
+            val priceResult = pricingService.closeOrLast(position.instrumentId, date)
+            if (priceResult.isFailure) {
+                return DomainResult.failure(priceResult.exceptionOrNull()!!)
+            }
+            val price = priceResult.getOrThrow()
+            val valuation = price * position.quantity
+            valuationCurrency = valuation.currency
+            totalValue = totalValue + valuation.amount
+
+            val average = position.averagePrice ?: continue
+            val convertedAverageResult = convertToCurrency(
+                average,
+                date,
+                valuation.currency,
+            )
+            if (convertedAverageResult.isFailure) {
+                return DomainResult.failure(convertedAverageResult.exceptionOrNull()!!)
+            }
+            val convertedAverage = convertedAverageResult.getOrThrow()
+            val cost = convertedAverage * position.quantity
+            totalCost = totalCost + cost.amount
+        }
+
+        val totalValueMoney = Money.of(totalValue, valuationCurrency)
+        val totalCostMoney = Money.of(totalCost, valuationCurrency)
+
+        val previousResult = storage.latestValuationBefore(portfolioId, date)
+        if (previousResult.isFailure) {
+            return DomainResult.failure(previousResult.exceptionOrNull()!!)
+        }
+        val previous = previousResult.getOrNull()
+
+        val previousValueAmount = previous?.valueRub
+        val totalValueAmount = totalValueMoney.amount
+        val totalCostAmount = totalCostMoney.amount
+
+        val pnlTotalAmount = totalValueAmount - totalCostAmount
+        val baseForDay = previousValueAmount ?: totalCostAmount
+        val pnlDayAmount = totalValueAmount - baseForDay
+
+        val previousPeak = previous?.let { computePeakValue(it) }
+        val peakValue = when {
+            previousPeak == null -> totalValueAmount
+            previousPeak < totalValueAmount -> totalValueAmount
+            else -> previousPeak
+        }
+        val drawdownAmount = if (peakValue.compareTo(BigDecimal.ZERO) == 0) {
+            BigDecimal.ZERO
+        } else {
+            totalValueAmount.divide(peakValue, MATH_CONTEXT).subtract(BigDecimal.ONE)
+        }
+
+        val record = Storage.ValuationRecord(
+            portfolioId = portfolioId,
+            date = date,
+            valueRub = totalValueAmount,
+            pnlDay = pnlDayAmount,
+            pnlTotal = pnlTotalAmount,
+            drawdown = normalize(drawdownAmount),
+        )
+
+        val persistedResult = storage.upsertValuation(record)
+        if (persistedResult.isFailure) {
+            return DomainResult.failure(persistedResult.exceptionOrNull()!!)
+        }
+        val persisted = persistedResult.getOrThrow()
+
+        val valueMoney = Money.of(persisted.valueRub, valuationCurrency)
+        val pnlDayMoney = Money.of(persisted.pnlDay, valuationCurrency)
+        val pnlTotalMoney = Money.of(persisted.pnlTotal, valuationCurrency)
+
+        return DomainResult.success(
+            ValuationDaily(
+                date = persisted.date,
+                valueRub = valueMoney,
+                pnlDay = pnlDayMoney,
+                pnlTotal = pnlTotalMoney,
+                drawdown = normalize(persisted.drawdown),
+            ),
+        )
+    }
+
+    private suspend fun convertToCurrency(
+        money: Money,
+        date: LocalDate,
+        targetCurrency: String,
+    ): DomainResult<Money> {
+        if (money.currency == targetCurrency) {
+            return DomainResult.success(money)
+        }
+        val rateResult = fxRateService.rateOn(date, money.currency, targetCurrency)
+        if (rateResult.isFailure) {
+            return DomainResult.failure(rateResult.exceptionOrNull()!!)
+        }
+        val rate = rateResult.getOrThrow()
+        val amount = money.amount.multiply(rate, MATH_CONTEXT)
+        return DomainResult.success(Money.of(amount, targetCurrency))
+    }
+
+    private fun computePeakValue(previous: Storage.ValuationRecord): BigDecimal {
+        val denominator = BigDecimal.ONE + previous.drawdown
+        return if (denominator.compareTo(BigDecimal.ZERO) == 0) {
+            previous.valueRub
+        } else {
+            previous.valueRub.divide(denominator, MATH_CONTEXT)
+        }
+    }
+
+    private fun normalize(value: BigDecimal): BigDecimal {
+        val stripped = value.stripTrailingZeros()
+        return if (stripped.scale() < 0) stripped.setScale(0) else stripped
+    }
+
+    interface Storage {
+        suspend fun listPositions(portfolioId: UUID): DomainResult<List<PositionSnapshot>>
+        suspend fun latestValuationBefore(portfolioId: UUID, date: LocalDate): DomainResult<ValuationRecord?>
+        suspend fun upsertValuation(record: ValuationRecord): DomainResult<ValuationRecord>
+
+        data class PositionSnapshot(
+            val instrumentId: Long,
+            val quantity: BigDecimal,
+            val averagePrice: Money?,
+        )
+
+        data class ValuationRecord(
+            val portfolioId: UUID,
+            val date: LocalDate,
+            val valueRub: BigDecimal,
+            val pnlDay: BigDecimal,
+            val pnlTotal: BigDecimal,
+            val drawdown: BigDecimal,
+        )
+    }
+
+    private companion object {
+        private val MATH_CONTEXT: MathContext = MathContext.DECIMAL128
+        private const val BASE_CURRENCY = "RUB"
+    }
+}

--- a/core/src/test/kotlin/portfolio/CsvImportServiceTest.kt
+++ b/core/src/test/kotlin/portfolio/CsvImportServiceTest.kt
@@ -1,0 +1,247 @@
+package portfolio
+
+import java.io.Reader
+import java.io.StringReader
+import java.math.BigDecimal
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.Instant
+import java.util.Locale
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import portfolio.errors.DomainResult
+import portfolio.model.ValuationMethod
+import portfolio.service.CsvImportService
+import portfolio.service.PortfolioService
+
+class CsvImportServiceTest {
+    private val portfolioId: UUID = UUID.randomUUID()
+
+    @Test
+    fun `imports sample csv file`() = runBlocking {
+        val resolver = FakeInstrumentResolver().apply {
+            registerSymbol("MOEX", "TQBR", "SBER", instrumentId = 1L)
+            registerAlias("BTCUSDT", "COINGECKO", instrumentId = 2L)
+        }
+        val lookup = FakeTradeLookup()
+        val storage = InMemoryStorage()
+        val portfolioService = PortfolioService(storage)
+        val service = CsvImportService(resolver, lookup, portfolioService)
+
+        openSampleCsv().use { reader ->
+            val result = service.import(portfolioId, reader, ValuationMethod.AVERAGE)
+            assertTrue(result.isSuccess)
+            val report = result.getOrThrow()
+            assertEquals(3, report.inserted)
+            assertEquals(0, report.skippedDuplicates)
+            assertTrue(report.failed.isEmpty())
+        }
+
+        assertEquals(3, storage.recordedTrades.size)
+        val aliasTrade = storage.recordedTrades.last()
+        assertEquals(2L, aliasTrade.instrumentId)
+        assertEquals("CryptoDesk", aliasTrade.broker)
+        assertEquals("Crypto accumulation", aliasTrade.note)
+    }
+
+    @Test
+    fun `skips duplicates by ext id and soft key`() = runBlocking {
+        val resolver = FakeInstrumentResolver().apply {
+            registerSymbol("MOEX", "TQBR", "SBER", instrumentId = 10L)
+        }
+        val duplicateKey = CsvImportService.SoftTradeKey.of(
+            portfolioId = portfolioId,
+            instrumentId = 10L,
+            executedAt = Instant.parse("2024-03-16T10:00:00Z"),
+            side = portfolio.model.TradeSide.BUY,
+            quantity = BigDecimal("3"),
+            price = BigDecimal("120"),
+        )
+        val lookup = FakeTradeLookup(
+            existingExtIds = mutableSetOf("db-trade"),
+            existingSoftKeys = mutableSetOf(duplicateKey),
+        )
+        val storage = InMemoryStorage()
+        val service = CsvImportService(resolver, lookup, PortfolioService(storage))
+
+        val csv = """
+            ext_id,datetime,ticker,exchange,board,alias_source,side,quantity,price,currency,fee,fee_currency,tax,tax_currency,broker,note
+            db-trade,2024-03-15T09:00:00Z,SBER,MOEX,TQBR,,BUY,1,100,RUB,0,RUB,0,RUB,,
+            new-ext,2024-03-16T10:00:00Z,SBER,MOEX,TQBR,,BUY,2,150,RUB,0,RUB,0,RUB,,
+            new-ext,2024-03-16T10:00:00Z,SBER,MOEX,TQBR,,BUY,2,150,RUB,0,RUB,0,RUB,,
+            ,2024-03-16T10:00:00Z,SBER,MOEX,TQBR,,BUY,2,150,RUB,0,RUB,0,RUB,,
+            ,2024-03-16T10:00:00Z,SBER,MOEX,TQBR,,BUY,3,120,RUB,0,RUB,0,RUB,,
+        """.trimIndent()
+
+        val result = service.import(portfolioId, StringReader(csv), ValuationMethod.AVERAGE)
+        assertTrue(result.isSuccess)
+        val report = result.getOrThrow()
+        assertEquals(1, report.inserted)
+        assertEquals(4, report.skippedDuplicates)
+        assertTrue(report.failed.isEmpty())
+        assertEquals(1, storage.recordedTrades.size)
+    }
+
+    @Test
+    fun `records failures but continues import`() = runBlocking {
+        val resolver = FakeInstrumentResolver().apply {
+            registerSymbol("MOEX", "TQBR", "SBER", instrumentId = 5L)
+        }
+        val lookup = FakeTradeLookup()
+        val storage = InMemoryStorage()
+        val service = CsvImportService(resolver, lookup, PortfolioService(storage))
+
+        val csv = """
+            ext_id,datetime,ticker,exchange,board,alias_source,side,quantity,price,currency,fee,fee_currency,tax,tax_currency,broker,note
+            buy-1,2024-03-18T10:00:00Z,SBER,MOEX,TQBR,,BUY,5,100,RUB,0,RUB,0,RUB,,
+            sell-too-much,2024-03-19T10:00:00Z,SBER,MOEX,TQBR,,SELL,10,110,RUB,0,RUB,0,RUB,,
+            ,2024-03-20T10:00:00Z,SBER,MOEX,TQBR,,SELL,5,120,RUB,0,RUB,0,RUB,,
+        """.trimIndent()
+
+        val result = service.import(portfolioId, StringReader(csv), ValuationMethod.AVERAGE)
+        assertTrue(result.isSuccess)
+        val report = result.getOrThrow()
+        assertEquals(2, report.inserted)
+        assertEquals(0, report.skippedDuplicates)
+        assertEquals(1, report.failed.size)
+        val failure = report.failed.single()
+        assertEquals("sell-too-much", failure.extId)
+        assertTrue(failure.message.contains("Cannot sell more than current quantity"))
+        assertEquals(2, storage.recordedTrades.size)
+    }
+
+    @Test
+    fun `resolves instruments through aliases`() = runBlocking {
+        val resolver = FakeInstrumentResolver().apply {
+            registerAlias("SBERP", "NEWS", instrumentId = 42L)
+        }
+        val lookup = FakeTradeLookup()
+        val storage = InMemoryStorage()
+        val service = CsvImportService(resolver, lookup, PortfolioService(storage))
+
+        val csv = """
+            ext_id,datetime,ticker,exchange,board,alias_source,side,quantity,price,currency,fee,fee_currency,tax,tax_currency,broker,note
+            alias-1,2024-03-21T08:30:00Z,SBERP,,,NEWS,BUY,1,200,RUB,0,RUB,0,RUB,,Alias import
+            alias-2,2024-03-22T08:30:00Z,UNKNOWN,,,,BUY,1,200,RUB,0,RUB,0,RUB,,Missing mapping
+        """.trimIndent()
+
+        val result = service.import(portfolioId, StringReader(csv), ValuationMethod.FIFO)
+        assertTrue(result.isSuccess)
+        val report = result.getOrThrow()
+        assertEquals(1, report.inserted)
+        assertEquals(0, report.skippedDuplicates)
+        assertEquals(1, report.failed.size)
+        val failureMessage = report.failed.first().message
+        assertTrue(
+            failureMessage.contains("Either exchange or alias_source"),
+            "Unexpected failure message: $failureMessage",
+        )
+
+        assertEquals(1, storage.recordedTrades.size)
+        val recorded = storage.recordedTrades.first()
+        assertEquals(42L, recorded.instrumentId)
+        assertEquals("Alias import", recorded.note)
+    }
+
+    private class InMemoryStorage : PortfolioService.Storage {
+        private val positions = mutableMapOf<Triple<UUID, Long, ValuationMethod>, PortfolioService.StoredPosition>()
+        val recordedTrades = mutableListOf<PortfolioService.StoredTrade>()
+
+        override suspend fun <T> transaction(
+            block: suspend PortfolioService.Storage.Transaction.() -> DomainResult<T>,
+        ): DomainResult<T> {
+            val tx = object : PortfolioService.Storage.Transaction {
+                override suspend fun loadPosition(
+                    portfolioId: UUID,
+                    instrumentId: Long,
+                    method: ValuationMethod,
+                ): DomainResult<PortfolioService.StoredPosition?> {
+                    val key = Triple(portfolioId, instrumentId, method)
+                    return DomainResult.success(positions[key])
+                }
+
+                override suspend fun savePosition(
+                    position: PortfolioService.StoredPosition,
+                ): DomainResult<Unit> {
+                    val key = Triple(position.portfolioId, position.instrumentId, position.valuationMethod)
+                    positions[key] = position
+                    return DomainResult.success(Unit)
+                }
+
+                override suspend fun recordTrade(
+                    trade: PortfolioService.StoredTrade,
+                ): DomainResult<Unit> {
+                    recordedTrades += trade
+                    return DomainResult.success(Unit)
+                }
+            }
+
+            return tx.block()
+        }
+
+        override suspend fun listPositions(portfolioId: UUID): DomainResult<List<PortfolioService.PositionSummary>> {
+            return DomainResult.success(emptyList())
+        }
+    }
+
+    private class FakeInstrumentResolver : CsvImportService.InstrumentResolver {
+        private val bySymbol = mutableMapOf<SymbolKey, Long>()
+        private val byAlias = mutableMapOf<AliasKey, Long>()
+
+        override suspend fun findBySymbol(
+            exchange: String,
+            board: String?,
+            symbol: String,
+        ): DomainResult<CsvImportService.InstrumentRef?> {
+            val key = SymbolKey(exchange.uppercase(Locale.ROOT), board?.uppercase(Locale.ROOT), symbol.uppercase(Locale.ROOT))
+            val instrumentId = bySymbol[key] ?: return DomainResult.success(null)
+            return DomainResult.success(CsvImportService.InstrumentRef(instrumentId))
+        }
+
+        override suspend fun findByAlias(
+            alias: String,
+            source: String,
+        ): DomainResult<CsvImportService.InstrumentRef?> {
+            val key = AliasKey(alias.uppercase(Locale.ROOT), source.uppercase(Locale.ROOT))
+            val instrumentId = byAlias[key] ?: return DomainResult.success(null)
+            return DomainResult.success(CsvImportService.InstrumentRef(instrumentId))
+        }
+
+        fun registerSymbol(exchange: String, board: String?, symbol: String, instrumentId: Long) {
+            bySymbol[SymbolKey(exchange.uppercase(Locale.ROOT), board?.uppercase(Locale.ROOT), symbol.uppercase(Locale.ROOT))] = instrumentId
+        }
+
+        fun registerAlias(alias: String, source: String, instrumentId: Long) {
+            byAlias[AliasKey(alias.uppercase(Locale.ROOT), source.uppercase(Locale.ROOT))] = instrumentId
+        }
+
+        private data class SymbolKey(val exchange: String, val board: String?, val symbol: String)
+        private data class AliasKey(val alias: String, val source: String)
+    }
+
+    private class FakeTradeLookup(
+        private val existingExtIds: MutableSet<String> = mutableSetOf(),
+        private val existingSoftKeys: MutableSet<CsvImportService.SoftTradeKey> = mutableSetOf(),
+    ) : CsvImportService.TradeLookup {
+        override suspend fun existsByExternalId(portfolioId: UUID, externalId: String): DomainResult<Boolean> {
+            return DomainResult.success(existingExtIds.contains(externalId))
+        }
+
+        override suspend fun existsBySoftKey(key: CsvImportService.SoftTradeKey): DomainResult<Boolean> {
+            return DomainResult.success(existingSoftKeys.contains(key))
+        }
+    }
+
+    private fun openSampleCsv(): Reader {
+        val candidates = listOf(
+            Paths.get("tests", "resources", "trades.csv"),
+            Paths.get("..", "tests", "resources", "trades.csv"),
+        )
+        val path = candidates.firstOrNull { Files.exists(it) }
+            ?: error("Sample trades CSV not found")
+        return Files.newBufferedReader(path)
+    }
+}

--- a/core/src/test/kotlin/portfolio/FxRateServiceTest.kt
+++ b/core/src/test/kotlin/portfolio/FxRateServiceTest.kt
@@ -1,0 +1,135 @@
+package portfolio
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import model.FxRate
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+import portfolio.service.FxRateRepository
+import portfolio.service.FxRateService
+
+class FxRateServiceTest {
+    private val zoneId: ZoneId = ZoneOffset.UTC
+
+    @Test
+    fun `returns rate for exact date`() = runBlocking {
+        val repository = FakeFxRateRepository(
+            mapOf(
+                "USD" to listOf(rate("USD", LocalDate.of(2024, 1, 10), BigDecimal("90.1234"))),
+            ),
+        )
+        val service = FxRateService(repository, zoneId)
+
+        val result = service.rateOn(LocalDate.of(2024, 1, 10), "usd")
+
+        assertTrue(result.isSuccess)
+        assertEquals(BigDecimal("90.1234"), result.getOrNull())
+        assertEquals(1, repository.calls)
+    }
+
+    @Test
+    fun `falls back to previous available date`() = runBlocking {
+        val repository = FakeFxRateRepository(
+            mapOf(
+                "USD" to listOf(
+                    rate("USD", LocalDate.of(2024, 1, 5), BigDecimal("92.50")),
+                ),
+            ),
+        )
+        val service = FxRateService(repository, zoneId)
+
+        val result = service.rateOn(LocalDate.of(2024, 1, 7), "USD")
+        assertTrue(result.isSuccess)
+        assertEquals(normalize(BigDecimal("92.50")), result.getOrNull())
+        assertEquals(1, repository.calls)
+
+        val cached = service.rateOn(LocalDate.of(2024, 1, 6), "USD")
+        assertTrue(cached.isSuccess)
+        assertEquals(normalize(BigDecimal("92.50")), cached.getOrNull())
+        assertEquals(1, repository.calls)
+    }
+
+    @Test
+    fun `calculates cross rate using base currency`() = runBlocking {
+        val repository = FakeFxRateRepository(
+            mapOf(
+                "EUR" to listOf(rate("EUR", LocalDate.of(2024, 1, 10), BigDecimal("100"))),
+                "USD" to listOf(rate("USD", LocalDate.of(2024, 1, 10), BigDecimal("90"))),
+            ),
+        )
+        val service = FxRateService(repository, zoneId)
+
+        val result = service.rateOn(LocalDate.of(2024, 1, 10), "EUR", base = "USD")
+
+        val expected = normalize(BigDecimal("100").divide(BigDecimal("90"), java.math.MathContext.DECIMAL128))
+
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.getOrNull())
+        assertEquals(2, repository.calls)
+    }
+
+    @Test
+    fun `rejects unknown currency codes`() = runBlocking {
+        val service = FxRateService(FakeFxRateRepository(emptyMap()), zoneId)
+
+        val result = service.rateOn(LocalDate.of(2024, 1, 10), "US1")
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertIs<PortfolioException>(exception)
+        assertIs<PortfolioError.Validation>(exception.error)
+    }
+
+    @Test
+    fun `returns not found when data missing`() = runBlocking {
+        val repository = FakeFxRateRepository(
+            mapOf(
+                "USD" to listOf(rate("USD", LocalDate.of(2024, 1, 5), BigDecimal("92.50"))),
+            ),
+        )
+        val service = FxRateService(repository, zoneId)
+
+        val result = service.rateOn(LocalDate.of(2024, 1, 4), "EUR")
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertIs<PortfolioException>(exception)
+        assertIs<PortfolioError.NotFound>(exception.error)
+    }
+
+    private fun rate(ccy: String, date: LocalDate, value: BigDecimal): FxRate =
+        FxRate(
+            ccy = ccy,
+            ts = date.atTime(LocalTime.NOON).atZone(zoneId).toInstant(),
+            rateRub = value,
+            source = "test",
+        )
+
+    private class FakeFxRateRepository(
+        entries: Map<String, List<FxRate>>,
+    ) : FxRateRepository {
+        private val rates: Map<String, List<FxRate>> = entries.mapValues { (_, list) ->
+            list.sortedBy { it.ts }
+        }
+        var calls: Int = 0
+
+        override suspend fun findOnOrBefore(ccy: String, timestamp: Instant): FxRate? {
+            calls += 1
+            return rates[ccy]?.filter { it.ts <= timestamp }?.maxByOrNull { it.ts }
+        }
+    }
+
+    private fun normalize(value: BigDecimal): BigDecimal {
+        val stripped = value.stripTrailingZeros()
+        return if (stripped.scale() < 0) stripped.setScale(0) else stripped
+    }
+}

--- a/core/src/test/kotlin/portfolio/MoneyTest.kt
+++ b/core/src/test/kotlin/portfolio/MoneyTest.kt
@@ -1,0 +1,81 @@
+package portfolio
+
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import portfolio.model.Money
+
+class MoneyTest {
+    @Test
+    fun `creates money with normalized scale and uppercase currency`() {
+        val money = Money.of(BigDecimal("10.00"), "usd")
+
+        assertEquals(BigDecimal("10"), money.amount)
+        assertEquals(0, money.amount.scale())
+        assertEquals("USD", money.currency)
+    }
+
+    @Test
+    fun `adds money in the same currency`() {
+        val first = Money.of(BigDecimal("10.10"), "USD")
+        val second = Money.of(BigDecimal("5.20"), "USD")
+
+        val result = first + second
+
+        assertEquals(BigDecimal("15.3"), result.amount)
+        assertEquals("USD", result.currency)
+    }
+
+    @Test
+    fun `subtraction keeps scale normalized`() {
+        val first = Money.of(BigDecimal("100.000"), "USD")
+        val second = Money.of(BigDecimal("40.50"), "USD")
+
+        val result = first - second
+
+        assertEquals(BigDecimal("59.5"), result.amount)
+    }
+
+    @Test
+    fun `multiplication by big decimal keeps scale normalized`() {
+        val money = Money.of(BigDecimal("10"), "USD")
+
+        val result = money * BigDecimal("2.50")
+
+        assertEquals(BigDecimal("25"), result.amount)
+    }
+
+    @Test
+    fun `multiplication by integer delegates to big decimal multiplier`() {
+        val money = Money.of(BigDecimal("7.5"), "USD")
+
+        val result = money * 3
+
+        assertEquals(BigDecimal("22.5"), result.amount)
+    }
+
+    @Test
+    fun `fails when currencies do not match`() {
+        val usd = Money.of(BigDecimal.ONE, "USD")
+        val eur = Money.of(BigDecimal.ONE, "EUR")
+
+        assertFailsWith<IllegalArgumentException> { usd + eur }
+        assertFailsWith<IllegalArgumentException> { usd - eur }
+    }
+
+    @Test
+    fun `fails when currency code is invalid`() {
+        assertFailsWith<IllegalArgumentException> { Money.of(BigDecimal.ONE, "US") }
+        assertFailsWith<IllegalArgumentException> { Money.of(BigDecimal.ONE, "usd1") }
+    }
+
+    @Test
+    fun `unary minus returns negated amount`() {
+        val money = Money.of(BigDecimal("12.34"), "USD")
+
+        val result = -money
+
+        assertEquals(BigDecimal("-12.34"), result.amount)
+    }
+}

--- a/core/src/test/kotlin/portfolio/PortfolioServiceTest.kt
+++ b/core/src/test/kotlin/portfolio/PortfolioServiceTest.kt
@@ -1,0 +1,321 @@
+package portfolio
+
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import model.FxRate
+import portfolio.errors.DomainResult
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+import portfolio.model.Money
+import portfolio.model.TradeSide
+import portfolio.model.TradeView
+import portfolio.model.ValuationMethod
+import portfolio.service.CoingeckoPriceProvider
+import portfolio.service.FxRateRepository
+import portfolio.service.FxRateService
+import portfolio.service.MoexPriceProvider
+import portfolio.service.PricingService
+import portfolio.service.PortfolioService
+import portfolio.service.PositionCalc
+
+class PortfolioServiceTest {
+    private val portfolioId = UUID.randomUUID()
+    private val instrumentId = 123L
+    private val tradeDate = LocalDate.of(2024, 3, 18)
+    private val clock = Clock.fixed(Instant.parse("2024-03-19T10:15:30Z"), ZoneId.of("UTC"))
+
+    @Test
+    fun `applies buy trade and stores updated average position`() = runBlocking {
+        val storage = FakeStorage()
+        val service = PortfolioService(storage, clock)
+
+        val trade = TradeView(
+            tradeId = UUID.randomUUID(),
+            portfolioId = portfolioId,
+            instrumentId = instrumentId,
+            tradeDate = tradeDate,
+            side = TradeSide.BUY,
+            quantity = BigDecimal("10"),
+            price = usd("100"),
+            fee = usd("1"),
+            tax = usd("0.50"),
+        )
+
+        val result = service.applyTrade(trade, ValuationMethod.AVERAGE)
+
+        assertTrue(result.isSuccess)
+        val saved = storage.savedPositions.single()
+        assertEquals(portfolioId, saved.portfolioId)
+        assertEquals(instrumentId, saved.instrumentId)
+        assertEquals(ValuationMethod.AVERAGE, saved.valuationMethod)
+        assertEquals(clock.instant(), saved.updatedAt)
+        assertEquals(BigDecimal("10"), saved.position.quantity)
+        assertEquals(usd("1001.5"), saved.position.costBasis)
+        assertEquals(usd("1000"), storage.recordedTrades.single().notional)
+        assertEquals(null, storage.recordedTrades.single().realizedPnl)
+    }
+
+    @Test
+    fun `rejects sell trade that exceeds current quantity`() = runBlocking {
+        val fifoCalc = PositionCalc.FifoCalc()
+        var position = PositionCalc.Position.empty("USD")
+        position = fifoCalc.applyBuy(position, BigDecimal("3"), usd("50"), usd("0"))
+            .position
+        val stored = PortfolioService.StoredPosition(
+            portfolioId,
+            instrumentId,
+            ValuationMethod.FIFO,
+            position,
+            clock.instant(),
+        )
+        val storage = FakeStorage(existing = stored)
+        val service = PortfolioService(storage, clock)
+
+        val trade = TradeView(
+            tradeId = UUID.randomUUID(),
+            portfolioId = portfolioId,
+            instrumentId = instrumentId,
+            tradeDate = tradeDate,
+            side = TradeSide.SELL,
+            quantity = BigDecimal("5"),
+            price = usd("60"),
+        )
+
+        val result = service.applyTrade(trade, ValuationMethod.FIFO)
+
+        assertTrue(result.isFailure)
+        val exception = assertIs<PortfolioException>(result.exceptionOrNull())
+        assertIs<PortfolioError.Validation>(exception.error)
+        assertTrue(storage.savedPositions.isEmpty())
+        assertTrue(storage.recordedTrades.isEmpty())
+    }
+
+    @Test
+    fun `applies fifo sell and records realized pnl`() = runBlocking {
+        val fifoCalc = PositionCalc.FifoCalc()
+        var position = PositionCalc.Position.empty("USD")
+        position = fifoCalc.applyBuy(position, BigDecimal("5"), usd("100"), usd("0"))
+            .position
+        position = fifoCalc.applyBuy(position, BigDecimal("3"), usd("120"), usd("0"))
+            .position
+        val stored = PortfolioService.StoredPosition(
+            portfolioId,
+            instrumentId,
+            ValuationMethod.FIFO,
+            position,
+            clock.instant(),
+        )
+        val storage = FakeStorage(existing = stored)
+        val service = PortfolioService(storage, clock)
+
+        val totalFees = usd("1.50")
+        val expected = fifoCalc.applySell(position, BigDecimal("6"), usd("150"), totalFees)
+
+        val trade = TradeView(
+            tradeId = UUID.randomUUID(),
+            portfolioId = portfolioId,
+            instrumentId = instrumentId,
+            tradeDate = tradeDate,
+            side = TradeSide.SELL,
+            quantity = BigDecimal("6"),
+            price = usd("150"),
+            fee = usd("1"),
+            tax = usd("0.50"),
+        )
+
+        val result = service.applyTrade(trade, ValuationMethod.FIFO)
+
+        assertTrue(result.isSuccess)
+        val saved = storage.savedPositions.single()
+        assertEquals(expected.position.quantity, saved.position.quantity)
+        assertEquals(expected.position.costBasis, saved.position.costBasis)
+        assertEquals(expected.position.lots, saved.position.lots)
+        val recorded = storage.recordedTrades.single()
+        assertEquals(expected.realizedPnl, recorded.realizedPnl)
+        assertEquals(trade.tradeId, recorded.tradeId)
+        assertEquals(ValuationMethod.FIFO, recorded.valuationMethod)
+    }
+
+    @Test
+    fun `rejects trade when currency mismatches stored position`() = runBlocking {
+        val avgCalc = PositionCalc.AverageCostCalc()
+        val initial = avgCalc.applyBuy(
+            PositionCalc.Position.empty("USD"),
+            BigDecimal("2"),
+            usd("100"),
+            usd("0"),
+        ).position
+        val stored = PortfolioService.StoredPosition(
+            portfolioId,
+            instrumentId,
+            ValuationMethod.AVERAGE,
+            initial,
+            clock.instant(),
+        )
+        val storage = FakeStorage(existing = stored)
+        val service = PortfolioService(storage, clock)
+
+        val trade = TradeView(
+            tradeId = UUID.randomUUID(),
+            portfolioId = portfolioId,
+            instrumentId = instrumentId,
+            tradeDate = tradeDate,
+            side = TradeSide.BUY,
+            quantity = BigDecimal.ONE,
+            price = Money.of(BigDecimal("90"), "EUR"),
+        )
+
+        val result = service.applyTrade(trade, ValuationMethod.AVERAGE)
+
+        assertTrue(result.isFailure)
+        val exception = assertIs<PortfolioException>(result.exceptionOrNull())
+        assertIs<PortfolioError.Validation>(exception.error)
+        assertTrue(storage.savedPositions.isEmpty())
+        assertTrue(storage.recordedTrades.isEmpty())
+    }
+
+    @Test
+    fun `lists open positions with unrealized pnl`() = runBlocking {
+        val storage = FakeStorage(
+            positions = listOf(
+                PortfolioService.PositionSummary(
+                    portfolioId = portfolioId,
+                    instrumentId = instrumentId,
+                    instrumentName = "ACME",
+                    quantity = BigDecimal("5"),
+                    averagePrice = Money.of(BigDecimal("100"), "USD"),
+                    valuationMethod = ValuationMethod.AVERAGE,
+                ),
+            ),
+        )
+        val fxService = FxRateService(
+            FakeFxRateRepository(
+                mapOf(
+                    "USD" to listOf(rate("USD", tradeDate, BigDecimal("90"))),
+                ),
+            ),
+        )
+        val pricing = PricingService(
+            StaticMoexProvider(
+                mapOf(
+                    (instrumentId to tradeDate) to Money.of(BigDecimal("150"), "USD"),
+                ),
+            ),
+            StaticCoingeckoProvider(),
+            fxService,
+        )
+        val service = PortfolioService(storage, clock)
+
+        val result = service.listPositions(portfolioId, tradeDate, pricing, fxService)
+
+        assertTrue(result.isSuccess)
+        val views = result.getOrThrow()
+        assertEquals(1, views.size)
+        val view = views.single()
+        assertEquals("ACME", view.instrumentName)
+        assertEquals(BigDecimal("5"), view.quantity)
+        assertEquals(Money.of(BigDecimal("67500"), "RUB"), view.valuation)
+        assertEquals(Money.of(BigDecimal("9000"), "RUB"), view.averageCost)
+        assertEquals(Money.of(BigDecimal("22500"), "RUB"), view.unrealizedPnl)
+        assertEquals(ValuationMethod.AVERAGE, view.valuationMethod)
+    }
+
+    private fun usd(amount: String): Money = Money.of(BigDecimal(amount), "USD")
+
+    private class FakeStorage(
+        existing: PortfolioService.StoredPosition? = null,
+        positions: List<PortfolioService.PositionSummary> = emptyList(),
+    ) : PortfolioService.Storage {
+        private var current: PortfolioService.StoredPosition? = existing
+        val savedPositions = mutableListOf<PortfolioService.StoredPosition>()
+        val recordedTrades = mutableListOf<PortfolioService.StoredTrade>()
+        private val positionSummaries = positions.toMutableList()
+
+        override suspend fun <T> transaction(
+            block: suspend PortfolioService.Storage.Transaction.() -> DomainResult<T>,
+        ): DomainResult<T> {
+            val tx = object : PortfolioService.Storage.Transaction {
+                override suspend fun loadPosition(
+                    portfolioId: UUID,
+                    instrumentId: Long,
+                    method: ValuationMethod,
+                ): DomainResult<PortfolioService.StoredPosition?> {
+                    val stored = current
+                    return if (stored != null && stored.portfolioId == portfolioId &&
+                        stored.instrumentId == instrumentId && stored.valuationMethod == method
+                    ) {
+                        DomainResult.success(stored)
+                    } else {
+                        DomainResult.success(null)
+                    }
+                }
+
+                override suspend fun savePosition(
+                    position: PortfolioService.StoredPosition,
+                ): DomainResult<Unit> {
+                    current = position
+                    savedPositions += position
+                    return DomainResult.success(Unit)
+                }
+
+                override suspend fun recordTrade(
+                    trade: PortfolioService.StoredTrade,
+                ): DomainResult<Unit> {
+                    recordedTrades += trade
+                    return DomainResult.success(Unit)
+                }
+            }
+
+            return tx.block()
+        }
+
+        override suspend fun listPositions(portfolioId: UUID): DomainResult<List<PortfolioService.PositionSummary>> {
+            return DomainResult.success(positionSummaries.filter { it.portfolioId == portfolioId })
+        }
+    }
+
+    private class FakeFxRateRepository(
+        private val rates: Map<String, List<FxRate>>,
+    ) : FxRateRepository {
+        override suspend fun findOnOrBefore(ccy: String, timestamp: Instant): FxRate? {
+            val entries = rates[ccy] ?: return null
+            return entries
+                .filter { !it.ts.isAfter(timestamp) }
+                .maxByOrNull { it.ts }
+        }
+    }
+
+    private class StaticMoexProvider(
+        private val closePrices: Map<Pair<Long, LocalDate>, Money?>,
+    ) : MoexPriceProvider {
+        override suspend fun closePrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> =
+            DomainResult.success(closePrices[instrumentId to on])
+
+        override suspend fun lastPrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> =
+            DomainResult.success(null)
+    }
+
+    private class StaticCoingeckoProvider : CoingeckoPriceProvider {
+        override suspend fun closePrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> =
+            DomainResult.success(null)
+
+        override suspend fun lastPrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> =
+            DomainResult.success(null)
+    }
+
+    private fun rate(ccy: String, date: LocalDate, value: BigDecimal): FxRate {
+        val ts = date.atTime(LocalTime.NOON).atZone(ZoneOffset.UTC).toInstant()
+        return FxRate(ccy = ccy, ts = ts, rateRub = value, source = "TEST")
+    }
+}

--- a/core/src/test/kotlin/portfolio/PositionCalcTest.kt
+++ b/core/src/test/kotlin/portfolio/PositionCalcTest.kt
@@ -1,0 +1,251 @@
+package portfolio
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+import java.math.BigDecimal
+import java.math.MathContext
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import portfolio.model.Money
+import portfolio.service.PositionCalc
+
+class PositionCalcTest {
+    private val averageCalc = PositionCalc.AverageCostCalc()
+    private val fifoCalc = PositionCalc.FifoCalc()
+
+    @Test
+    fun averageCostScenario() {
+        var position = PositionCalc.Position.empty(CURRENCY)
+
+        val firstBuy = averageCalc.applyBuy(
+            position,
+            BigDecimal.TEN,
+            money("100"),
+            money("5")
+        )
+        assertEquals(BigDecimal.TEN, firstBuy.position.quantity)
+        assertEquals(money("1005"), firstBuy.position.costBasis)
+        assertEquals(money("0"), firstBuy.realizedPnl)
+
+        position = firstBuy.position
+
+        val secondBuy = averageCalc.applyBuy(
+            position,
+            BigDecimal("5"),
+            money("110"),
+            money("2")
+        )
+        assertEquals(BigDecimal("15"), secondBuy.position.quantity)
+        assertEquals(money("1557"), secondBuy.position.costBasis)
+        assertEquals(money("0"), secondBuy.realizedPnl)
+        assertEquals(money("103.8"), secondBuy.position.averagePrice)
+
+        position = secondBuy.position
+
+        val sell = averageCalc.applySell(
+            position,
+            BigDecimal("8"),
+            money("120"),
+            money("4")
+        )
+        assertEquals(BigDecimal("7"), sell.position.quantity)
+        assertEquals(money("726.6"), sell.position.costBasis)
+        assertEquals(money("125.6"), sell.realizedPnl)
+        assertEquals(money("103.8"), sell.position.averagePrice)
+    }
+
+    @Test
+    fun fifoScenarioWithPartialLots() {
+        var position = PositionCalc.Position.empty(CURRENCY)
+
+        val firstBuy = fifoCalc.applyBuy(
+            position,
+            BigDecimal.TEN,
+            money("100"),
+            money("5")
+        )
+        assertEquals(BigDecimal.TEN, firstBuy.position.quantity)
+        assertEquals(1, firstBuy.position.lots.size)
+        assertEquals(money("1005"), firstBuy.position.costBasis)
+
+        position = firstBuy.position
+
+        val secondBuy = fifoCalc.applyBuy(
+            position,
+            BigDecimal("5"),
+            money("110"),
+            money("2")
+        )
+        assertEquals(BigDecimal("15"), secondBuy.position.quantity)
+        assertEquals(2, secondBuy.position.lots.size)
+        assertEquals(money("1557"), secondBuy.position.costBasis)
+
+        position = secondBuy.position
+
+        val sell = fifoCalc.applySell(
+            position,
+            BigDecimal("8"),
+            money("120"),
+            money("4")
+        )
+        assertEquals(BigDecimal("7"), sell.position.quantity)
+        assertEquals(money("753"), sell.position.costBasis)
+        assertEquals(money("152"), sell.realizedPnl)
+        assertEquals(2, sell.position.lots.size)
+        assertEquals(BigDecimal("2"), sell.position.lots[0].quantity)
+        assertEquals(money("201"), sell.position.lots[0].costBasis)
+        assertEquals(BigDecimal("5"), sell.position.lots[1].quantity)
+        assertEquals(money("552"), sell.position.lots[1].costBasis)
+    }
+
+    @Test
+    fun fifoCrossLotSellClearsPosition() {
+        var position = PositionCalc.Position.empty(CURRENCY)
+
+        position = fifoCalc.applyBuy(position, BigDecimal("3"), money("50"), money("1")).position
+        position = fifoCalc.applyBuy(position, BigDecimal("4"), money("55"), money("1.20")).position
+
+        val sell = fifoCalc.applySell(position, BigDecimal("7"), money("60"), money("3"))
+        assertEquals(BigDecimal.ZERO, sell.position.quantity)
+        assertEquals(money("0"), sell.position.costBasis)
+        assertTrue(sell.position.lots.isEmpty())
+        assertEquals(money("44.8"), sell.realizedPnl)
+    }
+
+    @Test
+    fun averagePropertyInvariants() = runBlocking {
+        checkAll(operationSequencesArb) { specs ->
+            val operations = buildOperations(specs)
+            verifySequence(averageCalc, operations)
+        }
+    }
+
+    @Test
+    fun fifoPropertyInvariants() = runBlocking {
+        checkAll(operationSequencesArb) { specs ->
+            val operations = buildOperations(specs)
+            verifySequence(fifoCalc, operations)
+        }
+    }
+
+    private fun verifySequence(calc: PositionCalc, operations: List<Operation>) {
+        var position = PositionCalc.Position.empty(CURRENCY)
+        var totalRealized = zeroMoney()
+
+        operations.forEach { operation ->
+            val result = when (operation) {
+                is Operation.Buy -> calc.applyBuy(position, operation.quantity, operation.price, operation.fee)
+                is Operation.Sell -> calc.applySell(position, operation.quantity, operation.price, operation.fee)
+            }
+            assertTrue(result.position.quantity >= BigDecimal.ZERO)
+            position = result.position
+            totalRealized = totalRealized + result.realizedPnl
+        }
+
+        if (position.quantity > BigDecimal.ZERO) {
+            val expectedAverage = Money.of(
+                position.costBasis.amount.divide(position.quantity, MathContext.DECIMAL128),
+                CURRENCY
+            )
+            assertNotNull(position.averagePrice)
+            assertEquals(expectedAverage, position.averagePrice)
+        } else {
+            assertEquals(BigDecimal.ZERO, position.quantity)
+            assertNull(position.averagePrice)
+            assertEquals(zeroMoney(), position.costBasis)
+        }
+
+        val totalBuys = operations.filterIsInstance<Operation.Buy>().fold(zeroMoney()) { acc, buy ->
+            acc + buy.price * buy.quantity + buy.fee
+        }
+        val totalSellProceeds = operations.filterIsInstance<Operation.Sell>().fold(zeroMoney()) { acc, sell ->
+            acc + sell.price * sell.quantity
+        }
+        val totalSellFees = operations.filterIsInstance<Operation.Sell>().fold(zeroMoney()) { acc, sell ->
+            acc + sell.fee
+        }
+
+        assertEquals(BigDecimal.ZERO, position.quantity)
+        assertEquals(totalSellProceeds - totalSellFees - totalBuys, totalRealized)
+        if (calc is PositionCalc.FifoCalc) {
+            assertTrue(position.lots.isEmpty())
+        }
+    }
+
+    private fun buildOperations(specs: List<OperationSpec>): List<Operation> {
+        val operations = mutableListOf<Operation>()
+        var openQuantity = BigDecimal.ZERO
+        val closingTemplate = specs.lastOrNull()
+
+        specs.forEach { spec ->
+            val quantity = BigDecimal(spec.quantity.toLong())
+            val price = money(spec.price)
+            val fee = money(spec.fee)
+            if (spec.isBuy || openQuantity < quantity) {
+                operations += Operation.Buy(quantity, price, fee)
+                openQuantity += quantity
+            } else {
+                operations += Operation.Sell(quantity, price, fee)
+                openQuantity -= quantity
+            }
+        }
+
+        if (openQuantity > BigDecimal.ZERO) {
+            val price = money(closingTemplate?.price ?: BigDecimal("100"))
+            val fee = money(closingTemplate?.fee ?: BigDecimal.ZERO)
+            operations += Operation.Sell(openQuantity, price, fee)
+        }
+
+        return operations
+    }
+
+    private data class OperationSpec(
+        val isBuy: Boolean,
+        val quantity: Int,
+        val price: BigDecimal,
+        val fee: BigDecimal
+    )
+
+    private sealed interface Operation {
+        data class Buy(
+            val quantity: BigDecimal,
+            val price: Money,
+            val fee: Money
+        ) : Operation
+
+        data class Sell(
+            val quantity: BigDecimal,
+            val price: Money,
+            val fee: Money
+        ) : Operation
+    }
+
+    private fun zeroMoney(): Money = money(BigDecimal.ZERO)
+
+    private fun money(amount: String): Money = money(BigDecimal(amount))
+
+    private fun money(amount: BigDecimal): Money = Money.of(amount, CURRENCY)
+
+    private val operationSpecArb = Arb.bind(Arb.boolean(), Arb.int(1..10), Arb.int(1000..10000), Arb.int(0..500)) { isBuy, qty, price, fee ->
+        OperationSpec(
+            isBuy = isBuy,
+            quantity = qty,
+            price = BigDecimal.valueOf(price.toLong(), 2),
+            fee = BigDecimal.valueOf(fee.toLong(), 2)
+        )
+    }
+
+    private val operationSequencesArb = Arb.list(operationSpecArb, 3..12)
+
+    companion object {
+        private const val CURRENCY = "USD"
+    }
+}

--- a/core/src/test/kotlin/portfolio/PricingServiceTest.kt
+++ b/core/src/test/kotlin/portfolio/PricingServiceTest.kt
@@ -1,0 +1,259 @@
+package portfolio
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.coroutines.runBlocking
+import model.FxRate
+import portfolio.errors.DomainResult
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+import portfolio.model.Money
+import portfolio.service.CoingeckoPriceProvider
+import portfolio.service.FxRateRepository
+import portfolio.service.FxRateService
+import portfolio.service.MoexPriceProvider
+import portfolio.service.PricingService
+import portfolio.service.PriceProvider
+
+class PricingServiceTest {
+    private val tradeDate = LocalDate.of(2024, 2, 1)
+
+    @Test
+    fun `returns close price from moex`() = runBlocking {
+        val moex = StubMoexProvider().apply {
+            closeHandler = { id, date ->
+                assertEquals(1L, id)
+                assertEquals(tradeDate, date)
+                DomainResult.success(Money.of(BigDecimal("10"), "USD"))
+            }
+            lastHandler = { _, _ ->
+                fail("Should not request last price when close is available")
+            }
+        }
+        val coingecko = StubCoingeckoProvider().apply {
+            closeHandler = { _, _ ->
+                fail("Should not call secondary provider when primary succeeds")
+            }
+            lastHandler = { _, _ ->
+                fail("Should not call secondary provider when primary succeeds")
+            }
+        }
+        val fxService = FxRateService(
+            FakeFxRateRepository(
+                mapOf(
+                    "USD" to listOf(rate("USD", tradeDate, BigDecimal("92.50"))),
+                ),
+            ),
+        )
+        val service = PricingService(moex, coingecko, fxService)
+
+        val result = service.closeOrLast(1L, tradeDate)
+
+        assertTrue(result.isSuccess)
+        assertEquals(Money.of(BigDecimal("925"), "RUB"), result.getOrNull())
+        assertEquals(1, moex.closeCalls)
+        assertEquals(0, moex.lastCalls)
+    }
+
+    @Test
+    fun `falls back to last price when close missing`() = runBlocking {
+        val moex = StubMoexProvider().apply {
+            closeHandler = { _, _ -> DomainResult.success(null) }
+            lastHandler = { id, date ->
+                assertEquals(2L, id)
+                assertEquals(tradeDate, date)
+                DomainResult.success(Money.of(BigDecimal("200"), "RUB"))
+            }
+        }
+        val coingecko = StubCoingeckoProvider().apply {
+            closeHandler = { _, _ -> DomainResult.success(null) }
+            lastHandler = { _, _ ->
+                fail("Should not request Coingecko last when MOEX provided one")
+            }
+        }
+        val fxService = FxRateService(FakeFxRateRepository(emptyMap()))
+        val service = PricingService(moex, coingecko, fxService)
+
+        val result = service.closeOrLast(2L, tradeDate)
+
+        assertTrue(result.isSuccess)
+        assertEquals(Money.of(BigDecimal("200"), "RUB"), result.getOrNull())
+        assertEquals(1, moex.closeCalls)
+        assertEquals(1, coingecko.closeCalls)
+        assertEquals(1, moex.lastCalls)
+        assertEquals(0, coingecko.lastCalls)
+    }
+
+    @Test
+    fun `honors fallback configuration`() = runBlocking {
+        val moex = StubMoexProvider().apply {
+            closeHandler = { _, _ -> DomainResult.success(null) }
+            lastHandler = { _, _ -> DomainResult.success(null) }
+        }
+        val coingecko = StubCoingeckoProvider().apply {
+            closeHandler = { id, date ->
+                assertEquals(3L, id)
+                assertEquals(tradeDate, date)
+                DomainResult.success(Money.of(BigDecimal("150"), "USD"))
+            }
+            lastHandler = { _, _ ->
+                fail("Fallback disabled, last price should not be requested")
+            }
+        }
+        val fxService = FxRateService(
+            FakeFxRateRepository(
+                mapOf(
+                    "USD" to listOf(rate("USD", tradeDate, BigDecimal("90"))),
+                ),
+            ),
+        )
+        val service = PricingService(
+            moex,
+            coingecko,
+            fxService,
+            PricingService.Config(fallbackToLast = false),
+        )
+
+        val result = service.closeOrLast(3L, tradeDate)
+
+        assertTrue(result.isSuccess)
+        assertEquals(Money.of(BigDecimal("13500"), "RUB"), result.getOrNull())
+        assertEquals(1, moex.closeCalls)
+        assertEquals(0, moex.lastCalls)
+        assertEquals(1, coingecko.closeCalls)
+        assertEquals(0, coingecko.lastCalls)
+    }
+
+    @Test
+    fun `uses close as secondary when last preferred`() = runBlocking {
+        val moex = StubMoexProvider().apply {
+            closeHandler = { _, _ ->
+                DomainResult.success(Money.of(BigDecimal("5"), "EUR"))
+            }
+            lastHandler = { _, _ -> DomainResult.success(null) }
+        }
+        val coingecko = StubCoingeckoProvider().apply {
+            closeHandler = { _, _ -> DomainResult.success(null) }
+            lastHandler = { _, _ -> DomainResult.success(null) }
+        }
+        val fxService = FxRateService(
+            FakeFxRateRepository(
+                mapOf(
+                    "EUR" to listOf(rate("EUR", tradeDate, BigDecimal("100"))),
+                ),
+            ),
+        )
+        val service = PricingService(
+            moex,
+            coingecko,
+            fxService,
+            PricingService.Config(preferClosePrice = false),
+        )
+
+        val result = service.closeOrLast(4L, tradeDate)
+
+        assertTrue(result.isSuccess)
+        assertEquals(Money.of(BigDecimal("500"), "RUB"), result.getOrNull())
+        assertEquals(1, moex.lastCalls)
+        assertEquals(1, moex.closeCalls)
+    }
+
+    @Test
+    fun `returns not found when providers lack data`() = runBlocking {
+        val moex = StubMoexProvider()
+        val coingecko = StubCoingeckoProvider()
+        val fxService = FxRateService(FakeFxRateRepository(emptyMap()))
+        val service = PricingService(moex, coingecko, fxService)
+
+        val result = service.closeOrLast(5L, tradeDate)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertIs<PortfolioException>(exception)
+        assertIs<PortfolioError.NotFound>(exception.error)
+    }
+
+    @Test
+    fun `propagates provider failure`() = runBlocking {
+        val error = PortfolioError.External("upstream down")
+        val moex = StubMoexProvider().apply {
+            closeHandler = { _, _ -> DomainResult.failure(PortfolioException(error)) }
+        }
+        val coingecko = StubCoingeckoProvider()
+        val fxService = FxRateService(FakeFxRateRepository(emptyMap()))
+        val service = PricingService(moex, coingecko, fxService)
+
+        val result = service.closeOrLast(6L, tradeDate)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertIs<PortfolioException>(exception)
+        assertEquals(error, exception.error)
+    }
+
+    @Test
+    fun `propagates fx conversion failure`() = runBlocking {
+        val moex = StubMoexProvider().apply {
+            closeHandler = { _, _ -> DomainResult.success(Money.of(BigDecimal("1"), "CHF")) }
+        }
+        val coingecko = StubCoingeckoProvider()
+        val fxService = FxRateService(FakeFxRateRepository(emptyMap()))
+        val service = PricingService(moex, coingecko, fxService)
+
+        val result = service.closeOrLast(7L, tradeDate)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertIs<PortfolioException>(exception)
+        assertIs<PortfolioError.NotFound>(exception.error)
+    }
+
+    private open class StubPriceProvider : PriceProvider {
+        var closeCalls: Int = 0
+        var lastCalls: Int = 0
+
+        var closeHandler: suspend (Long, LocalDate) -> DomainResult<Money?> = { _, _ -> DomainResult.success(null) }
+        var lastHandler: suspend (Long, LocalDate) -> DomainResult<Money?> = { _, _ -> DomainResult.success(null) }
+
+        override suspend fun closePrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> {
+            closeCalls += 1
+            return closeHandler(instrumentId, on)
+        }
+
+        override suspend fun lastPrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> {
+            lastCalls += 1
+            return lastHandler(instrumentId, on)
+        }
+    }
+
+    private class StubMoexProvider : StubPriceProvider(), MoexPriceProvider
+
+    private class StubCoingeckoProvider : StubPriceProvider(), CoingeckoPriceProvider
+
+    private class FakeFxRateRepository(
+        entries: Map<String, List<FxRate>>,
+    ) : FxRateRepository {
+        private val rates: Map<String, List<FxRate>> = entries.mapValues { (_, values) ->
+            values.sortedBy { it.ts }
+        }
+
+        override suspend fun findOnOrBefore(ccy: String, timestamp: Instant): FxRate? =
+            rates[ccy]?.filter { it.ts <= timestamp }?.maxByOrNull { it.ts }
+    }
+
+    private fun rate(ccy: String, date: LocalDate, value: BigDecimal): FxRate =
+        FxRate(
+            ccy = ccy,
+            ts = date.atTime(LocalTime.NOON).atZone(ZoneOffset.UTC).toInstant(),
+            rateRub = value,
+            source = "test",
+        )
+}

--- a/core/src/test/kotlin/portfolio/ValuationServiceTest.kt
+++ b/core/src/test/kotlin/portfolio/ValuationServiceTest.kt
@@ -1,0 +1,183 @@
+package portfolio
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import model.FxRate
+import portfolio.errors.DomainResult
+import portfolio.model.Money
+import portfolio.service.CoingeckoPriceProvider
+import portfolio.service.FxRateRepository
+import portfolio.service.FxRateService
+import portfolio.service.MoexPriceProvider
+import portfolio.service.PricingService
+import portfolio.service.ValuationService
+
+class ValuationServiceTest {
+    private val portfolioId = UUID.randomUUID()
+    private val date = LocalDate.of(2024, 4, 1)
+
+    @Test
+    fun `returns zero valuation for empty portfolio`() = runBlocking {
+        val storage = FakeStorage()
+        val fxService = FxRateService(FakeFxRateRepository(emptyMap()))
+        val pricing = PricingService(
+            MutableMoexProvider(),
+            StaticCoingeckoProvider(),
+            fxService,
+        )
+        val service = ValuationService(storage, pricing, fxService)
+
+        val result = service.revaluePortfolioOn(portfolioId, date)
+
+        assertTrue(result.isSuccess)
+        val valuation = result.getOrThrow()
+        assertEquals(Money.of(BigDecimal.ZERO, "RUB"), valuation.valueRub)
+        assertEquals(Money.of(BigDecimal.ZERO, "RUB"), valuation.pnlDay)
+        assertEquals(Money.of(BigDecimal.ZERO, "RUB"), valuation.pnlTotal)
+        assertEquals(BigDecimal.ZERO, valuation.drawdown)
+        assertEquals(1, storage.upserts.size)
+        val record = storage.upserts.single()
+        assertEquals(BigDecimal.ZERO, record.valueRub)
+        assertEquals(BigDecimal.ZERO, record.pnlDay)
+        assertEquals(BigDecimal.ZERO, record.pnlTotal)
+        assertEquals(BigDecimal.ZERO, record.drawdown)
+    }
+
+    @Test
+    fun `persists valuations and computes drawdown`() = runBlocking {
+        val positions = listOf(
+            ValuationService.Storage.PositionSnapshot(
+                instrumentId = 1L,
+                quantity = BigDecimal("5"),
+                averagePrice = Money.of(BigDecimal("100"), "USD"),
+            ),
+            ValuationService.Storage.PositionSnapshot(
+                instrumentId = 2L,
+                quantity = BigDecimal("2"),
+                averagePrice = Money.of(BigDecimal("3000"), "RUB"),
+            ),
+        )
+        val storage = FakeStorage(positions)
+        val fxService = FxRateService(
+            FakeFxRateRepository(
+                mapOf(
+                    "USD" to listOf(rate("USD", date, BigDecimal("90"))),
+                ),
+            ),
+        )
+        val moex = MutableMoexProvider().apply {
+            closePrices[(1L to date)] = Money.of(BigDecimal("120"), "USD")
+            closePrices[(2L to date)] = Money.of(BigDecimal("3200"), "RUB")
+        }
+        val pricing = PricingService(moex, StaticCoingeckoProvider(), fxService)
+        val service = ValuationService(storage, pricing, fxService)
+
+        val dayOne = service.revaluePortfolioOn(portfolioId, date)
+
+        assertTrue(dayOne.isSuccess)
+        val firstValuation = dayOne.getOrThrow()
+        assertMoneyEquals("60400", firstValuation.valueRub)
+        assertMoneyEquals("9400", firstValuation.pnlDay)
+        assertMoneyEquals("9400", firstValuation.pnlTotal)
+        assertEquals(BigDecimal.ZERO, firstValuation.drawdown)
+
+        val nextDate = date.plusDays(1)
+        moex.closePrices[(1L to nextDate)] = Money.of(BigDecimal("80"), "USD")
+        moex.closePrices[(2L to nextDate)] = Money.of(BigDecimal("2800"), "RUB")
+
+        val dayTwo = service.revaluePortfolioOn(portfolioId, nextDate)
+
+        assertTrue(dayTwo.isSuccess)
+        val secondValuation = dayTwo.getOrThrow()
+        assertMoneyEquals("41600", secondValuation.valueRub)
+        assertMoneyEquals("-18800", secondValuation.pnlDay)
+        assertMoneyEquals("-9400", secondValuation.pnlTotal)
+        val expectedDrawdown = BigDecimal("41600")
+            .divide(BigDecimal("60400"), MathContext.DECIMAL128)
+            .subtract(BigDecimal.ONE)
+            .stripTrailingZeros()
+        assertEquals(0, expectedDrawdown.compareTo(secondValuation.drawdown))
+
+        // ensure idempotent upsert per day
+        val repeat = service.revaluePortfolioOn(portfolioId, nextDate)
+        assertTrue(repeat.isSuccess)
+        assertEquals(3, storage.upserts.size)
+        val storedForNextDate = storage.records[nextDate]!!
+        assertEquals(secondValuation.valueRub.amount, storedForNextDate.valueRub)
+    }
+
+    private fun assertMoneyEquals(expected: String, actual: Money) {
+        assertEquals(Money.of(BigDecimal(expected), "RUB"), actual)
+    }
+
+    private class FakeStorage(
+        private val positions: List<ValuationService.Storage.PositionSnapshot> = emptyList(),
+    ) : ValuationService.Storage {
+        val records = mutableMapOf<LocalDate, ValuationService.Storage.ValuationRecord>()
+        val upserts = mutableListOf<ValuationService.Storage.ValuationRecord>()
+
+        override suspend fun listPositions(portfolioId: UUID): DomainResult<List<ValuationService.Storage.PositionSnapshot>> {
+            return DomainResult.success(positions)
+        }
+
+        override suspend fun latestValuationBefore(
+            portfolioId: UUID,
+            date: LocalDate,
+        ): DomainResult<ValuationService.Storage.ValuationRecord?> {
+            val previous = records.values
+                .filter { it.portfolioId == portfolioId && it.date < date }
+                .maxByOrNull { it.date }
+            return DomainResult.success(previous)
+        }
+
+        override suspend fun upsertValuation(
+            record: ValuationService.Storage.ValuationRecord,
+        ): DomainResult<ValuationService.Storage.ValuationRecord> {
+            records[record.date] = record
+            upserts += record
+            return DomainResult.success(record)
+        }
+    }
+
+    private class FakeFxRateRepository(
+        private val rates: Map<String, List<FxRate>>,
+    ) : FxRateRepository {
+        override suspend fun findOnOrBefore(ccy: String, timestamp: java.time.Instant): FxRate? {
+            val entries = rates[ccy] ?: return null
+            return entries
+                .filter { !it.ts.isAfter(timestamp) }
+                .maxByOrNull { it.ts }
+        }
+    }
+
+    private class MutableMoexProvider : MoexPriceProvider {
+        val closePrices = mutableMapOf<Pair<Long, LocalDate>, Money?>()
+
+        override suspend fun closePrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> =
+            DomainResult.success(closePrices[instrumentId to on])
+
+        override suspend fun lastPrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> =
+            DomainResult.success(null)
+    }
+
+    private class StaticCoingeckoProvider : CoingeckoPriceProvider {
+        override suspend fun closePrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> =
+            DomainResult.success(null)
+
+        override suspend fun lastPrice(instrumentId: Long, on: LocalDate): DomainResult<Money?> =
+            DomainResult.success(null)
+    }
+
+    private fun rate(ccy: String, date: LocalDate, value: BigDecimal): FxRate {
+        val ts = date.atTime(LocalTime.NOON).atZone(ZoneOffset.UTC).toInstant()
+        return FxRate(ccy = ccy, ts = ts, rateRub = value, source = "TEST")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ serialization = "1.6.3"
 micrometer = "1.12.5"
 hikari = "5.1.0"
 postgres = "42.7.4"
+kotest = "5.9.1"
 
 
 [libraries]
@@ -29,6 +30,9 @@ serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-jso
 typesafe-config = { module = "com.typesafe:config", version = "1.4.3" }
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/integrations/build.gradle.kts
+++ b/integrations/build.gradle.kts
@@ -18,15 +18,15 @@ val coroutinesVersion = libs.versions.coroutines.get()
 val micrometerVersion = libs.versions.micrometer.get()
 
 dependencies {
-    implementation("io.ktor:ktor-client-core-jvm:$ktorVersion")
+    api("io.ktor:ktor-client-core-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-cio-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-client-logging:$ktorVersion")
     implementation("io.ktor:ktor-client-encoding:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation(libs.serialization.json)
-    implementation(libs.micrometer.core)
-    implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
+    api(libs.micrometer.core)
+    api("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
 
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("io.kotest:kotest-runner-junit5:5.9.1")

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -22,6 +22,7 @@ configurations {
 }
 
 dependencies {
+    implementation(project(":core"))
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)
@@ -38,6 +39,8 @@ dependencies {
     add("flyway", libs.postgresql)
     add("flyway", libs.flyway.postgresql)
     add("flyway", libs.flyway.core)
+
+    testImplementation("com.h2database:h2:2.2.224")
 }
 
 configure<FlywayExtension> {

--- a/storage/src/main/kotlin/repo/FxRateRepository.kt
+++ b/storage/src/main/kotlin/repo/FxRateRepository.kt
@@ -1,0 +1,70 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.time.Instant
+import model.FxRate
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.lessEq
+import repo.mapper.setValues
+import repo.mapper.toColumnValues
+import repo.mapper.toDbTimestamp
+import repo.mapper.toFxRate
+import repo.tables.FxRatesTable
+import portfolio.service.FxRateRepository as FxRateRepositoryContract
+
+class FxRateRepository : FxRateRepositoryContract {
+    suspend fun upsert(rate: FxRate): FxRate = dbQuery {
+        val predicate = (FxRatesTable.ccy eq rate.ccy) and (FxRatesTable.ts eq rate.ts.toDbTimestamp())
+        val updated = FxRatesTable.update({ predicate }) {
+            it.setValues(rate.toColumnValues())
+        }
+        if (updated == 0) {
+            FxRatesTable.insert {
+                it.setValues(rate.toColumnValues())
+            }
+        }
+        FxRatesTable.select { predicate }.single().toFxRate()
+    }
+
+    override suspend fun findOnOrBefore(ccy: String, timestamp: Instant): FxRate? = dbQuery {
+        FxRatesTable.select {
+            (FxRatesTable.ccy eq ccy) and (FxRatesTable.ts lessEq timestamp.toDbTimestamp())
+        }
+            .orderBy(FxRatesTable.ts, SortOrder.DESC)
+            .limit(1)
+            .singleOrNull()?.toFxRate()
+    }
+
+    suspend fun findLatest(ccy: String): FxRate? = dbQuery {
+        FxRatesTable.select { FxRatesTable.ccy eq ccy }
+            .orderBy(FxRatesTable.ts, SortOrder.DESC)
+            .limit(1)
+            .singleOrNull()?.toFxRate()
+    }
+
+    suspend fun find(ccy: String, timestamp: Instant): FxRate? = dbQuery {
+        FxRatesTable.select {
+            (FxRatesTable.ccy eq ccy) and (FxRatesTable.ts eq timestamp.toDbTimestamp())
+        }.singleOrNull()?.toFxRate()
+    }
+
+    suspend fun list(ccy: String, limit: Int, offset: Long = 0): List<FxRate> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        FxRatesTable.select { FxRatesTable.ccy eq ccy }
+            .orderBy(FxRatesTable.ts, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toFxRate() }
+    }
+
+    suspend fun delete(ccy: String, timestamp: Instant): Boolean = dbQuery {
+        FxRatesTable.deleteWhere {
+            (FxRatesTable.ccy eq ccy) and (FxRatesTable.ts eq timestamp.toDbTimestamp())
+        } > 0
+    }
+}

--- a/storage/src/main/kotlin/repo/InstrumentRepository.kt
+++ b/storage/src/main/kotlin/repo/InstrumentRepository.kt
@@ -1,0 +1,115 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.or
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.isNull
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
+import repo.mapper.setValues
+import repo.mapper.toInstrumentAliasEntity
+import repo.mapper.toInstrumentEntity
+import repo.mapper.toColumnValues
+import repo.model.InstrumentAliasEntity
+import repo.model.InstrumentEntity
+import repo.model.InstrumentUpdate
+import repo.model.NewInstrument
+import repo.model.NewInstrumentAlias
+import repo.tables.InstrumentAliasesTable
+import repo.tables.InstrumentsTable
+
+class InstrumentRepository {
+    suspend fun createInstrument(newInstrument: NewInstrument): InstrumentEntity = dbQuery {
+        val statement = InstrumentsTable.insert {
+            it.setValues(newInstrument.toColumnValues())
+        }
+        statement.resultedValues?.singleOrNull()?.toInstrumentEntity()
+            ?: error("Failed to insert instrument")
+    }
+
+    suspend fun updateInstrument(instrumentId: Long, update: InstrumentUpdate): InstrumentEntity? = dbQuery {
+        val values = update.toColumnValues()
+        if (values.isEmpty()) {
+            return@dbQuery findById(instrumentId)
+        }
+        val updated = InstrumentsTable.update({ InstrumentsTable.instrumentId eq instrumentId }) {
+            it.setValues(values)
+        }
+        if (updated > 0) {
+            InstrumentsTable.select { InstrumentsTable.instrumentId eq instrumentId }
+                .singleOrNull()?.toInstrumentEntity()
+        } else {
+            null
+        }
+    }
+
+    suspend fun deleteInstrument(instrumentId: Long): Boolean = dbQuery {
+        InstrumentsTable.deleteWhere { InstrumentsTable.instrumentId eq instrumentId } > 0
+    }
+
+    suspend fun findById(instrumentId: Long): InstrumentEntity? = dbQuery {
+        InstrumentsTable.select { InstrumentsTable.instrumentId eq instrumentId }
+            .singleOrNull()?.toInstrumentEntity()
+    }
+
+    suspend fun findByIsin(isin: String): InstrumentEntity? = dbQuery {
+        InstrumentsTable.select { InstrumentsTable.isin eq isin }
+            .singleOrNull()?.toInstrumentEntity()
+    }
+
+    suspend fun findBySymbol(exchange: String, board: String?, symbol: String): InstrumentEntity? = dbQuery {
+        InstrumentsTable.select {
+            val boardCondition = board?.let { InstrumentsTable.board eq it } ?: InstrumentsTable.board.isNull()
+            (InstrumentsTable.exchange eq exchange) and boardCondition and (InstrumentsTable.symbol eq symbol)
+        }.singleOrNull()?.toInstrumentEntity()
+    }
+
+    suspend fun search(query: String, limit: Int, offset: Long = 0): List<InstrumentEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        val pattern = "%${query}%"
+        InstrumentsTable.select {
+            (InstrumentsTable.symbol like pattern) or (InstrumentsTable.exchange like pattern)
+        }
+            .orderBy(InstrumentsTable.symbol, SortOrder.ASC)
+            .limit(limit, offset)
+            .map { it.toInstrumentEntity() }
+    }
+
+    suspend fun listAliases(instrumentId: Long): List<InstrumentAliasEntity> = dbQuery {
+        InstrumentAliasesTable.select { InstrumentAliasesTable.instrumentId eq instrumentId }
+            .orderBy(InstrumentAliasesTable.alias, SortOrder.ASC)
+            .map { it.toInstrumentAliasEntity() }
+    }
+
+    suspend fun addAlias(newAlias: NewInstrumentAlias): InstrumentAliasEntity = dbQuery {
+        val statement = InstrumentAliasesTable.insert {
+            it.setValues(newAlias.toColumnValues())
+        }
+        statement.resultedValues?.singleOrNull()?.toInstrumentAliasEntity()
+            ?: error("Failed to insert instrument alias")
+    }
+
+    suspend fun removeAlias(aliasId: Long): Boolean = dbQuery {
+        InstrumentAliasesTable.deleteWhere { InstrumentAliasesTable.aliasId eq aliasId } > 0
+    }
+
+    suspend fun findAlias(alias: String, source: String): InstrumentAliasEntity? = dbQuery {
+        InstrumentAliasesTable.select {
+            (InstrumentAliasesTable.alias eq alias) and (InstrumentAliasesTable.sourceCol eq source)
+        }.singleOrNull()?.toInstrumentAliasEntity()
+    }
+
+    suspend fun listAll(limit: Int, offset: Long = 0): List<InstrumentEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        InstrumentsTable.selectAll()
+            .orderBy(InstrumentsTable.createdAt, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toInstrumentEntity() }
+    }
+}

--- a/storage/src/main/kotlin/repo/PortfolioRepository.kt
+++ b/storage/src/main/kotlin/repo/PortfolioRepository.kt
@@ -1,0 +1,83 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.util.UUID
+import org.jetbrains.exposed.sql.LowerCase
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
+import repo.mapper.setValues
+import repo.mapper.toColumnValues
+import repo.mapper.toPortfolioEntity
+import repo.model.NewPortfolio
+import repo.model.PortfolioEntity
+import repo.model.PortfolioUpdate
+import repo.tables.PortfoliosTable
+
+class PortfolioRepository {
+    suspend fun create(newPortfolio: NewPortfolio): PortfolioEntity = dbQuery {
+        val statement = PortfoliosTable.insert {
+            it.setValues(newPortfolio.toColumnValues())
+        }
+        statement.resultedValues?.singleOrNull()?.toPortfolioEntity()
+            ?: error("Failed to insert portfolio")
+    }
+
+    suspend fun findById(portfolioId: UUID): PortfolioEntity? = dbQuery {
+        PortfoliosTable.select { PortfoliosTable.portfolioId eq portfolioId }
+            .singleOrNull()?.toPortfolioEntity()
+    }
+
+    suspend fun findByUser(userId: Long, limit: Int, offset: Long = 0): List<PortfolioEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        PortfoliosTable.select { PortfoliosTable.userId eq userId }
+            .orderBy(PortfoliosTable.createdAt, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toPortfolioEntity() }
+    }
+
+    suspend fun listAll(limit: Int, offset: Long = 0): List<PortfolioEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        PortfoliosTable.selectAll()
+            .orderBy(PortfoliosTable.createdAt, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toPortfolioEntity() }
+    }
+
+    suspend fun searchByName(userId: Long, query: String, limit: Int, offset: Long = 0): List<PortfolioEntity> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        val pattern = "%${query.lowercase()}%"
+        PortfoliosTable.select {
+            (PortfoliosTable.userId eq userId) and (LowerCase(PortfoliosTable.name) like pattern)
+        }
+            .orderBy(PortfoliosTable.name, SortOrder.ASC)
+            .limit(limit, offset)
+            .map { it.toPortfolioEntity() }
+    }
+
+    suspend fun update(portfolioId: UUID, update: PortfolioUpdate): PortfolioEntity? = dbQuery {
+        val values = update.toColumnValues()
+        if (values.isEmpty()) {
+            return@dbQuery findById(portfolioId)
+        }
+        val updated = PortfoliosTable.update({ PortfoliosTable.portfolioId eq portfolioId }) {
+            it.setValues(values)
+        }
+        if (updated > 0) {
+            PortfoliosTable.select { PortfoliosTable.portfolioId eq portfolioId }
+                .singleOrNull()?.toPortfolioEntity()
+        } else {
+            null
+        }
+    }
+
+    suspend fun delete(portfolioId: UUID): Boolean = dbQuery {
+        PortfoliosTable.deleteWhere { PortfoliosTable.portfolioId eq portfolioId } > 0
+    }
+}

--- a/storage/src/main/kotlin/repo/PositionRepository.kt
+++ b/storage/src/main/kotlin/repo/PositionRepository.kt
@@ -1,0 +1,52 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.util.UUID
+import model.PositionDto
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import repo.mapper.setValues
+import repo.mapper.toInsertValues
+import repo.mapper.toPositionDto
+import repo.mapper.toUpdateValues
+import repo.tables.PositionsTable
+
+class PositionRepository {
+    suspend fun save(position: PositionDto): PositionDto = dbQuery {
+        val predicate = (PositionsTable.portfolioId eq position.portfolioId) and
+            (PositionsTable.instrumentId eq position.instrumentId)
+        val updated = PositionsTable.update({ predicate }) {
+            it.setValues(position.toUpdateValues())
+        }
+        if (updated == 0) {
+            PositionsTable.insert {
+                it.setValues(position.toInsertValues())
+            }
+        }
+        PositionsTable.select { predicate }.single().toPositionDto()
+    }
+
+    suspend fun find(portfolioId: UUID, instrumentId: Long): PositionDto? = dbQuery {
+        val predicate = (PositionsTable.portfolioId eq portfolioId) and (PositionsTable.instrumentId eq instrumentId)
+        PositionsTable.select { predicate }.singleOrNull()?.toPositionDto()
+    }
+
+    suspend fun list(portfolioId: UUID, limit: Int, offset: Long = 0): List<PositionDto> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        PositionsTable.select { PositionsTable.portfolioId eq portfolioId }
+            .orderBy(PositionsTable.instrumentId, SortOrder.ASC)
+            .limit(limit, offset)
+            .map { it.toPositionDto() }
+    }
+
+    suspend fun delete(portfolioId: UUID, instrumentId: Long): Boolean = dbQuery {
+        PositionsTable.deleteWhere {
+            (PositionsTable.portfolioId eq portfolioId) and (PositionsTable.instrumentId eq instrumentId)
+        } > 0
+    }
+}

--- a/storage/src/main/kotlin/repo/TradeRepository.kt
+++ b/storage/src/main/kotlin/repo/TradeRepository.kt
@@ -1,0 +1,100 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.time.Instant
+import java.util.UUID
+import model.TradeDto
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.lessEq
+import repo.mapper.setValues
+import repo.mapper.toColumnValues
+import repo.mapper.toDbTimestamp
+import repo.mapper.toTradeDto
+import repo.model.NewTrade
+import repo.model.TradeUpdate
+import repo.tables.TradesTable
+
+class TradeRepository {
+    suspend fun createTrade(newTrade: NewTrade): TradeDto = dbQuery {
+        val statement = TradesTable.insert {
+            it.setValues(newTrade.toColumnValues())
+        }
+        statement.resultedValues?.singleOrNull()?.toTradeDto()
+            ?: error("Failed to insert trade")
+    }
+
+    suspend fun updateTrade(tradeId: Long, update: TradeUpdate): TradeDto? = dbQuery {
+        val values = update.toColumnValues()
+        if (values.isEmpty()) {
+            return@dbQuery findById(tradeId)
+        }
+        val updated = TradesTable.update({ TradesTable.tradeId eq tradeId }) {
+            it.setValues(values)
+        }
+        if (updated > 0) {
+            TradesTable.select { TradesTable.tradeId eq tradeId }
+                .singleOrNull()?.toTradeDto()
+        } else {
+            null
+        }
+    }
+
+    suspend fun deleteTrade(tradeId: Long): Boolean = dbQuery {
+        TradesTable.deleteWhere { TradesTable.tradeId eq tradeId } > 0
+    }
+
+    suspend fun findById(tradeId: Long): TradeDto? = dbQuery {
+        TradesTable.select { TradesTable.tradeId eq tradeId }
+            .singleOrNull()?.toTradeDto()
+    }
+
+    suspend fun findByExternalId(extId: String): TradeDto? = dbQuery {
+        TradesTable.select { TradesTable.extId eq extId }
+            .singleOrNull()?.toTradeDto()
+    }
+
+    suspend fun listByPortfolio(portfolioId: UUID, limit: Int, offset: Long = 0): List<TradeDto> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        TradesTable.select { TradesTable.portfolioId eq portfolioId }
+            .orderBy(TradesTable.datetime, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toTradeDto() }
+    }
+
+    suspend fun listByInstrument(instrumentId: Long, limit: Int, offset: Long = 0): List<TradeDto> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        TradesTable.select { TradesTable.instrumentId eq instrumentId }
+            .orderBy(TradesTable.datetime, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toTradeDto() }
+    }
+
+    suspend fun listByPeriod(
+        portfolioId: UUID,
+        from: Instant?,
+        to: Instant?,
+        limit: Int,
+        offset: Long = 0,
+    ): List<TradeDto> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        val condition = when {
+            from != null && to != null -> TradesTable.datetime.between(from.toDbTimestamp(), to.toDbTimestamp())
+            from != null -> TradesTable.datetime greaterEq from.toDbTimestamp()
+            to != null -> TradesTable.datetime lessEq to.toDbTimestamp()
+            else -> null
+        }
+        val op = condition?.let { (TradesTable.portfolioId eq portfolioId) and it } ?: (TradesTable.portfolioId eq portfolioId)
+        TradesTable.select { op }
+            .orderBy(TradesTable.datetime, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toTradeDto() }
+    }
+}

--- a/storage/src/main/kotlin/repo/ValuationRepository.kt
+++ b/storage/src/main/kotlin/repo/ValuationRepository.kt
@@ -1,0 +1,74 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.time.LocalDate
+import java.util.UUID
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.lessEq
+import portfolio.model.DateRange
+import repo.mapper.setValues
+import repo.mapper.toColumnValues
+import repo.mapper.toValuationDailyRecord
+import repo.model.NewValuationDaily
+import repo.model.ValuationDailyRecord
+import repo.tables.ValuationsDailyTable
+
+class ValuationRepository {
+    suspend fun upsert(record: NewValuationDaily): ValuationDailyRecord = dbQuery {
+        val predicate = (ValuationsDailyTable.portfolioId eq record.portfolioId) and
+            (ValuationsDailyTable.date eq record.date)
+        val updated = ValuationsDailyTable.update({ predicate }) {
+            it.setValues(record.toColumnValues())
+        }
+        if (updated == 0) {
+            ValuationsDailyTable.insert {
+                it.setValues(record.toColumnValues())
+            }
+        }
+        ValuationsDailyTable.select { predicate }.single().toValuationDailyRecord()
+    }
+
+    suspend fun find(portfolioId: UUID, date: LocalDate): ValuationDailyRecord? = dbQuery {
+        ValuationsDailyTable.select {
+            (ValuationsDailyTable.portfolioId eq portfolioId) and (ValuationsDailyTable.date eq date)
+        }.singleOrNull()?.toValuationDailyRecord()
+    }
+
+    suspend fun list(portfolioId: UUID, limit: Int, offset: Long = 0): List<ValuationDailyRecord> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        ValuationsDailyTable.select { ValuationsDailyTable.portfolioId eq portfolioId }
+            .orderBy(ValuationsDailyTable.date, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toValuationDailyRecord() }
+    }
+
+    suspend fun listRange(
+        portfolioId: UUID,
+        range: DateRange,
+        limit: Int,
+        offset: Long = 0,
+    ): List<ValuationDailyRecord> = dbQuery {
+        require(limit > 0) { "limit must be positive" }
+        ValuationsDailyTable.select {
+            (ValuationsDailyTable.portfolioId eq portfolioId) and
+                (ValuationsDailyTable.date greaterEq range.from) and
+                (ValuationsDailyTable.date lessEq range.to)
+        }
+            .orderBy(ValuationsDailyTable.date, SortOrder.DESC)
+            .limit(limit, offset)
+            .map { it.toValuationDailyRecord() }
+    }
+
+    suspend fun delete(portfolioId: UUID, date: LocalDate): Boolean = dbQuery {
+        ValuationsDailyTable.deleteWhere {
+            (ValuationsDailyTable.portfolioId eq portfolioId) and (ValuationsDailyTable.date eq date)
+        } > 0
+    }
+}

--- a/storage/src/main/kotlin/repo/mapper/FxRateMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/FxRateMapper.kt
@@ -1,0 +1,20 @@
+package repo.mapper
+
+import model.FxRate
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.tables.FxRatesTable
+
+fun ResultRow.toFxRate(): FxRate = FxRate(
+    ccy = this[FxRatesTable.ccy],
+    ts = this[FxRatesTable.ts].toInstant(),
+    rateRub = this[FxRatesTable.rateRub],
+    source = this[FxRatesTable.sourceCol],
+)
+
+fun FxRate.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    FxRatesTable.ccy to ccy,
+    FxRatesTable.ts to ts.toDbTimestamp(),
+    FxRatesTable.rateRub to rateRub,
+    FxRatesTable.sourceCol to source,
+)

--- a/storage/src/main/kotlin/repo/mapper/InstrumentMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/InstrumentMapper.kt
@@ -1,0 +1,59 @@
+package repo.mapper
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.InstrumentAliasEntity
+import repo.model.InstrumentEntity
+import repo.model.InstrumentUpdate
+import repo.model.NewInstrument
+import repo.model.NewInstrumentAlias
+import repo.tables.InstrumentAliasesTable
+import repo.tables.InstrumentsTable
+
+fun ResultRow.toInstrumentEntity(): InstrumentEntity = InstrumentEntity(
+    instrumentId = this[InstrumentsTable.instrumentId],
+    clazz = this[InstrumentsTable.clazz],
+    exchange = this[InstrumentsTable.exchange],
+    board = this[InstrumentsTable.board],
+    symbol = this[InstrumentsTable.symbol],
+    isin = this[InstrumentsTable.isin],
+    cgId = this[InstrumentsTable.cgId],
+    currency = this[InstrumentsTable.currency],
+    createdAt = this[InstrumentsTable.createdAt].toInstant(),
+)
+
+fun NewInstrument.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    InstrumentsTable.clazz to clazz,
+    InstrumentsTable.exchange to exchange,
+    InstrumentsTable.board to board,
+    InstrumentsTable.symbol to symbol,
+    InstrumentsTable.isin to isin,
+    InstrumentsTable.cgId to cgId,
+    InstrumentsTable.currency to currency,
+    InstrumentsTable.createdAt to createdAt.toDbTimestamp(),
+)
+
+fun InstrumentUpdate.toColumnValues(): Map<Column<*>, Any?> {
+    val values = mutableMapOf<Column<*>, Any?>()
+    clazz?.let { values[InstrumentsTable.clazz] = it }
+    exchange?.let { values[InstrumentsTable.exchange] = it }
+    board?.let { values[InstrumentsTable.board] = it }
+    symbol?.let { values[InstrumentsTable.symbol] = it }
+    isin?.let { values[InstrumentsTable.isin] = it }
+    cgId?.let { values[InstrumentsTable.cgId] = it }
+    currency?.let { values[InstrumentsTable.currency] = it }
+    return values
+}
+
+fun ResultRow.toInstrumentAliasEntity(): InstrumentAliasEntity = InstrumentAliasEntity(
+    aliasId = this[InstrumentAliasesTable.aliasId],
+    instrumentId = this[InstrumentAliasesTable.instrumentId],
+    alias = this[InstrumentAliasesTable.alias],
+    source = this[InstrumentAliasesTable.sourceCol],
+)
+
+fun NewInstrumentAlias.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    InstrumentAliasesTable.instrumentId to instrumentId,
+    InstrumentAliasesTable.alias to alias,
+    InstrumentAliasesTable.sourceCol to source,
+)

--- a/storage/src/main/kotlin/repo/mapper/MapperExtensions.kt
+++ b/storage/src/main/kotlin/repo/mapper/MapperExtensions.kt
@@ -1,0 +1,16 @@
+package repo.mapper
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.statements.UpdateBuilder
+
+internal fun Instant.toDbTimestamp(): OffsetDateTime = OffsetDateTime.ofInstant(this, ZoneOffset.UTC)
+
+@Suppress("UNCHECKED_CAST")
+internal fun UpdateBuilder<*>.setValues(values: Map<Column<*>, Any?>) {
+    values.forEach { (column, value) ->
+        this[column as Column<Any?>] = value
+    }
+}

--- a/storage/src/main/kotlin/repo/mapper/PortfolioMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/PortfolioMapper.kt
@@ -1,0 +1,33 @@
+package repo.mapper
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.NewPortfolio
+import repo.model.PortfolioEntity
+import repo.model.PortfolioUpdate
+import repo.tables.PortfoliosTable
+
+fun ResultRow.toPortfolioEntity(): PortfolioEntity = PortfolioEntity(
+    portfolioId = this[PortfoliosTable.portfolioId],
+    userId = this[PortfoliosTable.userId],
+    name = this[PortfoliosTable.name],
+    baseCurrency = this[PortfoliosTable.baseCurrency],
+    isActive = this[PortfoliosTable.isActive],
+    createdAt = this[PortfoliosTable.createdAt].toInstant(),
+)
+
+fun NewPortfolio.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    PortfoliosTable.userId to userId,
+    PortfoliosTable.name to name,
+    PortfoliosTable.baseCurrency to baseCurrency,
+    PortfoliosTable.isActive to isActive,
+    PortfoliosTable.createdAt to createdAt.toDbTimestamp(),
+)
+
+fun PortfolioUpdate.toColumnValues(): Map<Column<*>, Any?> {
+    val values = mutableMapOf<Column<*>, Any?>()
+    name?.let { values[PortfoliosTable.name] = it }
+    baseCurrency?.let { values[PortfoliosTable.baseCurrency] = it }
+    isActive?.let { values[PortfoliosTable.isActive] = it }
+    return values
+}

--- a/storage/src/main/kotlin/repo/mapper/PositionMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/PositionMapper.kt
@@ -1,0 +1,31 @@
+package repo.mapper
+
+import model.PositionDto
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.tables.PositionsTable
+
+fun ResultRow.toPositionDto(): PositionDto = PositionDto(
+    portfolioId = this[PositionsTable.portfolioId],
+    instrumentId = this[PositionsTable.instrumentId],
+    qty = this[PositionsTable.qty],
+    avgPrice = this[PositionsTable.avgPrice],
+    avgPriceCcy = this[PositionsTable.avgPriceCcy],
+    updatedAt = this[PositionsTable.updatedAt].toInstant(),
+)
+
+fun PositionDto.toInsertValues(): Map<Column<*>, Any?> = mapOf(
+    PositionsTable.portfolioId to portfolioId,
+    PositionsTable.instrumentId to instrumentId,
+    PositionsTable.qty to qty,
+    PositionsTable.avgPrice to avgPrice,
+    PositionsTable.avgPriceCcy to avgPriceCcy,
+    PositionsTable.updatedAt to updatedAt.toDbTimestamp(),
+)
+
+fun PositionDto.toUpdateValues(): Map<Column<*>, Any?> = mapOf(
+    PositionsTable.qty to qty,
+    PositionsTable.avgPrice to avgPrice,
+    PositionsTable.avgPriceCcy to avgPriceCcy,
+    PositionsTable.updatedAt to updatedAt.toDbTimestamp(),
+)

--- a/storage/src/main/kotlin/repo/mapper/PriceMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/PriceMapper.kt
@@ -1,0 +1,22 @@
+package repo.mapper
+
+import model.PricePoint
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.tables.PricesTable
+
+fun ResultRow.toPricePoint(): PricePoint = PricePoint(
+    instrumentId = this[PricesTable.instrumentId],
+    ts = this[PricesTable.ts].toInstant(),
+    price = this[PricesTable.price],
+    ccy = this[PricesTable.ccy],
+    source = this[PricesTable.sourceCol],
+)
+
+fun PricePoint.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    PricesTable.instrumentId to instrumentId,
+    PricesTable.ts to ts.toDbTimestamp(),
+    PricesTable.price to price,
+    PricesTable.ccy to ccy,
+    PricesTable.sourceCol to source,
+)

--- a/storage/src/main/kotlin/repo/mapper/TradeMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/TradeMapper.kt
@@ -1,0 +1,64 @@
+package repo.mapper
+
+import model.TradeDto
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.NewTrade
+import repo.model.TradeUpdate
+import repo.tables.TradesTable
+
+fun ResultRow.toTradeDto(): TradeDto = TradeDto(
+    tradeId = this[TradesTable.tradeId],
+    portfolioId = this[TradesTable.portfolioId],
+    instrumentId = this[TradesTable.instrumentId],
+    datetime = this[TradesTable.datetime].toInstant(),
+    side = this[TradesTable.side],
+    quantity = this[TradesTable.quantity],
+    price = this[TradesTable.price],
+    priceCurrency = this[TradesTable.priceCurrency],
+    fee = this[TradesTable.fee],
+    feeCurrency = this[TradesTable.feeCurrency],
+    tax = this[TradesTable.tax],
+    taxCurrency = this[TradesTable.taxCurrency],
+    broker = this[TradesTable.broker],
+    note = this[TradesTable.note],
+    extId = this[TradesTable.extId],
+    createdAt = this[TradesTable.createdAt].toInstant(),
+)
+
+fun NewTrade.toColumnValues(): Map<Column<*>, Any?> {
+    val values = mutableMapOf<Column<*>, Any?>(
+        TradesTable.portfolioId to portfolioId,
+        TradesTable.instrumentId to instrumentId,
+        TradesTable.datetime to datetime.toDbTimestamp(),
+        TradesTable.side to side,
+        TradesTable.quantity to quantity,
+        TradesTable.price to price,
+        TradesTable.priceCurrency to priceCurrency,
+        TradesTable.fee to fee,
+        TradesTable.feeCurrency to feeCurrency,
+        TradesTable.createdAt to createdAt.toDbTimestamp(),
+    )
+    tax?.let { values[TradesTable.tax] = it }
+    taxCurrency?.let { values[TradesTable.taxCurrency] = it }
+    broker?.let { values[TradesTable.broker] = it }
+    note?.let { values[TradesTable.note] = it }
+    extId?.let { values[TradesTable.extId] = it }
+    return values
+}
+
+fun TradeUpdate.toColumnValues(): Map<Column<*>, Any?> {
+    val values = mutableMapOf<Column<*>, Any?>()
+    datetime?.let { values[TradesTable.datetime] = it.toDbTimestamp() }
+    side?.let { values[TradesTable.side] = it }
+    quantity?.let { values[TradesTable.quantity] = it }
+    price?.let { values[TradesTable.price] = it }
+    priceCurrency?.let { values[TradesTable.priceCurrency] = it }
+    fee?.let { values[TradesTable.fee] = it }
+    feeCurrency?.let { values[TradesTable.feeCurrency] = it }
+    tax?.let { values[TradesTable.tax] = it }
+    taxCurrency?.let { values[TradesTable.taxCurrency] = it }
+    broker?.let { values[TradesTable.broker] = it }
+    note?.let { values[TradesTable.note] = it }
+    return values
+}

--- a/storage/src/main/kotlin/repo/mapper/UserMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/UserMapper.kt
@@ -1,0 +1,18 @@
+package repo.mapper
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.NewUser
+import repo.model.UserEntity
+import repo.tables.UsersTable
+
+fun ResultRow.toUserEntity(): UserEntity = UserEntity(
+    userId = this[UsersTable.userId],
+    telegramUserId = this[UsersTable.tgUserId],
+    createdAt = this[UsersTable.createdAt].toInstant(),
+)
+
+fun NewUser.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    UsersTable.tgUserId to telegramUserId,
+    UsersTable.createdAt to createdAt.toDbTimestamp(),
+)

--- a/storage/src/main/kotlin/repo/mapper/ValuationMapper.kt
+++ b/storage/src/main/kotlin/repo/mapper/ValuationMapper.kt
@@ -1,0 +1,25 @@
+package repo.mapper
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import repo.model.NewValuationDaily
+import repo.model.ValuationDailyRecord
+import repo.tables.ValuationsDailyTable
+
+fun ResultRow.toValuationDailyRecord(): ValuationDailyRecord = ValuationDailyRecord(
+    portfolioId = this[ValuationsDailyTable.portfolioId],
+    date = this[ValuationsDailyTable.date],
+    valueRub = this[ValuationsDailyTable.valueRub],
+    pnlDay = this[ValuationsDailyTable.pnlDay],
+    pnlTotal = this[ValuationsDailyTable.pnlTotal],
+    drawdown = this[ValuationsDailyTable.drawdown],
+)
+
+fun NewValuationDaily.toColumnValues(): Map<Column<*>, Any?> = mapOf(
+    ValuationsDailyTable.portfolioId to portfolioId,
+    ValuationsDailyTable.date to date,
+    ValuationsDailyTable.valueRub to valueRub,
+    ValuationsDailyTable.pnlDay to pnlDay,
+    ValuationsDailyTable.pnlTotal to pnlTotal,
+    ValuationsDailyTable.drawdown to drawdown,
+)

--- a/storage/src/main/kotlin/repo/model/InstrumentModels.kt
+++ b/storage/src/main/kotlin/repo/model/InstrumentModels.kt
@@ -1,0 +1,54 @@
+package repo.model
+
+import java.time.Instant
+
+/** Row model for the [repo.tables.InstrumentsTable]. */
+data class InstrumentEntity(
+    val instrumentId: Long,
+    val clazz: String,
+    val exchange: String,
+    val board: String?,
+    val symbol: String,
+    val isin: String?,
+    val cgId: String?,
+    val currency: String,
+    val createdAt: Instant,
+)
+
+/** Creation payload for instruments. */
+data class NewInstrument(
+    val clazz: String,
+    val exchange: String,
+    val board: String?,
+    val symbol: String,
+    val isin: String?,
+    val cgId: String?,
+    val currency: String,
+    val createdAt: Instant = Instant.now(),
+)
+
+/** Update payload for instruments. */
+data class InstrumentUpdate(
+    val clazz: String? = null,
+    val exchange: String? = null,
+    val board: String? = null,
+    val symbol: String? = null,
+    val isin: String? = null,
+    val cgId: String? = null,
+    val currency: String? = null,
+)
+
+/** Row model for the [repo.tables.InstrumentAliasesTable]. */
+data class InstrumentAliasEntity(
+    val aliasId: Long,
+    val instrumentId: Long,
+    val alias: String,
+    val source: String,
+)
+
+/** Creation payload for instrument aliases. */
+data class NewInstrumentAlias(
+    val instrumentId: Long,
+    val alias: String,
+    val source: String,
+)

--- a/storage/src/main/kotlin/repo/model/PortfolioModels.kt
+++ b/storage/src/main/kotlin/repo/model/PortfolioModels.kt
@@ -1,0 +1,30 @@
+package repo.model
+
+import java.time.Instant
+import java.util.UUID
+
+/** Row model for the [repo.tables.PortfoliosTable]. */
+data class PortfolioEntity(
+    val portfolioId: UUID,
+    val userId: Long,
+    val name: String,
+    val baseCurrency: String,
+    val isActive: Boolean,
+    val createdAt: Instant,
+)
+
+/** Payload for creating a new portfolio. */
+data class NewPortfolio(
+    val userId: Long,
+    val name: String,
+    val baseCurrency: String,
+    val isActive: Boolean = true,
+    val createdAt: Instant = Instant.now(),
+)
+
+/** Payload for updating a portfolio. */
+data class PortfolioUpdate(
+    val name: String? = null,
+    val baseCurrency: String? = null,
+    val isActive: Boolean? = null,
+)

--- a/storage/src/main/kotlin/repo/model/TradeModels.kt
+++ b/storage/src/main/kotlin/repo/model/TradeModels.kt
@@ -1,0 +1,39 @@
+package repo.model
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/** Payload for inserting new trades. */
+data class NewTrade(
+    val portfolioId: UUID,
+    val instrumentId: Long,
+    val datetime: Instant,
+    val side: String,
+    val quantity: BigDecimal,
+    val price: BigDecimal,
+    val priceCurrency: String,
+    val fee: BigDecimal,
+    val feeCurrency: String,
+    val tax: BigDecimal?,
+    val taxCurrency: String?,
+    val broker: String?,
+    val note: String?,
+    val extId: String?,
+    val createdAt: Instant = Instant.now(),
+)
+
+/** Payload for updating a trade. */
+data class TradeUpdate(
+    val datetime: Instant? = null,
+    val side: String? = null,
+    val quantity: BigDecimal? = null,
+    val price: BigDecimal? = null,
+    val priceCurrency: String? = null,
+    val fee: BigDecimal? = null,
+    val feeCurrency: String? = null,
+    val tax: BigDecimal? = null,
+    val taxCurrency: String? = null,
+    val broker: String? = null,
+    val note: String? = null,
+)

--- a/storage/src/main/kotlin/repo/model/UserModels.kt
+++ b/storage/src/main/kotlin/repo/model/UserModels.kt
@@ -1,0 +1,16 @@
+package repo.model
+
+import java.time.Instant
+
+/** Represents a persisted application user. */
+data class UserEntity(
+    val userId: Long,
+    val telegramUserId: Long?,
+    val createdAt: Instant,
+)
+
+/** Payload for creating a user row. */
+data class NewUser(
+    val telegramUserId: Long?,
+    val createdAt: Instant = Instant.now(),
+)

--- a/storage/src/main/kotlin/repo/model/ValuationModels.kt
+++ b/storage/src/main/kotlin/repo/model/ValuationModels.kt
@@ -1,0 +1,25 @@
+package repo.model
+
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+/** Row model for the [repo.tables.ValuationsDailyTable]. */
+data class ValuationDailyRecord(
+    val portfolioId: UUID,
+    val date: LocalDate,
+    val valueRub: BigDecimal,
+    val pnlDay: BigDecimal,
+    val pnlTotal: BigDecimal,
+    val drawdown: BigDecimal,
+)
+
+/** Creation payload for valuations. */
+data class NewValuationDaily(
+    val portfolioId: UUID,
+    val date: LocalDate,
+    val valueRub: BigDecimal,
+    val pnlDay: BigDecimal,
+    val pnlTotal: BigDecimal,
+    val drawdown: BigDecimal,
+)

--- a/storage/src/main/kotlin/repo/tables/FxRatesTable.kt
+++ b/storage/src/main/kotlin/repo/tables/FxRatesTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.FxRatesTable as DbFxRatesTable
+
+val FxRatesTable = DbFxRatesTable

--- a/storage/src/main/kotlin/repo/tables/InstrumentAliasesTable.kt
+++ b/storage/src/main/kotlin/repo/tables/InstrumentAliasesTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.InstrumentAliasesTable as DbInstrumentAliasesTable
+
+val InstrumentAliasesTable = DbInstrumentAliasesTable

--- a/storage/src/main/kotlin/repo/tables/InstrumentsTable.kt
+++ b/storage/src/main/kotlin/repo/tables/InstrumentsTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.InstrumentsTable as DbInstrumentsTable
+
+val InstrumentsTable = DbInstrumentsTable

--- a/storage/src/main/kotlin/repo/tables/PortfoliosTable.kt
+++ b/storage/src/main/kotlin/repo/tables/PortfoliosTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.PortfoliosTable as DbPortfoliosTable
+
+val PortfoliosTable = DbPortfoliosTable

--- a/storage/src/main/kotlin/repo/tables/PositionsTable.kt
+++ b/storage/src/main/kotlin/repo/tables/PositionsTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.PositionsTable as DbPositionsTable
+
+val PositionsTable = DbPositionsTable

--- a/storage/src/main/kotlin/repo/tables/PricesTable.kt
+++ b/storage/src/main/kotlin/repo/tables/PricesTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.PricesTable as DbPricesTable
+
+val PricesTable = DbPricesTable

--- a/storage/src/main/kotlin/repo/tables/TradesTable.kt
+++ b/storage/src/main/kotlin/repo/tables/TradesTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.TradesTable as DbTradesTable
+
+val TradesTable = DbTradesTable

--- a/storage/src/main/kotlin/repo/tables/UsersTable.kt
+++ b/storage/src/main/kotlin/repo/tables/UsersTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.UsersTable as DbUsersTable
+
+val UsersTable = DbUsersTable

--- a/storage/src/main/kotlin/repo/tables/ValuationsDailyTable.kt
+++ b/storage/src/main/kotlin/repo/tables/ValuationsDailyTable.kt
@@ -1,0 +1,5 @@
+package repo.tables
+
+import db.tables.ValuationsDailyTable as DbValuationsDailyTable
+
+val ValuationsDailyTable = DbValuationsDailyTable

--- a/storage/src/test/kotlin/repo/RepositorySignatureTest.kt
+++ b/storage/src/test/kotlin/repo/RepositorySignatureTest.kt
@@ -1,0 +1,77 @@
+package repo
+
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class RepositorySignatureTest {
+    @Test
+    fun `portfolio repository exposes expected API`() {
+        val functions = PortfolioRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(functions.containsAll(listOf("create", "findById", "findByUser", "listAll", "searchByName", "update", "delete")))
+    }
+
+    @Test
+    fun `instrument repository exposes expected API`() {
+        val functions = InstrumentRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(
+            functions.containsAll(
+                listOf(
+                    "createInstrument",
+                    "updateInstrument",
+                    "deleteInstrument",
+                    "findById",
+                    "findByIsin",
+                    "findBySymbol",
+                    "search",
+                    "listAliases",
+                    "addAlias",
+                    "removeAlias",
+                    "findAlias",
+                    "listAll",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `trade repository exposes expected API`() {
+        val functions = TradeRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(
+            functions.containsAll(
+                listOf(
+                    "createTrade",
+                    "updateTrade",
+                    "deleteTrade",
+                    "findById",
+                    "findByExternalId",
+                    "listByPortfolio",
+                    "listByInstrument",
+                    "listByPeriod",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `position repository exposes expected API`() {
+        val functions = PositionRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(functions.containsAll(listOf("save", "find", "list", "delete")))
+    }
+
+    @Test
+    fun `fx rate repository exposes expected API`() {
+        val functions = FxRateRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(
+            functions.containsAll(
+                listOf("upsert", "findOnOrBefore", "findLatest", "find", "list", "delete"),
+            ),
+        )
+    }
+
+    @Test
+    fun `valuation repository exposes expected API`() {
+        val functions = ValuationRepository::class.declaredMemberFunctions.map { it.name }.toSet()
+        assertTrue(functions.containsAll(listOf("upsert", "find", "list", "listRange", "delete")))
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/FxRateMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/FxRateMapperTest.kt
@@ -1,0 +1,43 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import model.FxRate
+import repo.tables.FxRatesTable
+
+class FxRateMapperTest {
+    @Test
+    fun `maps result row to fx rate`() {
+        val ts = Instant.parse("2024-08-01T08:00:00Z")
+        val row = testResultRow(
+            FxRatesTable.ccy to "USD",
+            FxRatesTable.ts to OffsetDateTime.ofInstant(ts, ZoneOffset.UTC),
+            FxRatesTable.rateRub to BigDecimal("93.45"),
+            FxRatesTable.sourceCol to "cbr",
+        )
+
+        val rate = row.toFxRate()
+
+        assertEquals("USD", rate.ccy)
+        assertEquals(ts, rate.ts)
+        assertEquals(BigDecimal("93.45"), rate.rateRub.stripTrailingZeros())
+        assertEquals("cbr", rate.source)
+    }
+
+    @Test
+    fun `maps fx rate to column values`() {
+        val ts = Instant.parse("2024-08-01T08:00:00Z")
+        val rate = FxRate(ccy = "EUR", ts = ts, rateRub = BigDecimal("100.12"), source = "market")
+
+        val values = rate.toColumnValues()
+
+        assertEquals("EUR", values[FxRatesTable.ccy])
+        assertEquals(OffsetDateTime.ofInstant(ts, ZoneOffset.UTC), values[FxRatesTable.ts])
+        assertEquals(BigDecimal("100.12"), values[FxRatesTable.rateRub])
+        assertEquals("market", values[FxRatesTable.sourceCol])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/InstrumentMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/InstrumentMapperTest.kt
@@ -1,0 +1,102 @@
+package repo.mapper
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import repo.model.InstrumentUpdate
+import repo.model.NewInstrument
+import repo.model.NewInstrumentAlias
+import repo.tables.InstrumentAliasesTable
+import repo.tables.InstrumentsTable
+
+class InstrumentMapperTest {
+    @Test
+    fun `maps result row to instrument entity`() {
+        val createdAt = Instant.parse("2024-05-15T09:00:00Z")
+        val row = testResultRow(
+            InstrumentsTable.instrumentId to 10L,
+            InstrumentsTable.clazz to "stock",
+            InstrumentsTable.exchange to "MOEX",
+            InstrumentsTable.board to "TQBR",
+            InstrumentsTable.symbol to "SBER",
+            InstrumentsTable.isin to "RU0009029540",
+            InstrumentsTable.cgId to "cg-123",
+            InstrumentsTable.currency to "RUB",
+            InstrumentsTable.createdAt to OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC),
+        )
+
+        val entity = row.toInstrumentEntity()
+
+        assertEquals(10L, entity.instrumentId)
+        assertEquals("stock", entity.clazz)
+        assertEquals("MOEX", entity.exchange)
+        assertEquals("TQBR", entity.board)
+        assertEquals("SBER", entity.symbol)
+        assertEquals("RU0009029540", entity.isin)
+        assertEquals("cg-123", entity.cgId)
+        assertEquals("RUB", entity.currency)
+        assertEquals(createdAt, entity.createdAt)
+    }
+
+    @Test
+    fun `maps new instrument to column values`() {
+        val createdAt = Instant.parse("2024-05-15T09:00:00Z")
+        val payload = NewInstrument(
+            clazz = "bond",
+            exchange = "NYSE",
+            board = null,
+            symbol = "TSLA",
+            isin = null,
+            cgId = null,
+            currency = "USD",
+            createdAt = createdAt,
+        )
+
+        val values = payload.toColumnValues()
+
+        assertEquals("bond", values[InstrumentsTable.clazz])
+        assertEquals("NYSE", values[InstrumentsTable.exchange])
+        assertEquals(null, values[InstrumentsTable.board])
+        assertEquals("TSLA", values[InstrumentsTable.symbol])
+        assertEquals(null, values[InstrumentsTable.isin])
+        assertEquals("USD", values[InstrumentsTable.currency])
+        assertEquals(OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC), values[InstrumentsTable.createdAt])
+    }
+
+    @Test
+    fun `maps instrument update`() {
+        val update = InstrumentUpdate(clazz = "etf", symbol = "FXUS")
+
+        val values = update.toColumnValues()
+
+        assertEquals(2, values.size)
+        assertEquals("etf", values[InstrumentsTable.clazz])
+        assertEquals("FXUS", values[InstrumentsTable.symbol])
+        assertFalse(values.containsKey(InstrumentsTable.currency))
+    }
+
+    @Test
+    fun `maps instrument alias`() {
+        val row = testResultRow(
+            InstrumentAliasesTable.aliasId to 5L,
+            InstrumentAliasesTable.instrumentId to 10L,
+            InstrumentAliasesTable.alias to "SBERP",
+            InstrumentAliasesTable.sourceCol to "manual",
+        )
+
+        val alias = row.toInstrumentAliasEntity()
+
+        assertEquals(5L, alias.aliasId)
+        assertEquals(10L, alias.instrumentId)
+        assertEquals("SBERP", alias.alias)
+        assertEquals("manual", alias.source)
+
+        val insertValues = NewInstrumentAlias(instrumentId = 20L, alias = "GAZP", source = "import").toColumnValues()
+        assertEquals(20L, insertValues[InstrumentAliasesTable.instrumentId])
+        assertEquals("GAZP", insertValues[InstrumentAliasesTable.alias])
+        assertEquals("import", insertValues[InstrumentAliasesTable.sourceCol])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/PortfolioMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/PortfolioMapperTest.kt
@@ -1,0 +1,64 @@
+package repo.mapper
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import repo.model.NewPortfolio
+import repo.model.PortfolioUpdate
+import repo.tables.PortfoliosTable
+
+class PortfolioMapperTest {
+    @Test
+    fun `maps result row to portfolio entity`() {
+        val portfolioId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+        val createdAt = Instant.parse("2024-01-02T00:00:00Z")
+        val row = testResultRow(
+            PortfoliosTable.portfolioId to portfolioId,
+            PortfoliosTable.userId to 77L,
+            PortfoliosTable.name to "Retirement",
+            PortfoliosTable.baseCurrency to "USD",
+            PortfoliosTable.isActive to true,
+            PortfoliosTable.createdAt to OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC),
+        )
+
+        val entity = row.toPortfolioEntity()
+
+        assertEquals(portfolioId, entity.portfolioId)
+        assertEquals(77L, entity.userId)
+        assertEquals("Retirement", entity.name)
+        assertEquals("USD", entity.baseCurrency)
+        assertTrue(entity.isActive)
+        assertEquals(createdAt, entity.createdAt)
+    }
+
+    @Test
+    fun `maps new portfolio to insert values`() {
+        val createdAt = Instant.parse("2024-01-02T00:00:00Z")
+        val payload = NewPortfolio(userId = 7L, name = "Growth", baseCurrency = "EUR", isActive = false, createdAt = createdAt)
+
+        val values = payload.toColumnValues()
+
+        assertEquals(7L, values[PortfoliosTable.userId])
+        assertEquals("Growth", values[PortfoliosTable.name])
+        assertEquals("EUR", values[PortfoliosTable.baseCurrency])
+        assertEquals(false, values[PortfoliosTable.isActive])
+        assertEquals(OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC), values[PortfoliosTable.createdAt])
+    }
+
+    @Test
+    fun `maps portfolio update to column values`() {
+        val update = PortfolioUpdate(name = "Income", baseCurrency = null, isActive = true)
+
+        val values = update.toColumnValues()
+
+        assertEquals(2, values.size)
+        assertEquals("Income", values[PortfoliosTable.name])
+        assertEquals(true, values[PortfoliosTable.isActive])
+        assertFalse(values.containsKey(PortfoliosTable.baseCurrency))
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/PositionMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/PositionMapperTest.kt
@@ -1,0 +1,58 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import repo.tables.PositionsTable
+import model.PositionDto
+
+class PositionMapperTest {
+    @Test
+    fun `maps result row to position dto`() {
+        val portfolioId = UUID.fromString("10000000-0000-0000-0000-000000000000")
+        val updatedAt = Instant.parse("2024-06-01T10:00:00Z")
+        val row = testResultRow(
+            PositionsTable.portfolioId to portfolioId,
+            PositionsTable.instrumentId to 55L,
+            PositionsTable.qty to BigDecimal("15.5"),
+            PositionsTable.avgPrice to BigDecimal("123.45"),
+            PositionsTable.avgPriceCcy to "USD",
+            PositionsTable.updatedAt to OffsetDateTime.ofInstant(updatedAt, ZoneOffset.UTC),
+        )
+
+        val dto = row.toPositionDto()
+
+        assertEquals(portfolioId, dto.portfolioId)
+        assertEquals(55L, dto.instrumentId)
+        assertEquals(0, BigDecimal("15.5").compareTo(dto.qty))
+        assertEquals(0, BigDecimal("123.45").compareTo(dto.avgPrice))
+        assertEquals("USD", dto.avgPriceCcy)
+        assertEquals(updatedAt, dto.updatedAt)
+    }
+
+    @Test
+    fun `maps position dto to insert values`() {
+        val dto = PositionDto(
+            portfolioId = UUID.fromString("10000000-0000-0000-0000-000000000000"),
+            instrumentId = 5L,
+            qty = BigDecimal("1.0"),
+            avgPrice = null,
+            avgPriceCcy = null,
+            updatedAt = Instant.parse("2024-06-01T10:00:00Z"),
+        )
+
+        val insertValues = dto.toInsertValues()
+
+        assertEquals(dto.portfolioId, insertValues[PositionsTable.portfolioId])
+        assertEquals(null, insertValues[PositionsTable.avgPrice])
+        assertEquals(OffsetDateTime.ofInstant(dto.updatedAt, ZoneOffset.UTC), insertValues[PositionsTable.updatedAt])
+
+        val updateValues = dto.toUpdateValues()
+        assertEquals(BigDecimal("1.0"), updateValues[PositionsTable.qty])
+        assertEquals(null, updateValues[PositionsTable.avgPriceCcy])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/PriceMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/PriceMapperTest.kt
@@ -1,0 +1,45 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import model.PricePoint
+import repo.tables.PricesTable
+
+class PriceMapperTest {
+    @Test
+    fun `maps result row to price point`() {
+        val ts = Instant.parse("2024-07-01T12:30:00Z")
+        val row = testResultRow(
+            PricesTable.instrumentId to 5L,
+            PricesTable.ts to OffsetDateTime.ofInstant(ts, ZoneOffset.UTC),
+            PricesTable.price to BigDecimal("321.45"),
+            PricesTable.ccy to "USD",
+            PricesTable.sourceCol to "provider",
+        )
+
+        val point = row.toPricePoint()
+
+        assertEquals(5L, point.instrumentId)
+        assertEquals(ts, point.ts)
+        assertEquals(BigDecimal("321.45"), point.price.stripTrailingZeros())
+        assertEquals("USD", point.ccy)
+        assertEquals("provider", point.source)
+    }
+
+    @Test
+    fun `maps price point to column values`() {
+        val ts = Instant.parse("2024-07-01T12:30:00Z")
+        val point = PricePoint(instrumentId = 9L, ts = ts, price = BigDecimal("10.0"), ccy = "EUR", source = "manual")
+
+        val values = point.toColumnValues()
+
+        assertEquals(9L, values[PricesTable.instrumentId])
+        assertEquals(OffsetDateTime.ofInstant(ts, ZoneOffset.UTC), values[PricesTable.ts])
+        assertEquals(BigDecimal("10.0"), values[PricesTable.price])
+        assertEquals("manual", values[PricesTable.sourceCol])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/ResultRowTestFactory.kt
+++ b/storage/src/test/kotlin/repo/mapper/ResultRowTestFactory.kt
@@ -1,0 +1,21 @@
+package repo.mapper
+
+import java.util.LinkedHashMap
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.ResultRow
+
+private val testDatabase by lazy {
+    Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL", driver = "org.h2.Driver")
+}
+
+internal fun testResultRow(vararg pairs: Pair<Expression<*>, Any?>): ResultRow {
+    testDatabase
+    val fieldIndex = LinkedHashMap<Expression<*>, Int>(pairs.size)
+    val data = arrayOfNulls<Any?>(pairs.size)
+    pairs.forEachIndexed { index, (expression, value) ->
+        fieldIndex[expression] = index
+        data[index] = value
+    }
+    return ResultRow(fieldIndex, data)
+}

--- a/storage/src/test/kotlin/repo/mapper/TradeMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/TradeMapperTest.kt
@@ -1,0 +1,103 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import repo.model.NewTrade
+import repo.model.TradeUpdate
+import repo.tables.TradesTable
+
+class TradeMapperTest {
+    @Test
+    fun `maps result row to trade dto`() {
+        val tradeId = 11L
+        val portfolioId = UUID.fromString("00000000-0000-0000-0000-000000000111")
+        val instrumentId = 200L
+        val datetime = Instant.parse("2024-04-01T12:00:00Z")
+        val createdAt = Instant.parse("2024-04-02T12:00:00Z")
+        val row = testResultRow(
+            TradesTable.tradeId to tradeId,
+            TradesTable.portfolioId to portfolioId,
+            TradesTable.instrumentId to instrumentId,
+            TradesTable.datetime to OffsetDateTime.ofInstant(datetime, ZoneOffset.UTC),
+            TradesTable.side to "BUY",
+            TradesTable.quantity to BigDecimal("10.5"),
+            TradesTable.price to BigDecimal("150.25"),
+            TradesTable.priceCurrency to "USD",
+            TradesTable.fee to BigDecimal("1.23"),
+            TradesTable.feeCurrency to "USD",
+            TradesTable.tax to BigDecimal("0.45"),
+            TradesTable.taxCurrency to "USD",
+            TradesTable.broker to "TestBroker",
+            TradesTable.note to "note",
+            TradesTable.extId to "ext-1",
+            TradesTable.createdAt to OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC),
+        )
+
+        val dto = row.toTradeDto()
+
+        assertEquals(tradeId, dto.tradeId)
+        assertEquals(portfolioId, dto.portfolioId)
+        assertEquals(instrumentId, dto.instrumentId)
+        assertEquals(datetime, dto.datetime)
+        assertEquals("BUY", dto.side)
+        assertEquals(0, BigDecimal("10.5").compareTo(dto.quantity))
+        assertEquals(0, BigDecimal("150.25").compareTo(dto.price))
+        assertEquals("USD", dto.priceCurrency)
+        assertEquals(0, BigDecimal("1.23").compareTo(dto.fee))
+        assertEquals(0, BigDecimal("0.45").compareTo(dto.tax))
+        assertEquals("USD", dto.taxCurrency)
+        assertEquals("TestBroker", dto.broker)
+        assertEquals("note", dto.note)
+        assertEquals("ext-1", dto.extId)
+        assertEquals(createdAt, dto.createdAt)
+    }
+
+    @Test
+    fun `maps new trade to column values`() {
+        val portfolioId = UUID.fromString("00000000-0000-0000-0000-000000000999")
+        val datetime = Instant.parse("2024-04-01T12:00:00Z")
+        val createdAt = Instant.parse("2024-04-01T13:00:00Z")
+        val newTrade = NewTrade(
+            portfolioId = portfolioId,
+            instrumentId = 1L,
+            datetime = datetime,
+            side = "SELL",
+            quantity = BigDecimal.ONE,
+            price = BigDecimal.TEN,
+            priceCurrency = "USD",
+            fee = BigDecimal.ZERO,
+            feeCurrency = "USD",
+            tax = null,
+            taxCurrency = null,
+            broker = null,
+            note = null,
+            extId = null,
+            createdAt = createdAt,
+        )
+
+        val values = newTrade.toColumnValues()
+
+        assertEquals(portfolioId, values[TradesTable.portfolioId])
+        assertEquals(OffsetDateTime.ofInstant(datetime, ZoneOffset.UTC), values[TradesTable.datetime])
+        assertFalse(values.containsKey(TradesTable.tax))
+        assertFalse(values.containsKey(TradesTable.broker))
+        assertEquals(OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC), values[TradesTable.createdAt])
+    }
+
+    @Test
+    fun `maps trade update to column values`() {
+        val update = TradeUpdate(price = BigDecimal("99.9"), note = "updated")
+
+        val values = update.toColumnValues()
+
+        assertEquals(BigDecimal("99.9"), values[TradesTable.price])
+        assertEquals("updated", values[TradesTable.note])
+        assertFalse(values.containsKey(TradesTable.side))
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/UserMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/UserMapperTest.kt
@@ -1,0 +1,36 @@
+package repo.mapper
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import repo.model.NewUser
+import repo.tables.UsersTable
+
+class UserMapperTest {
+    @Test
+    fun `maps result row to user entity`() {
+        val createdAt = Instant.parse("2024-03-01T10:15:30Z")
+        val row = testResultRow(
+            UsersTable.userId to 1L,
+            UsersTable.tgUserId to 42L,
+            UsersTable.createdAt to OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC),
+        )
+
+        val entity = row.toUserEntity()
+
+        assertEquals(1L, entity.userId)
+        assertEquals(42L, entity.telegramUserId)
+        assertEquals(createdAt, entity.createdAt)
+    }
+
+    @Test
+    fun `maps new user to column values`() {
+        val createdAt = Instant.parse("2024-03-01T10:15:30Z")
+        val values = NewUser(telegramUserId = null, createdAt = createdAt).toColumnValues()
+
+        assertEquals(null, values[UsersTable.tgUserId])
+        assertEquals(OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC), values[UsersTable.createdAt])
+    }
+}

--- a/storage/src/test/kotlin/repo/mapper/ValuationMapperTest.kt
+++ b/storage/src/test/kotlin/repo/mapper/ValuationMapperTest.kt
@@ -1,0 +1,53 @@
+package repo.mapper
+
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import repo.model.NewValuationDaily
+import repo.tables.ValuationsDailyTable
+
+class ValuationMapperTest {
+    @Test
+    fun `maps result row to valuation`() {
+        val portfolioId = UUID.fromString("20000000-0000-0000-0000-000000000000")
+        val date = LocalDate.of(2024, 9, 1)
+        val row = testResultRow(
+            ValuationsDailyTable.portfolioId to portfolioId,
+            ValuationsDailyTable.date to date,
+            ValuationsDailyTable.valueRub to BigDecimal("100000.12"),
+            ValuationsDailyTable.pnlDay to BigDecimal("150.00"),
+            ValuationsDailyTable.pnlTotal to BigDecimal("2500.50"),
+            ValuationsDailyTable.drawdown to BigDecimal("-50.25"),
+        )
+
+        val record = row.toValuationDailyRecord()
+
+        assertEquals(portfolioId, record.portfolioId)
+        assertEquals(date, record.date)
+        assertEquals(0, BigDecimal("100000.12").compareTo(record.valueRub))
+        assertEquals(0, BigDecimal("150.00").compareTo(record.pnlDay))
+        assertEquals(0, BigDecimal("2500.50").compareTo(record.pnlTotal))
+        assertEquals(0, BigDecimal("-50.25").compareTo(record.drawdown))
+    }
+
+    @Test
+    fun `maps valuation payload to column values`() {
+        val portfolioId = UUID.fromString("20000000-0000-0000-0000-000000000000")
+        val payload = NewValuationDaily(
+            portfolioId = portfolioId,
+            date = LocalDate.of(2024, 9, 2),
+            valueRub = BigDecimal("101000.00"),
+            pnlDay = BigDecimal("100.00"),
+            pnlTotal = BigDecimal("2600.50"),
+            drawdown = BigDecimal("-40.25"),
+        )
+
+        val values = payload.toColumnValues()
+
+        assertEquals(portfolioId, values[ValuationsDailyTable.portfolioId])
+        assertEquals(LocalDate.of(2024, 9, 2), values[ValuationsDailyTable.date])
+        assertEquals(BigDecimal("101000.00"), values[ValuationsDailyTable.valueRub])
+    }
+}

--- a/tests/resources/trades.csv
+++ b/tests/resources/trades.csv
@@ -1,0 +1,4 @@
+ext_id,datetime,ticker,exchange,board,alias_source,side,quantity,price,currency,fee,fee_currency,tax,tax_currency,broker,note
+T1,2024-03-18T10:00:00Z,SBER,MOEX,TQBR,,BUY,10,250,RUB,1,RUB,0,RUB,BrokerOne,First buy
+,2024-03-19T10:00:00Z,SBER,MOEX,TQBR,,SELL,5,260,RUB,0.5,RUB,0,RUB,BrokerOne,Partial sell
+CG-1,2024-03-20T12:00:00Z,BTCUSDT,,,COINGECKO,BUY,0.5,40000,USD,5,USD,0,USD,CryptoDesk,Crypto accumulation


### PR DESCRIPTION
## Summary
- add a valuation service that prices open positions, aggregates portfolio metrics, and records daily valuation rows
- extend portfolio models and services to expose unrealized PnL alongside value/pnl/drawdown figures
- cover new behaviour with valuation and portfolio list position unit tests plus fixture updates

## Testing
- ./gradlew build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cc133bd4b4832192a0f7c62f88adc8