### PR TITLE
Implement Telegram initData verification and route

### DIFF
--- a/app/src/main/kotlin/App.kt
+++ b/app/src/main/kotlin/App.kt
@@ -8,6 +8,7 @@ import io.ktor.server.application.Application
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.routing.routing
+import routes.authRoutes
 import security.installSecurity
 import security.installUploadGuard
 
@@ -24,5 +25,8 @@ fun Application.module() {
     DatabaseFactory.init()
     integrationsModule()
     installPortfolioModule()
-    routing { healthRoutes() }
+    routing {
+        healthRoutes()
+        authRoutes()
+    }
 }

--- a/app/src/main/kotlin/auth/WebAppVerify.kt
+++ b/app/src/main/kotlin/auth/WebAppVerify.kt
@@ -1,0 +1,147 @@
+package auth
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.time.Instant
+import java.util.LinkedHashMap
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+object WebAppVerify {
+    private const val HASH_KEY = "hash"
+    private const val AUTH_DATE_KEY = "auth_date"
+    private val WEB_APP_KEY_BYTES = "WebAppData".toByteArray(StandardCharsets.UTF_8)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    data class Parsed(
+        val raw: Map<String, String>,
+        val userId: Long?,
+        val username: String?,
+        val firstName: String?,
+        val authDate: Instant,
+        val hash: String,
+    )
+
+    fun parse(initData: String): Parsed {
+        val trimmed = initData.trim().removePrefix("?")
+        require(trimmed.isNotEmpty()) { "initData must not be blank" }
+
+        val pairs = trimmed.split('&')
+            .filter { it.isNotEmpty() }
+
+        val rawMap = LinkedHashMap<String, String>(pairs.size)
+        for (pair in pairs) {
+            val separatorIndex = pair.indexOf('=')
+            val keyEncoded: String
+            val valueEncoded: String
+            if (separatorIndex >= 0) {
+                keyEncoded = pair.substring(0, separatorIndex)
+                valueEncoded = pair.substring(separatorIndex + 1)
+            } else {
+                keyEncoded = pair
+                valueEncoded = ""
+            }
+            val key = urlDecode(keyEncoded)
+            val value = urlDecode(valueEncoded)
+            rawMap[key] = value
+        }
+
+        val hash = rawMap[HASH_KEY]?.takeIf { it.isNotBlank() }
+            ?: throw IllegalArgumentException("hash is missing")
+
+        val authDateValue = rawMap[AUTH_DATE_KEY]?.toLongOrNull()
+            ?: throw IllegalArgumentException("auth_date is missing or invalid")
+        val authDate = Instant.ofEpochSecond(authDateValue)
+
+        val userRaw = rawMap["user"]
+        var userId: Long? = null
+        var username: String? = null
+        var firstName: String? = null
+        if (!userRaw.isNullOrBlank()) {
+            runCatching { json.parseToJsonElement(userRaw) }
+                .map { it.jsonObject }
+                .onSuccess { userObject ->
+                    userId = userObject["id"]?.jsonPrimitive?.longOrNull
+                    username = userObject["username"]?.jsonPrimitive?.contentOrNull
+                    firstName = userObject["first_name"]?.jsonPrimitive?.contentOrNull
+                }
+        }
+
+        return Parsed(
+            raw = rawMap.toMap(),
+            userId = userId,
+            username = username,
+            firstName = firstName,
+            authDate = authDate,
+            hash = hash,
+        )
+    }
+
+    fun isValid(
+        initData: String,
+        botToken: String,
+        ttlMinutes: Int,
+        now: Instant = Instant.now(),
+    ): Boolean {
+        val parsed = runCatching { parse(initData) }.getOrElse { return false }
+        return isValid(parsed, botToken, ttlMinutes, now)
+    }
+
+    fun isValid(
+        parsed: Parsed,
+        botToken: String,
+        ttlMinutes: Int,
+        now: Instant = Instant.now(),
+    ): Boolean {
+        if (botToken.isBlank() || ttlMinutes <= 0) {
+            return false
+        }
+
+        val dataCheckString = buildDataCheckString(parsed.raw)
+        val secret = hmacSha256(WEB_APP_KEY_BYTES, botToken.toByteArray(StandardCharsets.UTF_8))
+        val calcHash = hmacSha256(secret, dataCheckString.toByteArray(StandardCharsets.UTF_8)).toHex()
+
+        if (!constantTimeEquals(calcHash, parsed.hash)) {
+            return false
+        }
+
+        val ttlDuration = Duration.ofMinutes(ttlMinutes.toLong())
+        if (parsed.authDate.isBefore(now.minus(ttlDuration))) {
+            return false
+        }
+
+        return true
+    }
+
+    fun constantTimeEquals(a: String, b: String): Boolean {
+        val aBytes = a.toByteArray(StandardCharsets.UTF_8)
+        val bBytes = b.toByteArray(StandardCharsets.UTF_8)
+        return java.security.MessageDigest.isEqual(aBytes, bBytes)
+    }
+
+    private fun buildDataCheckString(raw: Map<String, String>): String =
+        raw.filterKeys { it != HASH_KEY }
+            .toSortedMap()
+            .entries
+            .joinToString(separator = "\n") { (key, value) -> "$key=$value" }
+
+    private fun hmacSha256(key: ByteArray, message: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(message)
+    }
+
+    private fun ByteArray.toHex(): String = joinToString(separator = "") { byte ->
+        val unsigned = byte.toInt() and 0xff
+        unsigned.toString(16).padStart(2, '0')
+    }
+
+    private fun urlDecode(value: String): String =
+        URLDecoder.decode(value, StandardCharsets.UTF_8.name())
+}

--- a/app/src/main/kotlin/routes/AuthRoutes.kt
+++ b/app/src/main/kotlin/routes/AuthRoutes.kt
@@ -1,0 +1,98 @@
+package routes
+
+import auth.WebAppVerify
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlinx.serialization.Serializable
+import security.JwtSupport
+import kotlin.collections.buildMap
+
+fun Route.authRoutes() {
+    post("/api/auth/telegram/verify") {
+        val request = runCatching { call.receive<TelegramVerifyRequest>() }.getOrElse {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("bad_request"))
+            return@post
+        }
+
+        val initData = request.initData?.takeIf { it.isNotBlank() }
+        if (initData == null) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("bad_request"))
+            return@post
+        }
+
+        val environment = call.application.environment
+        val botToken = environment.config.property("telegram.botToken").getString()
+        val ttlMinutes = environment.config.propertyOrNull("security.webappTtlMinutes")?.getString()?.toIntOrNull() ?: 15
+        val now = Instant.now()
+
+        val parsed = try {
+            WebAppVerify.parse(initData)
+        } catch (ex: IllegalArgumentException) {
+            environment.log.warn("Telegram initData parsing failed: ${ex.message}")
+            call.respond(HttpStatusCode.Unauthorized, ErrorResponse("invalid_init_data"))
+            return@post
+        }
+
+        if (!WebAppVerify.isValid(parsed, botToken, ttlMinutes, now)) {
+            environment.log.warn("Telegram initData validation failed")
+            call.respond(HttpStatusCode.Unauthorized, ErrorResponse("invalid_init_data"))
+            return@post
+        }
+
+        val userId = parsed.userId ?: run {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("bad_request"))
+            return@post
+        }
+
+        val jwtConfig = JwtSupport.config(environment)
+        val claims = buildMap<String, String> {
+            parsed.username?.takeIf { it.isNotBlank() }?.let { put("username", it) }
+            parsed.firstName?.takeIf { it.isNotBlank() }?.let { put("first_name", it) }
+        }
+
+        val token = JwtSupport.issueToken(jwtConfig, userId.toString(), claims, now)
+        val expiresAt = now.plus(jwtConfig.accessTtlMinutes.toLong(), ChronoUnit.MINUTES)
+
+        val response = TelegramVerifyResponse(
+            token = token,
+            expiresAt = expiresAt.toString(),
+            user = TelegramUserPayload(
+                id = userId,
+                username = parsed.username,
+                firstName = parsed.firstName,
+            ),
+        )
+
+        call.respond(response)
+    }
+}
+
+@Serializable
+private data class TelegramVerifyRequest(
+    val initData: String? = null,
+)
+
+@Serializable
+private data class TelegramVerifyResponse(
+    val token: String,
+    val expiresAt: String,
+    val user: TelegramUserPayload,
+)
+
+@Serializable
+private data class TelegramUserPayload(
+    val id: Long,
+    val username: String? = null,
+    val firstName: String? = null,
+)
+
+@Serializable
+private data class ErrorResponse(
+    val error: String,
+)

--- a/app/src/test/kotlin/auth/WebAppVerifyTest.kt
+++ b/app/src/test/kotlin/auth/WebAppVerifyTest.kt
@@ -1,0 +1,117 @@
+package auth
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.LinkedHashMap
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WebAppVerifyTest {
+    private val botToken = "1234567890:ABCdefGhIjklMNopQR_stUvWXyz1234"
+    private val verificationNow = Instant.parse("2024-01-01T12:00:00Z")
+    private val freshAuthDate = verificationNow.minusSeconds(120)
+    private val baseParameters = mapOf(
+        "auth_date" to freshAuthDate.epochSecond.toString(),
+        "query_id" to "AAEAAABBBB",
+        "user" to """{"id":987654321,"username":"john","first_name":"John"}""",
+        "extra" to "value with spaces",
+    )
+
+    @Test
+    fun `isValid should return true for correctly signed initData`() {
+        val (initData, _) = createSignedInitData(
+            parameters = baseParameters,
+            botToken = botToken,
+            order = listOf("user", "auth_date", "extra", "query_id", "hash"),
+        )
+
+        assertTrue(WebAppVerify.isValid(initData, botToken, ttlMinutes = 30, now = verificationNow))
+
+        val parsed = WebAppVerify.parse(initData)
+        assertEquals(987654321L, parsed.userId)
+        assertEquals("john", parsed.username)
+        assertEquals("John", parsed.firstName)
+        assertEquals(freshAuthDate, parsed.authDate)
+    }
+
+    @Test
+    fun `isValid should fail when payload is tampered`() {
+        val (validInitData, withHash) = createSignedInitData(
+            parameters = baseParameters,
+            botToken = botToken,
+        )
+        val tamperedUser = """{"id":987654321,"username":"attacker","first_name":"John"}"""
+        val encodedOriginalUser = URLEncoder.encode(baseParameters.getValue("user"), StandardCharsets.UTF_8)
+        val encodedTamperedUser = URLEncoder.encode(tamperedUser, StandardCharsets.UTF_8)
+        val tamperedInitData = validInitData.replace(encodedOriginalUser, encodedTamperedUser)
+
+        assertFalse(WebAppVerify.isValid(tamperedInitData, botToken, ttlMinutes = 30, now = verificationNow))
+        assertTrue(WebAppVerify.constantTimeEquals(withHash.getValue("hash"), withHash.getValue("hash")))
+    }
+
+    @Test
+    fun `isValid should fail when auth date exceeds ttl`() {
+        val expiredAuthDate = verificationNow.minusSeconds(3600)
+        val expiredParameters = baseParameters.toMutableMap()
+        expiredParameters["auth_date"] = expiredAuthDate.epochSecond.toString()
+        val (expiredInitData, _) = createSignedInitData(expiredParameters, botToken)
+
+        assertFalse(WebAppVerify.isValid(expiredInitData, botToken, ttlMinutes = 15, now = verificationNow))
+    }
+
+    @Test
+    fun `isValid should ignore ordering and percent-encoding variations`() {
+        val (orderedInitData, _) = createSignedInitData(
+            parameters = baseParameters,
+            botToken = botToken,
+            order = listOf("hash", "query_id", "extra", "auth_date", "user"),
+        )
+        val reencodedInitData = orderedInitData.replace("value+with+spaces", "value%20with%20spaces")
+
+        assertTrue(WebAppVerify.isValid(reencodedInitData, botToken, ttlMinutes = 30, now = verificationNow))
+    }
+
+    private fun createSignedInitData(
+        parameters: Map<String, String>,
+        botToken: String,
+        order: List<String>? = null,
+    ): Pair<String, Map<String, String>> {
+        val dataCheckString = parameters.entries
+            .sortedBy { it.key }
+            .joinToString("\n") { (key, value) -> "$key=$value" }
+        val secret = hmacSha256("WebAppData".toByteArray(StandardCharsets.UTF_8), botToken.toByteArray(StandardCharsets.UTF_8))
+        val hash = hmacSha256(secret, dataCheckString.toByteArray(StandardCharsets.UTF_8)).toHex()
+
+        val withHash = LinkedHashMap(parameters)
+        withHash["hash"] = hash
+        val desiredOrder = order ?: withHash.keys.toList()
+        val finalOrder = if (desiredOrder.size == withHash.size) {
+            desiredOrder
+        } else {
+            desiredOrder + withHash.keys.filter { it !in desiredOrder }
+        }
+        val initData = finalOrder.joinToString("&") { key ->
+            val value = withHash.getValue(key)
+            val encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8)
+            val encodedValue = URLEncoder.encode(value, StandardCharsets.UTF_8)
+            "$encodedKey=$encodedValue"
+        }
+        return initData to withHash
+    }
+
+    private fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data)
+    }
+
+    private fun ByteArray.toHex(): String = joinToString(separator = "") { byte ->
+        val unsigned = byte.toInt() and 0xff
+        unsigned.toString(16).padStart(2, '0')
+    }
+}


### PR DESCRIPTION
## Summary
- add a WebApp initData validator that checks the Telegram HMAC signature, parses the user payload and enforces a configurable TTL
- expose POST /api/auth/telegram/verify to validate initData and issue JWT access tokens, wiring the route into the application module
- cover the validator with unit tests for valid payloads, tampering, TTL expiry and parameter ordering

## Testing
- ./gradlew :app:compileKotlin --console=plain
- ./gradlew :app:test --tests auth.WebAppVerifyTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf6220fdd48321943baaf586dc3817