### PR TITLE
Add JWT support and configure Ktor auth

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,8 +5,11 @@ plugins {
 dependencies {
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)
-    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.server.auth)
+    implementation(libs.ktor.server.auth.jwt)
     implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.java.jwt)
     implementation(project(":core"))
     implementation(project(":storage"))
     implementation(project(":integrations"))
@@ -15,6 +18,7 @@ dependencies {
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.java.time)
     implementation("io.micrometer:micrometer-registry-prometheus:${libs.versions.micrometer.get()}")
+    testImplementation(libs.kotlin.test)
 }
 
 application {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "2.2.10"
 ktor = "3.2.3"
+javajwt = "4.4.0"
 coroutines = "1.10.2"
 flyway = "10.17.2"
 exposed = "0.52.0"
@@ -16,11 +17,15 @@ logback = "1.5.12"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 ktor-server-core = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
-ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json-jvm", version.ref = "ktor" }
-ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation-jvm", version.ref = "ktor" }
+ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
+ktor-server-auth-jwt = { module = "io.ktor:ktor-server-auth-jwt", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+java-jwt = { module = "com.auth0:java-jwt", version.ref = "javajwt" }
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
 exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }


### PR DESCRIPTION
## Summary
- add the java-jwt version catalog entry along with Ktor auth and JSON serialization artifacts
- wire the app module to use the new JWT/auth dependencies and expose kotlin-test for unit testing

## Testing
- ./gradlew :app:compileKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf250e7fe48321883c46008e8cb8e8