### PR TITLE
Add security installation for JWT authentication

### DIFF
--- a/app/src/main/kotlin/security/AuthInstall.kt
+++ b/app/src/main/kotlin/security/AuthInstall.kt
@@ -1,0 +1,38 @@
+package security
+
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.jwt.jwt
+import io.ktor.server.auth.principal
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import kotlinx.serialization.json.Json
+
+fun Application.installSecurity() {
+    install(ContentNegotiation) {
+        json(
+            Json {
+                ignoreUnknownKeys = true
+                encodeDefaults = true
+            },
+        )
+    }
+
+    val cfg = JwtSupport.config(environment)
+
+    install(Authentication) {
+        jwt("auth-jwt") {
+            realm = cfg.realm
+            verifier(JwtSupport.verify(cfg))
+            validate { cred ->
+                if (cred.payload.subject != null) JWTPrincipal(cred.payload) else null
+            }
+        }
+    }
+}
+
+val ApplicationCall.userIdOrNull: String?
+    get() = principal<JWTPrincipal>()?.payload?.subject


### PR DESCRIPTION
## Summary
- add an Application.installSecurity extension that configures ContentNegotiation with JSON and JWT authentication
- expose an ApplicationCall.userIdOrNull helper to access the JWT subject

## Testing
- ./gradlew :app:compileKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf5619cf0483218eb6bdf9639ffd44