### PR TITLE
Add JwtSupport tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.exposed.java.time)
     implementation("io.micrometer:micrometer-registry-prometheus:${libs.versions.micrometer.get()}")
     testImplementation(libs.kotlin.test)
+    testImplementation(kotlin("test-junit5"))
 }
 
 application {

--- a/app/src/test/kotlin/security/JwtSupportTest.kt
+++ b/app/src/test/kotlin/security/JwtSupportTest.kt
@@ -1,0 +1,64 @@
+package security
+
+import com.auth0.jwt.exceptions.JWTVerificationException
+import com.auth0.jwt.exceptions.TokenExpiredException
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class JwtSupportTest {
+    private val baseConfig = JwtConfig(
+        issuer = "test-issuer",
+        audience = "test-audience",
+        realm = "test-realm",
+        secret = "very-secret-key",
+        accessTtlMinutes = 5,
+    )
+
+    @Test
+    fun `issueToken and verify should return expected subject and claims`() {
+        val claims = mapOf("role" to "admin", "userId" to "42")
+        val token = JwtSupport.issueToken(
+            config = baseConfig,
+            subject = "user-123",
+            claims = claims,
+        )
+
+        val decoded = JwtSupport.verify(baseConfig).verify(token)
+
+        assertEquals("user-123", decoded.subject)
+        claims.forEach { (key, value) ->
+            assertEquals(value, decoded.getClaim(key).asString(), "Claim $key should match")
+        }
+    }
+
+    @Test
+    fun `verify should fail for tokens signed with another secret`() {
+        val token = JwtSupport.issueToken(
+            config = baseConfig,
+            subject = "user-456",
+        )
+        val differentSecretConfig = baseConfig.copy(secret = "different-secret")
+
+        assertFailsWith<JWTVerificationException> {
+            JwtSupport.verify(differentSecretConfig).verify(token)
+        }
+    }
+
+    @Test
+    fun `verify should reject expired tokens`() {
+        val past = Instant.now().minus(2, ChronoUnit.HOURS)
+        val shortLivedConfig = baseConfig.copy(accessTtlMinutes = 1)
+        val token = JwtSupport.issueToken(
+            config = shortLivedConfig,
+            subject = "user-789",
+            now = past,
+        )
+
+        assertFailsWith<TokenExpiredException> {
+            JwtSupport.verify(shortLivedConfig).verify(token)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering JwtSupport token issuance, secret mismatch, and expiration handling
- include kotlin test junit5 dependency so the new tests can run

## Testing
- ./gradlew :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf5f58eaec8321ba620ed37a7aaef6