### PR TITLE
Implement portfolio routes with validation and tests

### DIFF
--- a/app/src/main/kotlin/App.kt
+++ b/app/src/main/kotlin/App.kt
@@ -5,10 +5,12 @@ import di.installPortfolioModule
 import health.healthRoutes
 import integrations.integrationsModule
 import io.ktor.server.application.Application
+import io.ktor.server.auth.authenticate
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.routing.routing
 import routes.authRoutes
+import routes.portfolioRoutes
 import security.installSecurity
 import security.installUploadGuard
 
@@ -28,5 +30,8 @@ fun Application.module() {
     routing {
         healthRoutes()
         authRoutes()
+        authenticate("auth-jwt") {
+            portfolioRoutes()
+        }
     }
 }

--- a/app/src/main/kotlin/routes/HttpUtils.kt
+++ b/app/src/main/kotlin/routes/HttpUtils.kt
@@ -1,0 +1,86 @@
+package routes
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respond
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.exceptions.ExposedSQLException
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+import routes.dto.ValidationError
+import java.sql.SQLException
+
+@Serializable
+data class ApiErrorResponse(
+    val error: String,
+    val message: String? = null,
+    val details: List<ValidationError> = emptyList(),
+)
+
+suspend fun ApplicationCall.respondBadRequest(details: List<ValidationError>) {
+    respond(
+        HttpStatusCode.BadRequest,
+        ApiErrorResponse(
+            error = "bad_request",
+            message = "Invalid request payload",
+            details = details,
+        ),
+    )
+}
+
+suspend fun ApplicationCall.respondUnauthorized() {
+    respond(
+        HttpStatusCode.Unauthorized,
+        ApiErrorResponse(error = "unauthorized", message = "Authentication required"),
+    )
+}
+
+suspend fun ApplicationCall.respondConflict(reason: String) {
+    respond(
+        HttpStatusCode.Conflict,
+        ApiErrorResponse(error = "conflict", message = reason),
+    )
+}
+
+suspend fun ApplicationCall.respondInternal() {
+    respond(
+        HttpStatusCode.InternalServerError,
+        ApiErrorResponse(error = "internal_error", message = "Internal server error"),
+    )
+}
+
+suspend fun ApplicationCall.handleDomainError(cause: Throwable) {
+    when (val error = (cause as? PortfolioException)?.error) {
+        is PortfolioError.Validation -> {
+            respondBadRequest(listOf(ValidationError(field = "general", message = error.message)))
+        }
+        is PortfolioError.NotFound -> {
+            respond(
+                HttpStatusCode.NotFound,
+                ApiErrorResponse(error = "not_found", message = error.message),
+            )
+        }
+        is PortfolioError.External -> {
+            application.environment.log.error("External portfolio error", cause)
+            respondInternal()
+        }
+        null -> {
+            if (cause.isUniqueViolation()) {
+                respondConflict("Resource already exists")
+            } else {
+                application.environment.log.error("Unhandled error", cause)
+                respondInternal()
+            }
+        }
+    }
+}
+
+private fun Throwable.isUniqueViolation(): Boolean {
+    return when (this) {
+        is ExposedSQLException -> sqlState == UNIQUE_VIOLATION || (cause?.isUniqueViolation() == true)
+        is SQLException -> sqlState == UNIQUE_VIOLATION || (cause?.isUniqueViolation() == true)
+        else -> cause?.takeIf { it !== this }?.isUniqueViolation() == true
+    }
+}
+
+private const val UNIQUE_VIOLATION = "23505"

--- a/app/src/main/kotlin/routes/PortfolioRoutes.kt
+++ b/app/src/main/kotlin/routes/PortfolioRoutes.kt
@@ -1,0 +1,310 @@
+package routes
+
+import db.DatabaseFactory
+import di.portfolioModule
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.util.AttributeKey
+import java.sql.SQLException
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import org.jetbrains.exposed.exceptions.ExposedSQLException
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import repo.model.NewPortfolio
+import repo.tables.UsersTable
+import routes.dto.CreatePortfolioRequest
+import routes.dto.PortfolioItemResponse
+import routes.dto.ValidatedCreate
+import routes.dto.ValidationError
+import routes.dto.validate
+import security.userIdOrNull
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+
+fun Route.portfolioRoutes() {
+    route("/api/portfolio") {
+        get {
+            val deps = call.portfolioDependencies()
+            val result = processPortfolioList(
+                subject = call.userIdOrNull,
+                deps = deps,
+                onError = { throwable -> call.application.environment.log.error("Unhandled error", throwable) },
+            )
+            call.respondResult(result)
+        }
+
+        post {
+            val request = try {
+                call.receive<CreatePortfolioRequest>()
+            } catch (_: Throwable) {
+                call.respondBadRequest(listOf(ValidationError(field = "body", message = "Invalid JSON payload")))
+                return@post
+            }
+
+            val deps = call.portfolioDependencies()
+            val result = processPortfolioCreate(
+                subject = call.userIdOrNull,
+                request = request,
+                deps = deps,
+                onError = { throwable -> call.application.environment.log.error("Unhandled error", throwable) },
+            )
+            call.respondResult(result)
+        }
+    }
+}
+
+internal val PortfolioRouteDepsKey = AttributeKey<PortfolioRouteDeps>("PortfolioRouteDeps")
+
+internal data class PortfolioRouteDeps(
+    val defaultValuationMethod: String,
+    val resolveUser: suspend (Long) -> Long,
+    val listPortfolios: suspend (Long) -> List<PortfolioRecord>,
+    val createPortfolio: suspend (Long, ValidatedCreate.Valid) -> PortfolioRecord,
+)
+
+internal data class PortfolioRecord(
+    val id: String,
+    val name: String,
+    val baseCurrency: String,
+    val valuationMethod: String,
+    val isActive: Boolean,
+    val createdAt: Instant,
+)
+
+internal data class PortfolioRouteResult(
+    val status: HttpStatusCode,
+    val payload: Any? = null,
+)
+
+private fun PortfolioRecord.toResponse(): PortfolioItemResponse = PortfolioItemResponse(
+    id = id,
+    name = name,
+    baseCurrency = baseCurrency,
+    valuationMethod = valuationMethod,
+    isActive = isActive,
+    createdAt = createdAt.toString(),
+)
+
+private fun ApplicationCall.portfolioDependencies(): PortfolioRouteDeps {
+    val attributes = application.attributes
+    if (attributes.contains(PortfolioRouteDepsKey)) {
+        return attributes[PortfolioRouteDepsKey]
+    }
+    return buildDefaultDependencies()
+}
+
+private fun ApplicationCall.buildDefaultDependencies(): PortfolioRouteDeps {
+    val module = application.portfolioModule()
+    val repository = module.repositories.portfolioRepository
+    val defaultMethod = module.settings.portfolio.defaultValuationMethod.name
+    val cache = application.valuationMethodCache()
+    return PortfolioRouteDeps(
+        defaultValuationMethod = defaultMethod,
+        resolveUser = { tgUserId -> ensureUser(tgUserId) },
+        listPortfolios = { userId ->
+            repository.findByUser(userId, Int.MAX_VALUE).map { entity ->
+                val portfolioId = entity.portfolioId.toString()
+                PortfolioRecord(
+                    id = portfolioId,
+                    name = entity.name,
+                    baseCurrency = entity.baseCurrency,
+                    valuationMethod = cache[portfolioId] ?: defaultMethod,
+                    isActive = entity.isActive,
+                    createdAt = entity.createdAt,
+                )
+            }
+        },
+        createPortfolio = { userId, payload ->
+            val created = repository.create(
+                NewPortfolio(
+                    userId = userId,
+                    name = payload.name,
+                    baseCurrency = payload.baseCurrency,
+                    createdAt = Instant.now(),
+                ),
+            )
+            val portfolioId = created.portfolioId.toString()
+            cache[portfolioId] = payload.valuationMethod
+            PortfolioRecord(
+                id = portfolioId,
+                name = created.name,
+                baseCurrency = created.baseCurrency,
+                valuationMethod = payload.valuationMethod,
+                isActive = created.isActive,
+                createdAt = created.createdAt,
+            )
+        },
+    )
+}
+
+private fun Application.valuationMethodCache(): ConcurrentHashMap<String, String> {
+    if (!attributes.contains(valuationCacheKey)) {
+        attributes.put(valuationCacheKey, ConcurrentHashMap())
+    }
+    return attributes[valuationCacheKey]
+}
+
+internal suspend fun processPortfolioList(
+    subject: String?,
+    deps: PortfolioRouteDeps,
+    onError: (Throwable) -> Unit = {},
+): PortfolioRouteResult {
+    val tgUserId = subject?.toLongOrNull() ?: return unauthorizedResult()
+    val userId = runCatching { deps.resolveUser(tgUserId) }
+        .getOrElse { return mapException(it, onError) }
+    val records = runCatching { deps.listPortfolios(userId) }
+        .getOrElse { return mapException(it, onError) }
+    return PortfolioRouteResult(HttpStatusCode.OK, records.map { it.toResponse() })
+}
+
+internal suspend fun processPortfolioCreate(
+    subject: String?,
+    request: CreatePortfolioRequest,
+    deps: PortfolioRouteDeps,
+    onError: (Throwable) -> Unit = {},
+): PortfolioRouteResult {
+    val tgUserId = subject?.toLongOrNull() ?: return unauthorizedResult()
+    val validation = request.validate(deps.defaultValuationMethod)
+    val validated = when (validation) {
+        is ValidatedCreate.Valid -> validation
+        is ValidatedCreate.Invalid -> {
+            return PortfolioRouteResult(
+                HttpStatusCode.BadRequest,
+                ApiErrorResponse(
+                    error = "bad_request",
+                    message = "Invalid request payload",
+                    details = validation.errors,
+                ),
+            )
+        }
+    }
+
+    val userId = runCatching { deps.resolveUser(tgUserId) }
+        .getOrElse { return mapException(it, onError) }
+    val record = runCatching { deps.createPortfolio(userId, validated) }
+        .getOrElse { throwable ->
+            if (isUniqueViolation(throwable)) {
+                return PortfolioRouteResult(
+                    HttpStatusCode.Conflict,
+                    ApiErrorResponse(
+                        error = "conflict",
+                        message = "Portfolio with the same name already exists",
+                    ),
+                )
+            }
+            return mapException(throwable, onError)
+        }
+
+    return PortfolioRouteResult(HttpStatusCode.Created, record.toResponse())
+}
+
+private fun unauthorizedResult(): PortfolioRouteResult =
+    PortfolioRouteResult(
+        HttpStatusCode.Unauthorized,
+        ApiErrorResponse(error = "unauthorized", message = "Authentication required"),
+    )
+
+private fun mapException(throwable: Throwable, onError: (Throwable) -> Unit): PortfolioRouteResult {
+    val domain = (throwable as? PortfolioException)?.error
+    return when (domain) {
+        is PortfolioError.Validation -> PortfolioRouteResult(
+            HttpStatusCode.BadRequest,
+            ApiErrorResponse(
+                error = "bad_request",
+                message = domain.message,
+                details = listOf(ValidationError(field = "general", message = domain.message)),
+            ),
+        )
+        is PortfolioError.NotFound -> PortfolioRouteResult(
+            HttpStatusCode.NotFound,
+            ApiErrorResponse(error = "not_found", message = domain.message),
+        )
+        is PortfolioError.External -> {
+            onError(throwable)
+            PortfolioRouteResult(
+                HttpStatusCode.InternalServerError,
+                ApiErrorResponse(error = "internal_error", message = "Internal server error"),
+            )
+        }
+        null -> {
+            if (isUniqueViolation(throwable)) {
+                PortfolioRouteResult(
+                    HttpStatusCode.Conflict,
+                    ApiErrorResponse(error = "conflict", message = "Resource already exists"),
+                )
+            } else {
+                onError(throwable)
+                PortfolioRouteResult(
+                    HttpStatusCode.InternalServerError,
+                    ApiErrorResponse(error = "internal_error", message = "Internal server error"),
+                )
+            }
+        }
+    }
+}
+
+private suspend fun ApplicationCall.respondResult(result: PortfolioRouteResult) {
+    val payload = result.payload
+    if (payload != null) {
+        respond(result.status, payload)
+    } else {
+        respond(result.status)
+    }
+}
+
+private suspend fun ensureUser(tgUserId: Long): Long {
+    val existing = DatabaseFactory.dbQuery {
+        UsersTable
+            .selectAll()
+            .where { UsersTable.tgUserId eq tgUserId }
+            .limit(1)
+            .singleOrNull()
+            ?.get(UsersTable.userId)
+    }
+    if (existing != null) {
+        return existing
+    }
+
+    return try {
+        DatabaseFactory.dbQuery {
+            UsersTable.insert { statement ->
+                statement[UsersTable.tgUserId] = tgUserId
+            } get UsersTable.userId
+        }
+    } catch (ex: ExposedSQLException) {
+        if (ex.sqlState == UNIQUE_VIOLATION || isUniqueViolation(ex.cause)) {
+            DatabaseFactory.dbQuery {
+                UsersTable
+                    .selectAll()
+                    .where { UsersTable.tgUserId eq tgUserId }
+                    .limit(1)
+                    .singleOrNull()
+                    ?.get(UsersTable.userId)
+            } ?: throw ex
+        } else {
+            throw ex
+        }
+    }
+}
+
+private fun isUniqueViolation(throwable: Throwable?): Boolean {
+    if (throwable == null) return false
+    return when (throwable) {
+        is ExposedSQLException -> throwable.sqlState == UNIQUE_VIOLATION || isUniqueViolation(throwable.cause)
+        is SQLException -> throwable.sqlState == UNIQUE_VIOLATION || isUniqueViolation(throwable.cause)
+        else -> if (throwable.cause === throwable) false else isUniqueViolation(throwable.cause)
+    }
+}
+
+private const val UNIQUE_VIOLATION = "23505"
+private val valuationCacheKey = AttributeKey<ConcurrentHashMap<String, String>>("PortfolioValuationCache")

--- a/app/src/main/kotlin/routes/dto/PortfolioDtos.kt
+++ b/app/src/main/kotlin/routes/dto/PortfolioDtos.kt
@@ -1,0 +1,77 @@
+package routes.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreatePortfolioRequest(
+    val name: String,
+    val baseCurrency: String,
+    val valuationMethod: String? = null,
+)
+
+@Serializable
+data class PortfolioItemResponse(
+    val id: String,
+    val name: String,
+    val baseCurrency: String,
+    val valuationMethod: String,
+    val isActive: Boolean,
+    val createdAt: String,
+)
+
+@Serializable
+data class ValidationError(
+    val field: String,
+    val message: String,
+)
+
+sealed class ValidatedCreate {
+    data class Valid(
+        val name: String,
+        val baseCurrency: String,
+        val valuationMethod: String,
+    ) : ValidatedCreate()
+
+    data class Invalid(val errors: List<ValidationError>) : ValidatedCreate()
+}
+
+fun CreatePortfolioRequest.validate(defaultMethod: String): ValidatedCreate {
+    val errors = mutableListOf<ValidationError>()
+
+    val normalizedName = name.trim()
+    if (normalizedName.length !in NAME_LENGTH_RANGE) {
+        errors += ValidationError("name", "Name must be between 2 and 64 characters")
+    }
+
+    val normalizedCurrency = baseCurrency.trim().uppercase()
+    if (!CURRENCY_REGEX.matches(normalizedCurrency)) {
+        errors += ValidationError("baseCurrency", "Base currency must be a 3-letter uppercase code")
+    }
+
+    val normalizedDefault = defaultMethod.trim().uppercase()
+    val normalizedMethod = valuationMethod
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.uppercase()
+        ?: normalizedDefault
+    if (normalizedMethod !in ALLOWED_METHODS) {
+        errors += ValidationError(
+            field = "valuationMethod",
+            message = "Valuation method must be one of: ${ALLOWED_METHODS.joinToString(",")}"
+        )
+    }
+
+    return if (errors.isEmpty()) {
+        ValidatedCreate.Valid(
+            name = normalizedName,
+            baseCurrency = normalizedCurrency,
+            valuationMethod = normalizedMethod,
+        )
+    } else {
+        ValidatedCreate.Invalid(errors)
+    }
+}
+
+private val NAME_LENGTH_RANGE = 2..64
+private val CURRENCY_REGEX = Regex("^[A-Z]{3}$")
+private val ALLOWED_METHODS = setOf("AVERAGE", "FIFO")

--- a/app/src/test/kotlin/routes/PortfolioRoutesTest.kt
+++ b/app/src/test/kotlin/routes/PortfolioRoutesTest.kt
@@ -1,0 +1,162 @@
+package routes
+
+import io.ktor.http.HttpStatusCode
+import java.sql.SQLException
+import java.time.Instant
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import routes.dto.CreatePortfolioRequest
+import routes.dto.PortfolioItemResponse
+import security.JwtConfig
+import security.JwtSupport
+import routes.ApiErrorResponse
+
+class PortfolioRoutesTest {
+    private val jwtConfig = JwtConfig(
+        issuer = "newsbot",
+        audience = "newsbot-clients",
+        realm = "newsbot-api",
+        secret = "test-secret",
+        accessTtlMinutes = 60,
+    )
+
+    @Test
+    fun `GET portfolio returns portfolios for authenticated user`() = runBlocking {
+        val deps = FakeDeps()
+        deps.records += listOf(
+            PortfolioRecord(
+                id = "portfolio-1",
+                name = "Main",
+                baseCurrency = "USD",
+                valuationMethod = "AVERAGE",
+                isActive = true,
+                createdAt = Instant.parse("2024-03-10T10:00:00Z"),
+            ),
+            PortfolioRecord(
+                id = "portfolio-2",
+                name = "Crypto",
+                baseCurrency = "USDT",
+                valuationMethod = "FIFO",
+                isActive = false,
+                createdAt = Instant.parse("2024-03-11T09:15:00Z"),
+            ),
+        )
+
+        val subject = subjectFromToken(issueToken("123456"))
+        val result = processPortfolioList(subject, deps.toDeps())
+
+        assertEquals(HttpStatusCode.OK, result.status)
+        val payload = result.payload as List<PortfolioItemResponse>
+        assertEquals(2, payload.size)
+        assertEquals("Main", payload[0].name)
+        assertEquals("Crypto", payload[1].name)
+    }
+
+    @Test
+    fun `POST portfolio creates portfolio`() = runBlocking {
+        val deps = FakeDeps()
+        val subject = subjectFromToken(issueToken("999"))
+        val request = CreatePortfolioRequest("Growth", "rub")
+
+        val result = processPortfolioCreate(subject, request, deps.toDeps())
+
+        assertEquals(HttpStatusCode.Created, result.status)
+        val payload = result.payload as PortfolioItemResponse
+        assertEquals("Growth", payload.name)
+        assertEquals("RUB", payload.baseCurrency)
+        assertEquals("AVERAGE", payload.valuationMethod)
+        assertTrue(deps.records.any { it.name == "Growth" })
+    }
+
+    @Test
+    fun `POST portfolio normalizes base currency`() = runBlocking {
+        val deps = FakeDeps().apply { defaultMethod = "FIFO" }
+        val subject = subjectFromToken(issueToken("555"))
+        val request = CreatePortfolioRequest("Alpha", "rub")
+
+        val result = processPortfolioCreate(subject, request, deps.toDeps())
+
+        assertEquals(HttpStatusCode.Created, result.status)
+        val payload = result.payload as PortfolioItemResponse
+        assertEquals("RUB", payload.baseCurrency)
+        assertEquals("FIFO", payload.valuationMethod)
+        assertEquals("RUB", deps.records.last().baseCurrency)
+    }
+
+    @Test
+    fun `POST portfolio with short name returns 400`() = runBlocking {
+        val deps = FakeDeps()
+        val subject = subjectFromToken(issueToken("42"))
+        val request = CreatePortfolioRequest("A", "USD")
+
+        val result = processPortfolioCreate(subject, request, deps.toDeps())
+
+        assertEquals(HttpStatusCode.BadRequest, result.status)
+        val payload = result.payload
+        assertIs<ApiErrorResponse>(payload)
+        assertTrue(payload.details.any { it.field == "name" })
+    }
+
+    @Test
+    fun `POST portfolio with duplicate name returns 409`() = runBlocking {
+        val deps = FakeDeps().apply { createException = SQLException("duplicate", UNIQUE_VIOLATION) }
+        val subject = subjectFromToken(issueToken("77"))
+        val request = CreatePortfolioRequest("Dup", "USD")
+
+        val result = processPortfolioCreate(subject, request, deps.toDeps())
+
+        assertEquals(HttpStatusCode.Conflict, result.status)
+        val payload = result.payload
+        assertIs<ApiErrorResponse>(payload)
+        assertEquals("conflict", payload.error)
+    }
+
+    @Test
+    fun `requests without JWT return 401`() = runBlocking {
+        val deps = FakeDeps()
+
+        val getResult = processPortfolioList(null, deps.toDeps())
+        assertEquals(HttpStatusCode.Unauthorized, getResult.status)
+
+        val postResult = processPortfolioCreate(null, CreatePortfolioRequest("X", "USD"), deps.toDeps())
+        assertEquals(HttpStatusCode.Unauthorized, postResult.status)
+    }
+
+    private fun issueToken(subject: String): String = JwtSupport.issueToken(jwtConfig, subject)
+
+    private fun subjectFromToken(token: String): String = JwtSupport.verify(jwtConfig).verify(token).subject
+
+    private class FakeDeps {
+        var defaultMethod: String = "AVERAGE"
+        var createException: Throwable? = null
+        val records = mutableListOf<PortfolioRecord>()
+        private var counter = 0
+
+        fun toDeps(): PortfolioRouteDeps = PortfolioRouteDeps(
+            defaultValuationMethod = defaultMethod,
+            resolveUser = { 1L },
+            listPortfolios = { records.toList() },
+            createPortfolio = { _, valid ->
+                createException?.let { throw it }
+                counter += 1
+                val record = PortfolioRecord(
+                    id = "portfolio-${counter}",
+                    name = valid.name,
+                    baseCurrency = valid.baseCurrency,
+                    valuationMethod = valid.valuationMethod,
+                    isActive = true,
+                    createdAt = Instant.parse("2024-03-10T00:00:00Z").plusSeconds(counter.toLong()),
+                )
+                records += record
+                record
+            },
+        )
+    }
+
+    companion object {
+        private const val UNIQUE_VIOLATION = "23505"
+    }
+}


### PR DESCRIPTION
## Summary
- add authenticated portfolio routing with reusable dependency accessors and result helpers
- provide DTOs and shared HTTP error responses for portfolio APIs
- cover portfolio flows with unit tests exercising validation, conflicts, and unauthorized cases

## Testing
- ./gradlew app:test

------
https://chatgpt.com/codex/tasks/task_e_68d297bd45dc83218350c9cc84183ca6