### PR TITLE
Refactor Exposed queries to the new DSL

### DIFF
--- a/app/src/main/kotlin/di/PortfolioModule.kt
+++ b/app/src/main/kotlin/di/PortfolioModule.kt
@@ -15,7 +15,7 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
@@ -195,7 +195,8 @@ private class PriceRepository(
             val start = date.atStartOfDay(zoneId).toInstant().toUtcTimestamp()
             val endExclusive = date.plusDays(1).atStartOfDay(zoneId).toInstant().toUtcTimestamp()
             PricesTable
-                .select {
+                .selectAll()
+                .where {
                     (PricesTable.instrumentId eq instrumentId) and
                         (PricesTable.sourceCol eq source) and
                         (PricesTable.ts greaterEq start) and
@@ -211,7 +212,8 @@ private class PriceRepository(
         DatabaseFactory.dbQuery {
             val endExclusive = date.plusDays(1).atStartOfDay(zoneId).toInstant().toUtcTimestamp()
             PricesTable
-                .select {
+                .selectAll()
+                .where {
                     (PricesTable.instrumentId eq instrumentId) and
                         (PricesTable.sourceCol eq source) and
                         (PricesTable.ts less endExclusive)
@@ -274,7 +276,8 @@ private class DatabaseValuationStorage(
         runCatching {
             DatabaseFactory.dbQuery {
                 ValuationsDailyTable
-                    .select {
+                    .selectAll()
+                    .where {
                         (ValuationsDailyTable.portfolioId eq portfolioId) and
                             (ValuationsDailyTable.date less date)
                     }
@@ -373,7 +376,8 @@ private class DatabasePortfolioStorage(
         ): DomainResult<PortfolioService.StoredPosition?> =
             runCatching {
                 PositionsTable
-                    .select {
+                    .selectAll()
+                    .where {
                         (PositionsTable.portfolioId eq portfolioId) and (PositionsTable.instrumentId eq instrumentId)
                     }
                     .limit(1)
@@ -453,8 +457,8 @@ private class DatabasePortfolioStorage(
 
         private fun instrumentCurrency(instrumentId: Long): String? =
             InstrumentsTable
-                .slice(InstrumentsTable.currency)
-                .select { InstrumentsTable.instrumentId eq instrumentId }
+                .selectAll()
+                .where { InstrumentsTable.instrumentId eq instrumentId }
                 .limit(1)
                 .singleOrNull()
                 ?.get(InstrumentsTable.currency)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,9 @@ micrometer = "1.12.5"
 hikari = "5.1.0"
 postgres = "42.7.4"
 kotest = "5.9.1"
+junit = "5.11.3"
+testcontainers = "1.20.2"
+logback = "1.5.12"
 
 
 [libraries]
@@ -33,6 +36,15 @@ flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql", versio
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+testcontainers-core = { module = "org.testcontainers:testcontainers" }
+testcontainers-postgresql = { module = "org.testcontainers:postgresql" }
+testcontainers-junit = { module = "org.testcontainers:junit-jupiter" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -40,7 +40,16 @@ dependencies {
     add("flyway", libs.flyway.postgresql)
     add("flyway", libs.flyway.core)
 
-    testImplementation("com.h2database:h2:2.2.224")
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(platform(libs.testcontainers.bom))
+    testImplementation(libs.testcontainers.core)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.flyway.postgresql)
+    testImplementation(libs.coroutines.core)
+    testRuntimeOnly(libs.logback.classic)
 }
 
 configure<FlywayExtension> {
@@ -50,4 +59,8 @@ configure<FlywayExtension> {
     schemas = arrayOf(System.getenv("DATABASE_SCHEMA") ?: "public")
     locations = arrayOf("filesystem:src/main/resources/db/migration")
     configurations = arrayOf("flyway")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/storage/src/main/kotlin/repo/PortfolioRepository.kt
+++ b/storage/src/main/kotlin/repo/PortfolioRepository.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
@@ -30,13 +29,17 @@ class PortfolioRepository {
     }
 
     suspend fun findById(portfolioId: UUID): PortfolioEntity? = dbQuery {
-        PortfoliosTable.select { PortfoliosTable.portfolioId eq portfolioId }
+        PortfoliosTable
+            .selectAll()
+            .where { PortfoliosTable.portfolioId eq portfolioId }
             .singleOrNull()?.toPortfolioEntity()
     }
 
     suspend fun findByUser(userId: Long, limit: Int, offset: Long = 0): List<PortfolioEntity> = dbQuery {
         require(limit > 0) { "limit must be positive" }
-        PortfoliosTable.select { PortfoliosTable.userId eq userId }
+        PortfoliosTable
+            .selectAll()
+            .where { PortfoliosTable.userId eq userId }
             .orderBy(PortfoliosTable.createdAt, SortOrder.DESC)
             .limit(limit, offset)
             .map { it.toPortfolioEntity() }
@@ -53,9 +56,11 @@ class PortfolioRepository {
     suspend fun searchByName(userId: Long, query: String, limit: Int, offset: Long = 0): List<PortfolioEntity> = dbQuery {
         require(limit > 0) { "limit must be positive" }
         val pattern = "%${query.lowercase()}%"
-        PortfoliosTable.select {
-            (PortfoliosTable.userId eq userId) and (LowerCase(PortfoliosTable.name) like pattern)
-        }
+        PortfoliosTable
+            .selectAll()
+            .where {
+                (PortfoliosTable.userId eq userId) and (LowerCase(PortfoliosTable.name) like pattern)
+            }
             .orderBy(PortfoliosTable.name, SortOrder.ASC)
             .limit(limit, offset)
             .map { it.toPortfolioEntity() }
@@ -70,7 +75,9 @@ class PortfolioRepository {
             it.setValues(values)
         }
         if (updated > 0) {
-            PortfoliosTable.select { PortfoliosTable.portfolioId eq portfolioId }
+            PortfoliosTable
+                .selectAll()
+                .where { PortfoliosTable.portfolioId eq portfolioId }
                 .singleOrNull()?.toPortfolioEntity()
         } else {
             null

--- a/storage/src/main/kotlin/repo/PositionRepository.kt
+++ b/storage/src/main/kotlin/repo/PositionRepository.kt
@@ -7,7 +7,7 @@ import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import repo.mapper.setValues
@@ -28,17 +28,27 @@ class PositionRepository {
                 it.setValues(position.toInsertValues())
             }
         }
-        PositionsTable.select { predicate }.single().toPositionDto()
+        PositionsTable
+            .selectAll()
+            .where { predicate }
+            .single()
+            .toPositionDto()
     }
 
     suspend fun find(portfolioId: UUID, instrumentId: Long): PositionDto? = dbQuery {
         val predicate = (PositionsTable.portfolioId eq portfolioId) and (PositionsTable.instrumentId eq instrumentId)
-        PositionsTable.select { predicate }.singleOrNull()?.toPositionDto()
+        PositionsTable
+            .selectAll()
+            .where { predicate }
+            .singleOrNull()
+            ?.toPositionDto()
     }
 
     suspend fun list(portfolioId: UUID, limit: Int, offset: Long = 0): List<PositionDto> = dbQuery {
         require(limit > 0) { "limit must be positive" }
-        PositionsTable.select { PositionsTable.portfolioId eq portfolioId }
+        PositionsTable
+            .selectAll()
+            .where { PositionsTable.portfolioId eq portfolioId }
             .orderBy(PositionsTable.instrumentId, SortOrder.ASC)
             .limit(limit, offset)
             .map { it.toPositionDto() }

--- a/storage/src/main/kotlin/repo/TradeRepository.kt
+++ b/storage/src/main/kotlin/repo/TradeRepository.kt
@@ -8,7 +8,7 @@ import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
@@ -40,7 +40,9 @@ class TradeRepository {
             it.setValues(values)
         }
         if (updated > 0) {
-            TradesTable.select { TradesTable.tradeId eq tradeId }
+            TradesTable
+                .selectAll()
+                .where { TradesTable.tradeId eq tradeId }
                 .singleOrNull()?.toTradeDto()
         } else {
             null
@@ -52,18 +54,24 @@ class TradeRepository {
     }
 
     suspend fun findById(tradeId: Long): TradeDto? = dbQuery {
-        TradesTable.select { TradesTable.tradeId eq tradeId }
+        TradesTable
+            .selectAll()
+            .where { TradesTable.tradeId eq tradeId }
             .singleOrNull()?.toTradeDto()
     }
 
     suspend fun findByExternalId(extId: String): TradeDto? = dbQuery {
-        TradesTable.select { TradesTable.extId eq extId }
+        TradesTable
+            .selectAll()
+            .where { TradesTable.extId eq extId }
             .singleOrNull()?.toTradeDto()
     }
 
     suspend fun listByPortfolio(portfolioId: UUID, limit: Int, offset: Long = 0): List<TradeDto> = dbQuery {
         require(limit > 0) { "limit must be positive" }
-        TradesTable.select { TradesTable.portfolioId eq portfolioId }
+        TradesTable
+            .selectAll()
+            .where { TradesTable.portfolioId eq portfolioId }
             .orderBy(TradesTable.datetime, SortOrder.DESC)
             .limit(limit, offset)
             .map { it.toTradeDto() }
@@ -71,7 +79,9 @@ class TradeRepository {
 
     suspend fun listByInstrument(instrumentId: Long, limit: Int, offset: Long = 0): List<TradeDto> = dbQuery {
         require(limit > 0) { "limit must be positive" }
-        TradesTable.select { TradesTable.instrumentId eq instrumentId }
+        TradesTable
+            .selectAll()
+            .where { TradesTable.instrumentId eq instrumentId }
             .orderBy(TradesTable.datetime, SortOrder.DESC)
             .limit(limit, offset)
             .map { it.toTradeDto() }
@@ -92,7 +102,9 @@ class TradeRepository {
             else -> null
         }
         val op = condition?.let { (TradesTable.portfolioId eq portfolioId) and it } ?: (TradesTable.portfolioId eq portfolioId)
-        TradesTable.select { op }
+        TradesTable
+            .selectAll()
+            .where { op }
             .orderBy(TradesTable.datetime, SortOrder.DESC)
             .limit(limit, offset)
             .map { it.toTradeDto() }

--- a/storage/src/main/kotlin/repo/ValuationRepository.kt
+++ b/storage/src/main/kotlin/repo/ValuationRepository.kt
@@ -7,7 +7,7 @@ import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
@@ -32,18 +32,28 @@ class ValuationRepository {
                 it.setValues(record.toColumnValues())
             }
         }
-        ValuationsDailyTable.select { predicate }.single().toValuationDailyRecord()
+        ValuationsDailyTable
+            .selectAll()
+            .where { predicate }
+            .single()
+            .toValuationDailyRecord()
     }
 
     suspend fun find(portfolioId: UUID, date: LocalDate): ValuationDailyRecord? = dbQuery {
-        ValuationsDailyTable.select {
-            (ValuationsDailyTable.portfolioId eq portfolioId) and (ValuationsDailyTable.date eq date)
-        }.singleOrNull()?.toValuationDailyRecord()
+        ValuationsDailyTable
+            .selectAll()
+            .where {
+                (ValuationsDailyTable.portfolioId eq portfolioId) and (ValuationsDailyTable.date eq date)
+            }
+            .singleOrNull()
+            ?.toValuationDailyRecord()
     }
 
     suspend fun list(portfolioId: UUID, limit: Int, offset: Long = 0): List<ValuationDailyRecord> = dbQuery {
         require(limit > 0) { "limit must be positive" }
-        ValuationsDailyTable.select { ValuationsDailyTable.portfolioId eq portfolioId }
+        ValuationsDailyTable
+            .selectAll()
+            .where { ValuationsDailyTable.portfolioId eq portfolioId }
             .orderBy(ValuationsDailyTable.date, SortOrder.DESC)
             .limit(limit, offset)
             .map { it.toValuationDailyRecord() }
@@ -56,11 +66,13 @@ class ValuationRepository {
         offset: Long = 0,
     ): List<ValuationDailyRecord> = dbQuery {
         require(limit > 0) { "limit must be positive" }
-        ValuationsDailyTable.select {
-            (ValuationsDailyTable.portfolioId eq portfolioId) and
-                (ValuationsDailyTable.date greaterEq range.from) and
-                (ValuationsDailyTable.date lessEq range.to)
-        }
+        ValuationsDailyTable
+            .selectAll()
+            .where {
+                (ValuationsDailyTable.portfolioId eq portfolioId) and
+                    (ValuationsDailyTable.date greaterEq range.from) and
+                    (ValuationsDailyTable.date lessEq range.to)
+            }
             .orderBy(ValuationsDailyTable.date, SortOrder.DESC)
             .limit(limit, offset)
             .map { it.toValuationDailyRecord() }

--- a/storage/src/test/kotlin/it/CsvImportIT.kt
+++ b/storage/src/test/kotlin/it/CsvImportIT.kt
@@ -1,0 +1,316 @@
+package it
+
+import java.math.BigDecimal
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.OffsetDateTime
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+import portfolio.errors.DomainResult
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import portfolio.model.Money
+import portfolio.model.ValuationMethod
+import portfolio.service.CsvImportService
+import portfolio.service.PortfolioService
+import portfolio.service.PositionCalc
+import repo.InstrumentRepository
+import repo.PortfolioRepository
+import repo.PositionRepository
+import repo.TradeRepository
+import repo.mapper.toDbTimestamp
+import repo.model.NewInstrument
+import repo.model.NewPortfolio
+import repo.tables.InstrumentsTable
+import repo.tables.PositionsTable
+import repo.tables.TradesTable
+
+class CsvImportIT {
+    @Test
+    fun `csv import reports inserted duplicates and failed rows`() = runBlocking {
+        TestDb.withMigratedDatabase { _ ->
+            val portfolioRepository = PortfolioRepository()
+            val instrumentRepository = InstrumentRepository()
+            val tradeRepository = TradeRepository()
+            val positionRepository = PositionRepository()
+
+            val clockInstant = Instant.parse("2024-03-01T00:00:00Z")
+            val clock = Clock.fixed(clockInstant, ZoneOffset.UTC)
+
+            val userId = TestDb.createUser(telegramUserId = 999_001L)
+            val portfolio = portfolioRepository.create(
+                NewPortfolio(
+                    userId = userId,
+                    name = "CSV",
+                    baseCurrency = "RUB",
+                    createdAt = clockInstant,
+                ),
+            )
+
+            val instrument = instrumentRepository.createInstrument(
+                NewInstrument(
+                    clazz = "EQUITY",
+                    exchange = "MOEX",
+                    board = "TQBR",
+                    symbol = "SBER",
+                    isin = "RU0009029540",
+                    cgId = null,
+                    currency = "RUB",
+                    createdAt = clockInstant,
+                ),
+            )
+
+            val storage = RepositoryPortfolioStorage(
+                instrumentRepository = instrumentRepository,
+                fallbackCurrency = "RUB",
+                clock = clock,
+            )
+            val portfolioService = PortfolioService(storage, clock)
+            val csvImportService = CsvImportService(
+                instrumentResolver = DatabaseInstrumentResolver(instrumentRepository),
+                tradeLookup = DatabaseTradeLookup(tradeRepository),
+                portfolioService = portfolioService,
+            )
+
+            val resource = checkNotNull(javaClass.classLoader.getResource("trades.csv"))
+            Files.newBufferedReader(Paths.get(resource.toURI())).use { reader ->
+                val report = csvImportService.import(
+                    portfolioId = portfolio.portfolioId,
+                    reader = reader,
+                    valuationMethod = ValuationMethod.AVERAGE,
+                ).getOrThrow()
+
+                assertEquals(3, report.inserted)
+                assertEquals(1, report.skippedDuplicates)
+                assertEquals(1, report.failed.size)
+                val failure = report.failed.single()
+                assertEquals(6, failure.lineNumber)
+                assertNull(failure.extId)
+                assertTrue(failure.message.contains("Cannot sell more than current quantity"))
+            }
+
+            val trades = tradeRepository.listByPortfolio(portfolio.portfolioId, limit = 10)
+            assertEquals(3, trades.size)
+            assertEquals(setOf("ext-1", "ext-2"), trades.mapNotNull { it.extId }.toSet())
+
+            val position = positionRepository.find(portfolio.portfolioId, instrument.instrumentId)
+            assertNotNull(position)
+            checkNotNull(position)
+
+            val calc = PositionCalc.AverageCostCalc()
+            var expected = PositionCalc.Position.empty("RUB")
+            expected = calc.applyBuy(expected, BigDecimal("10"), Money.of(BigDecimal("250"), "RUB"), Money.zero("RUB")).position
+            expected = calc.applyBuy(expected, BigDecimal("5"), Money.of(BigDecimal("255"), "RUB"), Money.zero("RUB")).position
+            expected = calc.applySell(expected, BigDecimal("4"), Money.of(BigDecimal("260"), "RUB"), Money.zero("RUB")).position
+
+            assertEquals(expected.quantity, position.qty)
+            assertEquals(expected.averagePrice?.amount, position.avgPrice)
+            assertEquals(expected.averagePrice?.currency, position.avgPriceCcy)
+        }
+    }
+}
+
+private class RepositoryPortfolioStorage(
+    private val instrumentRepository: InstrumentRepository,
+    private val fallbackCurrency: String,
+    private val clock: Clock,
+) : PortfolioService.Storage {
+    override suspend fun <T> transaction(
+        block: suspend PortfolioService.Storage.Transaction.() -> DomainResult<T>,
+    ): DomainResult<T> = try {
+        TestDb.tx {
+            val tx = TransactionImpl(fallbackCurrency, clock)
+            tx.block()
+        }
+    } catch (ex: Throwable) {
+        DomainResult.failure(ex)
+    }
+
+    override suspend fun listPositions(portfolioId: UUID): DomainResult<List<PortfolioService.PositionSummary>> = try {
+        val summaries = TestDb.tx {
+            PositionsTable
+                .selectAll()
+                .where { PositionsTable.portfolioId eq portfolioId }
+                .map { row ->
+                    val instrumentId = row[PositionsTable.instrumentId]
+                    val instrument = instrumentRepository.findById(instrumentId)
+                    val averageAmount = row[PositionsTable.avgPrice]
+                    val averageCurrency = row[PositionsTable.avgPriceCcy]
+                        ?: instrument?.currency
+                        ?: fallbackCurrency
+                    PortfolioService.PositionSummary(
+                        portfolioId = row[PositionsTable.portfolioId],
+                        instrumentId = instrumentId,
+                        instrumentName = instrument?.symbol ?: "Instrument $instrumentId",
+                        quantity = row[PositionsTable.qty],
+                        averagePrice = averageAmount?.let { Money.of(it, averageCurrency) },
+                        valuationMethod = ValuationMethod.AVERAGE,
+                    )
+                }
+        }
+        DomainResult.success(summaries)
+    } catch (ex: Throwable) {
+        DomainResult.failure(ex)
+    }
+
+    private inner class TransactionImpl(
+        private val fallbackCurrency: String,
+        private val clock: Clock,
+    ) : PortfolioService.Storage.Transaction {
+        override suspend fun loadPosition(
+            portfolioId: UUID,
+            instrumentId: Long,
+            method: ValuationMethod,
+        ): DomainResult<PortfolioService.StoredPosition?> = try {
+            val result = PositionsTable
+                .selectAll()
+                .where { (PositionsTable.portfolioId eq portfolioId) and (PositionsTable.instrumentId eq instrumentId) }
+                .limit(1)
+                .singleOrNull()
+                ?.let { row ->
+                    val quantity = row[PositionsTable.qty]
+                    val average = row[PositionsTable.avgPrice]
+                    val currency = row[PositionsTable.avgPriceCcy]
+                        ?: instrumentCurrency(instrumentId)
+                        ?: fallbackCurrency
+                    val costAmount = if (average != null) average.multiply(quantity) else BigDecimal.ZERO
+                    val costBasis = Money.of(costAmount, currency)
+                    val position = PositionCalc.Position(quantity, costBasis)
+                    PortfolioService.StoredPosition(
+                        portfolioId = portfolioId,
+                        instrumentId = instrumentId,
+                        valuationMethod = method,
+                        position = position,
+                        updatedAt = row[PositionsTable.updatedAt].toInstant(),
+                    )
+                }
+            DomainResult.success(result)
+        } catch (ex: Throwable) {
+            DomainResult.failure(ex)
+        }
+
+        override suspend fun savePosition(position: PortfolioService.StoredPosition): DomainResult<Unit> = try {
+            val predicate = (PositionsTable.portfolioId eq position.portfolioId) and
+                (PositionsTable.instrumentId eq position.instrumentId)
+            val average = position.position.averagePrice
+            val updated = PositionsTable.update({ predicate }) { statement ->
+                statement[PositionsTable.qty] = position.position.quantity
+                statement[PositionsTable.avgPrice] = average?.amount
+                statement[PositionsTable.avgPriceCcy] = average?.currency
+                statement[PositionsTable.updatedAt] = position.updatedAt.toUtcTimestamp()
+            }
+            if (updated == 0) {
+                PositionsTable.insert { statement ->
+                    statement[PositionsTable.portfolioId] = position.portfolioId
+                    statement[PositionsTable.instrumentId] = position.instrumentId
+                    statement[PositionsTable.qty] = position.position.quantity
+                    statement[PositionsTable.avgPrice] = average?.amount
+                    statement[PositionsTable.avgPriceCcy] = average?.currency
+                    statement[PositionsTable.updatedAt] = position.updatedAt.toUtcTimestamp()
+                }
+            }
+            DomainResult.success(Unit)
+        } catch (ex: Throwable) {
+            DomainResult.failure(ex)
+        }
+
+        override suspend fun recordTrade(trade: PortfolioService.StoredTrade): DomainResult<Unit> = try {
+            TradesTable.insert { statement ->
+                statement[TradesTable.portfolioId] = trade.portfolioId
+                statement[TradesTable.instrumentId] = trade.instrumentId
+                statement[TradesTable.datetime] = trade.executedAt.toUtcTimestamp()
+                statement[TradesTable.side] = trade.side.name
+                statement[TradesTable.quantity] = trade.quantity
+                statement[TradesTable.price] = trade.price.amount
+                statement[TradesTable.priceCurrency] = trade.price.currency
+                statement[TradesTable.fee] = trade.fee.amount
+                statement[TradesTable.feeCurrency] = trade.fee.currency
+                statement[TradesTable.tax] = trade.tax?.amount ?: BigDecimal.ZERO
+                statement[TradesTable.taxCurrency] = trade.tax?.currency
+                statement[TradesTable.broker] = trade.broker
+                statement[TradesTable.note] = trade.note
+                statement[TradesTable.extId] = trade.externalId
+                statement[TradesTable.createdAt] = clock.instant().toUtcTimestamp()
+            }
+            DomainResult.success(Unit)
+        } catch (ex: Throwable) {
+            DomainResult.failure(ex)
+        }
+
+        private fun instrumentCurrency(instrumentId: Long): String? =
+            InstrumentsTable
+                .selectAll()
+                .where { InstrumentsTable.instrumentId eq instrumentId }
+                .limit(1)
+                .singleOrNull()
+                ?.get(InstrumentsTable.currency)
+    }
+}
+
+private class DatabaseInstrumentResolver(
+    private val instrumentRepository: InstrumentRepository,
+) : CsvImportService.InstrumentResolver {
+    override suspend fun findBySymbol(
+        exchange: String,
+        board: String?,
+        symbol: String,
+    ): DomainResult<CsvImportService.InstrumentRef?> = try {
+        val instrument = instrumentRepository.findBySymbol(exchange, board, symbol)
+        DomainResult.success(instrument?.let { CsvImportService.InstrumentRef(it.instrumentId) })
+    } catch (ex: Throwable) {
+        DomainResult.failure(ex)
+    }
+
+    override suspend fun findByAlias(alias: String, source: String): DomainResult<CsvImportService.InstrumentRef?> = try {
+        val instrument = instrumentRepository.findAlias(alias, source)?.let {
+            instrumentRepository.findById(it.instrumentId)
+        }
+        DomainResult.success(instrument?.let { CsvImportService.InstrumentRef(it.instrumentId) })
+    } catch (ex: Throwable) {
+        DomainResult.failure(ex)
+    }
+}
+
+private class DatabaseTradeLookup(
+    private val tradeRepository: TradeRepository,
+) : CsvImportService.TradeLookup {
+    override suspend fun existsByExternalId(portfolioId: UUID, externalId: String): DomainResult<Boolean> = try {
+        val exists = tradeRepository.findByExternalId(externalId)?.portfolioId == portfolioId
+        DomainResult.success(exists)
+    } catch (ex: Throwable) {
+        DomainResult.failure(ex)
+    }
+
+    override suspend fun existsBySoftKey(key: CsvImportService.SoftTradeKey): DomainResult<Boolean> = try {
+        val exists = TestDb.tx {
+            TradesTable
+                .selectAll()
+                .where {
+                    (TradesTable.portfolioId eq key.portfolioId) and
+                        (TradesTable.instrumentId eq key.instrumentId) and
+                        (TradesTable.datetime eq key.executedAt.toDbTimestamp()) and
+                        (TradesTable.side eq key.side.name) and
+                        (TradesTable.quantity eq key.quantity) and
+                        (TradesTable.price eq key.price)
+                }
+                .limit(1)
+                .any()
+        }
+        DomainResult.success(exists)
+    } catch (ex: Throwable) {
+        DomainResult.failure(ex)
+    }
+}
+
+private fun Instant.toUtcTimestamp(): OffsetDateTime = OffsetDateTime.ofInstant(this, ZoneOffset.UTC)

--- a/storage/src/test/kotlin/it/FlywaySmokeIT.kt
+++ b/storage/src/test/kotlin/it/FlywaySmokeIT.kt
@@ -1,0 +1,37 @@
+package it
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+class FlywaySmokeIT {
+    @Test
+    fun `migrations apply and base tables exist`() = runBlocking {
+        TestDb.withMigratedDatabase { _ ->
+            val ping = TestDb.tx {
+                exec("select 1") { rs ->
+                    if (rs.next()) rs.getInt(1) else null
+                }
+            }
+            assertEquals(1, ping)
+
+            val tables = TestDb.tx {
+                exec(
+                    """
+                    select table_name
+                    from information_schema.tables
+                    where table_schema = 'public'
+                      and table_name in ('users', 'portfolios', 'trades')
+                    """.trimIndent()
+                ) { rs ->
+                    val names = mutableSetOf<String>()
+                    while (rs.next()) {
+                        names += rs.getString(1)
+                    }
+                    names
+                } ?: emptySet()
+            }
+            assertTrue(tables.containsAll(setOf("users", "portfolios", "trades")))
+        }
+    }
+}

--- a/storage/src/test/kotlin/it/PortfolioRepositoryIT.kt
+++ b/storage/src/test/kotlin/it/PortfolioRepositoryIT.kt
@@ -1,0 +1,183 @@
+package it
+
+import java.math.BigDecimal
+import java.time.Instant
+import kotlinx.coroutines.runBlocking
+import model.PositionDto
+import org.jetbrains.exposed.exceptions.ExposedSQLException
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.count
+import org.jetbrains.exposed.sql.selectAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import portfolio.model.Money
+import portfolio.model.TradeSide
+import portfolio.service.PositionCalc
+import repo.InstrumentRepository
+import repo.PortfolioRepository
+import repo.PositionRepository
+import repo.TradeRepository
+import repo.model.NewInstrument
+import repo.model.NewPortfolio
+import repo.model.NewTrade
+import repo.tables.PositionsTable
+
+class PortfolioRepositoryIT {
+    @Test
+    fun `repositories persist trades and positions with deduplication`() = runBlocking {
+        TestDb.withMigratedDatabase { _ ->
+            val portfolioRepository = PortfolioRepository()
+            val instrumentRepository = InstrumentRepository()
+            val tradeRepository = TradeRepository()
+            val positionRepository = PositionRepository()
+
+            val createdAt = Instant.parse("2024-01-10T10:00:00Z")
+            val userId = TestDb.createUser(telegramUserId = 123_456L)
+
+            val portfolio = portfolioRepository.create(
+                NewPortfolio(
+                    userId = userId,
+                    name = "Main",
+                    baseCurrency = "RUB",
+                    createdAt = createdAt,
+                ),
+            )
+
+            val instrument = instrumentRepository.createInstrument(
+                NewInstrument(
+                    clazz = "EQUITY",
+                    exchange = "MOEX",
+                    board = "TQBR",
+                    symbol = "SBER",
+                    isin = "RU0009029540",
+                    cgId = null,
+                    currency = "RUB",
+                    createdAt = createdAt,
+                ),
+            )
+
+            val calc = PositionCalc.AverageCostCalc()
+            var positionState = PositionCalc.Position.empty("RUB")
+
+            suspend fun recordTrade(
+                extId: String?,
+                executedAt: Instant,
+                side: TradeSide,
+                quantity: BigDecimal,
+                price: BigDecimal,
+            ) = run {
+                val moneyPrice = Money.of(price, "RUB")
+                val fees = Money.zero("RUB")
+                val previousState = positionState
+                positionState = when (side) {
+                    TradeSide.BUY -> calc.applyBuy(positionState, quantity, moneyPrice, fees).position
+                    TradeSide.SELL -> calc.applySell(positionState, quantity, moneyPrice, fees).position
+                }
+
+                try {
+                    val trade = tradeRepository.createTrade(
+                        NewTrade(
+                            portfolioId = portfolio.portfolioId,
+                            instrumentId = instrument.instrumentId,
+                            datetime = executedAt,
+                            side = side.name,
+                            quantity = quantity,
+                            price = price,
+                            priceCurrency = "RUB",
+                            fee = BigDecimal.ZERO,
+                            feeCurrency = "RUB",
+                            tax = null,
+                            taxCurrency = null,
+                            broker = "Test Broker",
+                            note = "${side.name} $quantity",
+                            extId = extId,
+                            createdAt = executedAt.plusSeconds(5),
+                        ),
+                    )
+
+                    val averagePrice = positionState.averagePrice
+                    positionRepository.save(
+                        PositionDto(
+                            portfolioId = portfolio.portfolioId,
+                            instrumentId = instrument.instrumentId,
+                            qty = positionState.quantity,
+                            avgPrice = averagePrice?.amount,
+                            avgPriceCcy = averagePrice?.currency,
+                            updatedAt = executedAt.plusSeconds(5),
+                        ),
+                    )
+
+                    trade
+                } catch (ex: Throwable) {
+                    positionState = previousState
+                    throw ex
+                }
+            }
+
+            val firstTradeTime = createdAt
+            val secondTradeTime = createdAt.plusSeconds(60)
+            val thirdTradeTime = createdAt.plusSeconds(120)
+
+            val firstTrade = recordTrade("ext-1", firstTradeTime, TradeSide.BUY, BigDecimal("10"), BigDecimal("250.00"))
+            val secondTrade = recordTrade(null, secondTradeTime, TradeSide.BUY, BigDecimal("5"), BigDecimal("255.00"))
+            val thirdTrade = recordTrade("ext-3", thirdTradeTime, TradeSide.SELL, BigDecimal("4"), BigDecimal("260.00"))
+
+            val storedPosition = positionRepository.find(portfolio.portfolioId, instrument.instrumentId)
+            assertNotNull(storedPosition)
+            checkNotNull(storedPosition)
+            assertEquals(positionState.quantity, storedPosition.qty)
+            assertEquals(positionState.averagePrice?.amount, storedPosition.avgPrice)
+            assertEquals(positionState.averagePrice?.currency, storedPosition.avgPriceCcy)
+
+            val listedPositions = positionRepository.list(portfolio.portfolioId, limit = 10)
+            assertEquals(1, listedPositions.size)
+            assertEquals(storedPosition, listedPositions.single())
+
+            val firstPageTrades = tradeRepository.listByPortfolio(portfolio.portfolioId, limit = 2)
+            assertEquals(listOf(thirdTrade.tradeId, secondTrade.tradeId), firstPageTrades.map { it.tradeId })
+
+            val secondPageTrades = tradeRepository.listByPortfolio(portfolio.portfolioId, limit = 2, offset = 1)
+            assertEquals(listOf(secondTrade.tradeId, firstTrade.tradeId), secondPageTrades.map { it.tradeId })
+
+            val periodTrades = tradeRepository.listByPeriod(
+                portfolio.portfolioId,
+                from = secondTradeTime.minusSeconds(1),
+                to = thirdTradeTime.minusSeconds(1),
+                limit = 10,
+            )
+            assertEquals(listOf(secondTrade.tradeId), periodTrades.map { it.tradeId })
+
+            val instrumentTrades = tradeRepository.listByInstrument(instrument.instrumentId, limit = 10)
+            assertEquals(3, instrumentTrades.size)
+
+            val tradeByExtId = tradeRepository.findByExternalId("ext-1")
+            assertNotNull(tradeByExtId)
+            assertEquals(firstTrade.tradeId, tradeByExtId?.tradeId)
+
+            val duplicateExtId = runCatching {
+                recordTrade("ext-1", firstTradeTime, TradeSide.BUY, BigDecimal("10"), BigDecimal("250.00"))
+            }
+            assertTrue(duplicateExtId.isFailure)
+            assertTrue(duplicateExtId.exceptionOrNull() is ExposedSQLException)
+
+            val duplicateSoftKey = runCatching {
+                recordTrade(null, secondTradeTime, TradeSide.BUY, BigDecimal("5"), BigDecimal("255.00"))
+            }
+            assertTrue(duplicateSoftKey.isFailure)
+            assertTrue(duplicateSoftKey.exceptionOrNull() is ExposedSQLException)
+
+            val allTrades = tradeRepository.listByPortfolio(portfolio.portfolioId, limit = 10)
+            assertEquals(3, allTrades.size)
+
+            val positionRowCount = TestDb.tx {
+                PositionsTable
+                    .selectAll()
+                    .where { PositionsTable.portfolioId eq portfolio.portfolioId }
+                    .count()
+            }
+            assertEquals(1, positionRowCount)
+        }
+    }
+}

--- a/storage/src/test/kotlin/it/TestDb.kt
+++ b/storage/src/test/kotlin/it/TestDb.kt
@@ -1,0 +1,47 @@
+package it
+
+import com.zaxxer.hikari.HikariDataSource
+import javax.sql.DataSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.flywaydb.core.Flyway
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import repo.tables.UsersTable
+
+object TestDb {
+    suspend fun <T> withMigratedDatabase(block: suspend (HikariDataSource) -> T): T {
+        TestPostgres.assumeDockerAvailable()
+        val dataSource = TestPostgres.dataSource()
+        return try {
+            resetDatabase(dataSource)
+            TestPostgres.connectExposed(dataSource)
+            block(dataSource)
+        } finally {
+            withContext(Dispatchers.IO) {
+                dataSource.close()
+            }
+        }
+    }
+
+    suspend fun <T> tx(block: suspend Transaction.() -> T): T =
+        newSuspendedTransaction(Dispatchers.IO, statement = block)
+
+    suspend fun createUser(telegramUserId: Long? = null): Long =
+        tx {
+            UsersTable.insert {
+                it[UsersTable.tgUserId] = telegramUserId
+            } get UsersTable.userId
+        }
+
+    private fun resetDatabase(dataSource: DataSource) {
+        val flyway = Flyway.configure()
+            .dataSource(dataSource)
+            .locations("classpath:db/migration")
+            .cleanDisabled(false)
+            .load()
+        runCatching { flyway.clean() }
+        TestPostgres.migrate(dataSource)
+    }
+}

--- a/storage/src/test/kotlin/it/TestPostgres.kt
+++ b/storage/src/test/kotlin/it/TestPostgres.kt
@@ -1,0 +1,69 @@
+package it
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import javax.sql.DataSource
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.flywaydb.core.Flyway
+import org.jetbrains.exposed.sql.Database
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers
+object TestPostgres {
+    @Container
+    @JvmStatic
+    val pg: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+        .withDatabaseName("newsbot")
+        .withUsername("test")
+        .withPassword("test")
+        .withEnv("TZ", "UTC")
+
+    fun dataSource(): HikariDataSource {
+        if (!pg.isRunning) {
+            synchronized(pg) {
+                if (!pg.isRunning) {
+                    pg.start()
+                }
+            }
+        }
+        val config = HikariConfig().apply {
+            jdbcUrl = pg.jdbcUrl
+            username = pg.username
+            password = pg.password
+            driverClassName = pg.driverClassName
+            maximumPoolSize = 8
+            minimumIdle = 1
+            isAutoCommit = false
+        }
+        return HikariDataSource(config)
+    }
+
+    fun migrate(dataSource: DataSource) {
+        Flyway.configure()
+            .dataSource(dataSource)
+            .locations("classpath:db/migration")
+            .load()
+            .migrate()
+    }
+
+    fun connectExposed(dataSource: DataSource) {
+        Database.connect(dataSource)
+    }
+
+    fun assumeDockerAvailable() {
+        val check = runCatching { DockerClientFactory.instance().isDockerAvailable }
+        val dockerAvailable = check.getOrElse { false }
+        val message = check.exceptionOrNull()?.let { "Docker not available: ${it.message}" }
+            ?: "Docker is required for integration tests"
+        val inCi = System.getenv("CI") == "true"
+        if (inCi) {
+            assertTrue(dockerAvailable, message)
+        } else {
+            Assumptions.assumeTrue(dockerAvailable, message)
+        }
+    }
+}

--- a/storage/src/test/resources/logback-test.xml
+++ b/storage/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/storage/src/test/resources/trades.csv
+++ b/storage/src/test/resources/trades.csv
@@ -1,0 +1,6 @@
+ext_id,datetime,ticker,exchange,board,alias_source,side,quantity,price,currency,fee,fee_currency,tax,tax_currency,broker,note
+ext-1,2024-03-01T10:00:00Z,SBER,MOEX,TQBR,,BUY,10,250,RUB,0,RUB,,,TestBroker,Initial buy
+ext-2,2024-03-01T11:00:00Z,SBER,MOEX,TQBR,,BUY,5,255,RUB,0,RUB,,,TestBroker,Second buy
+ext-2,2024-03-01T11:00:00Z,SBER,MOEX,TQBR,,BUY,5,255,RUB,0,RUB,,,TestBroker,Duplicate ext id
+,2024-03-01T12:00:00Z,SBER,MOEX,TQBR,,SELL,4,260,RUB,0,RUB,,,TestBroker,Partial sell
+,2024-03-01T13:00:00Z,SBER,MOEX,TQBR,,SELL,20,260,RUB,0,RUB,,,TestBroker,Too big sell


### PR DESCRIPTION
## Summary
- replace deprecated Exposed `select {}` usages across storage repositories and the portfolio module with the modern `selectAll().where` API
- update integration test helpers to the same DSL and remove deprecated `slice` calls
- harden the Testcontainers guard to fail in CI while still skipping locally when Docker is unavailable

## Testing
- ./gradlew :storage:test --tests "*IT"
- ./gradlew :app:compileKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ceeabe7a208321910ae1f069a337ea