### PR TITLE
Implement portfolio positions and trades endpoints with validation

### DIFF
--- a/app/src/main/kotlin/App.kt
+++ b/app/src/main/kotlin/App.kt
@@ -11,6 +11,7 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.routing.routing
 import routes.authRoutes
 import routes.portfolioRoutes
+import routes.portfolioPositionsTradesRoutes
 import security.installSecurity
 import security.installUploadGuard
 
@@ -32,6 +33,7 @@ fun Application.module() {
         authRoutes()
         authenticate("auth-jwt") {
             portfolioRoutes()
+            portfolioPositionsTradesRoutes()
         }
     }
 }

--- a/app/src/main/kotlin/routes/HttpUtils.kt
+++ b/app/src/main/kotlin/routes/HttpUtils.kt
@@ -9,6 +9,7 @@ import portfolio.errors.PortfolioError
 import portfolio.errors.PortfolioException
 import routes.dto.ValidationError
 import java.sql.SQLException
+import kotlin.jvm.JvmName
 
 @Serializable
 data class ApiErrorResponse(
@@ -17,70 +18,95 @@ data class ApiErrorResponse(
     val details: List<ValidationError> = emptyList(),
 )
 
+@Serializable
+data class HttpErrorResponse(
+    val error: String,
+    val reason: String? = null,
+    val details: List<String>? = null,
+)
+
+@JvmName("respondBadRequestWithStrings")
+suspend fun ApplicationCall.respondBadRequest(details: List<String>) {
+    respond(HttpStatusCode.BadRequest, HttpErrorResponse(error = "bad_request", details = details))
+}
+
+@JvmName("respondBadRequestWithValidation")
 suspend fun ApplicationCall.respondBadRequest(details: List<ValidationError>) {
-    respond(
-        HttpStatusCode.BadRequest,
-        ApiErrorResponse(
-            error = "bad_request",
-            message = "Invalid request payload",
-            details = details,
-        ),
-    )
+    respondBadRequest(details.map { "${it.field}: ${it.message}" })
 }
 
 suspend fun ApplicationCall.respondUnauthorized() {
-    respond(
-        HttpStatusCode.Unauthorized,
-        ApiErrorResponse(error = "unauthorized", message = "Authentication required"),
-    )
+    respond(HttpStatusCode.Unauthorized, HttpErrorResponse(error = "unauthorized"))
 }
 
 suspend fun ApplicationCall.respondConflict(reason: String) {
-    respond(
-        HttpStatusCode.Conflict,
-        ApiErrorResponse(error = "conflict", message = reason),
-    )
+    respond(HttpStatusCode.Conflict, HttpErrorResponse(error = "conflict", reason = reason))
+}
+
+suspend fun ApplicationCall.respondNotFound(reason: String?) {
+    respond(HttpStatusCode.NotFound, HttpErrorResponse(error = "not_found", reason = reason))
 }
 
 suspend fun ApplicationCall.respondInternal() {
-    respond(
-        HttpStatusCode.InternalServerError,
-        ApiErrorResponse(error = "internal_error", message = "Internal server error"),
-    )
+    respond(HttpStatusCode.InternalServerError, HttpErrorResponse(error = "internal"))
 }
 
 suspend fun ApplicationCall.handleDomainError(cause: Throwable) {
-    when (val error = (cause as? PortfolioException)?.error) {
-        is PortfolioError.Validation -> {
-            respondBadRequest(listOf(ValidationError(field = "general", message = error.message)))
+    when (cause) {
+        is IllegalArgumentException -> {
+            respondBadRequest(listOf(cause.message ?: "invalid_request"))
+            return
         }
-        is PortfolioError.NotFound -> {
-            respond(
-                HttpStatusCode.NotFound,
-                ApiErrorResponse(error = "not_found", message = error.message),
-            )
+        is PortfolioException -> {
+            handlePortfolioException(cause)
+            return
         }
-        is PortfolioError.External -> {
-            application.environment.log.error("External portfolio error", cause)
+    }
+
+    when {
+        cause.isConflictException() || cause.isUniqueViolation() -> {
+            respondConflict(cause.message ?: "conflict")
+        }
+        cause.isNotFoundException() -> {
+            respondNotFound(cause.message)
+        }
+        else -> {
+            application.environment.log.error("Unhandled error", cause)
             respondInternal()
-        }
-        null -> {
-            if (cause.isUniqueViolation()) {
-                respondConflict("Resource already exists")
-            } else {
-                application.environment.log.error("Unhandled error", cause)
-                respondInternal()
-            }
         }
     }
 }
 
-private fun Throwable.isUniqueViolation(): Boolean {
-    return when (this) {
-        is ExposedSQLException -> sqlState == UNIQUE_VIOLATION || (cause?.isUniqueViolation() == true)
-        is SQLException -> sqlState == UNIQUE_VIOLATION || (cause?.isUniqueViolation() == true)
-        else -> cause?.takeIf { it !== this }?.isUniqueViolation() == true
+private suspend fun ApplicationCall.handlePortfolioException(exception: PortfolioException) {
+    when (val error = exception.error) {
+        is PortfolioError.Validation -> respondBadRequest(listOf(error.message))
+        is PortfolioError.NotFound -> respondNotFound(error.message)
+        is PortfolioError.External -> {
+            application.environment.log.error("Portfolio service error", exception)
+            respondInternal()
+        }
     }
+}
+
+private fun Throwable.isConflictException(): Boolean =
+    matchesName(setOf("AlreadyExists", "AlreadyExistsException"))
+
+private fun Throwable.isNotFoundException(): Boolean =
+    matchesName(setOf("NotFound", "NotFoundException"))
+
+private tailrec fun Throwable.matchesName(names: Set<String>): Boolean {
+    val simple = this::class.simpleName
+    if (simple != null && simple in names) {
+        return true
+    }
+    val nested = cause
+    return nested != null && nested !== this && nested.matchesName(names)
+}
+
+private fun Throwable.isUniqueViolation(): Boolean = when (this) {
+    is ExposedSQLException -> sqlState == UNIQUE_VIOLATION || (cause?.isUniqueViolation() == true)
+    is SQLException -> sqlState == UNIQUE_VIOLATION || (cause?.isUniqueViolation() == true)
+    else -> cause?.takeIf { it !== this }?.isUniqueViolation() == true
 }
 
 private const val UNIQUE_VIOLATION = "23505"

--- a/app/src/main/kotlin/routes/PortfolioPositionsTradesRoutes.kt
+++ b/app/src/main/kotlin/routes/PortfolioPositionsTradesRoutes.kt
@@ -1,0 +1,300 @@
+package routes
+
+import db.DatabaseFactory
+import di.portfolioModule
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import io.ktor.util.AttributeKey
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import model.TradeDto
+import org.jetbrains.exposed.sql.Op
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.count
+import org.jetbrains.exposed.sql.select
+import portfolio.model.Money
+import portfolio.model.PositionView
+import routes.dto.MoneyDto
+import routes.dto.PositionItemResponse
+import routes.dto.TradeItemResponse
+import routes.dto.TradesPageResponse
+import routes.dto.paramDate
+import routes.dto.paramLimit
+import routes.dto.paramOffset
+import routes.dto.paramOrder
+import routes.dto.paramSide
+import routes.dto.paramSort
+import repo.mapper.toTradeDto
+import repo.tables.TradesTable
+import security.userIdOrNull
+
+fun Route.portfolioPositionsTradesRoutes() {
+    route("/api/portfolio/{id}") {
+        get("/positions") {
+            val subject = call.userIdOrNull
+            if (subject == null) {
+                call.respondUnauthorized()
+                return@get
+            }
+
+            val portfolioId = call.requirePortfolioId() ?: return@get
+            val sort = runCatching { call.paramSort() }.getOrElse {
+                call.respondBadRequest(listOf(it.message ?: "invalid_request"))
+                return@get
+            }
+            val order = runCatching { call.paramOrder() }.getOrElse {
+                call.respondBadRequest(listOf(it.message ?: "invalid_request"))
+                return@get
+            }
+
+            val deps = call.positionsTradesDeps()
+            deps.listPositions(portfolioId).fold(
+                onSuccess = { positions ->
+                    val sorted = positions.sorted(sort, order)
+                    val response = sorted.map { it.toResponse() }
+                    call.respond(response)
+                },
+                onFailure = { error -> call.handleDomainError(error) },
+            )
+        }
+
+        get("/trades") {
+            val subject = call.userIdOrNull
+            if (subject == null) {
+                call.respondUnauthorized()
+                return@get
+            }
+
+            val portfolioId = call.requirePortfolioId() ?: return@get
+            val limit = runCatching { call.paramLimit() }.getOrElse {
+                call.respondBadRequest(listOf(it.message ?: "invalid_request"))
+                return@get
+            }
+            val offset = runCatching { call.paramOffset() }.getOrElse {
+                call.respondBadRequest(listOf(it.message ?: "invalid_request"))
+                return@get
+            }
+            val from = runCatching { call.paramDate("from") }.getOrElse {
+                call.respondBadRequest(listOf(it.message ?: "invalid_request"))
+                return@get
+            }
+            val to = runCatching { call.paramDate("to") }.getOrElse {
+                call.respondBadRequest(listOf(it.message ?: "invalid_request"))
+                return@get
+            }
+            val side = runCatching { call.paramSide() }.getOrElse {
+                call.respondBadRequest(listOf(it.message ?: "invalid_request"))
+                return@get
+            }
+
+            if (from != null && to != null && to.isBefore(from)) {
+                call.respondBadRequest(listOf("from must be on or before to"))
+                return@get
+            }
+
+            val deps = call.positionsTradesDeps()
+            val query = TradesQuery(
+                limit = limit,
+                offset = offset,
+                from = from,
+                to = to,
+                side = side,
+            )
+            deps.listTrades(portfolioId, query).fold(
+                onSuccess = { page ->
+                    val response = TradesPageResponse(
+                        total = page.total,
+                        items = page.items.map { it.toResponse() },
+                        limit = limit,
+                        offset = offset,
+                    )
+                    call.respond(response)
+                },
+                onFailure = { error -> call.handleDomainError(error) },
+            )
+        }
+    }
+}
+
+internal val PortfolioPositionsTradesDepsKey = AttributeKey<PortfolioPositionsTradesDeps>("PortfolioPositionsTradesDeps")
+
+internal data class PortfolioPositionsTradesDeps(
+    val listPositions: suspend (UUID) -> Result<List<PositionView>>,
+    val listTrades: suspend (UUID, TradesQuery) -> Result<TradesData>,
+)
+
+internal data class TradesQuery(
+    val limit: Int,
+    val offset: Int,
+    val from: LocalDate?,
+    val to: LocalDate?,
+    val side: String?,
+)
+
+internal data class TradesData(
+    val total: Long,
+    val items: List<TradeRecord>,
+)
+
+internal data class TradeRecord(
+    val instrumentId: Long,
+    val tradeDate: LocalDate,
+    val side: String,
+    val quantity: BigDecimal,
+    val price: Money,
+    val notional: Money,
+    val fee: Money,
+    val tax: Money?,
+    val extId: String?,
+)
+
+private fun ApplicationCall.positionsTradesDeps(): PortfolioPositionsTradesDeps {
+    val attributes = application.attributes
+    if (attributes.contains(PortfolioPositionsTradesDepsKey)) {
+        return attributes[PortfolioPositionsTradesDepsKey]
+    }
+    val deps = buildPositionsTradesDeps()
+    attributes.put(PortfolioPositionsTradesDepsKey, deps)
+    return deps
+}
+
+private fun ApplicationCall.buildPositionsTradesDeps(): PortfolioPositionsTradesDeps {
+    val module = application.portfolioModule()
+    val services = module.services
+    return PortfolioPositionsTradesDeps(
+        listPositions = { portfolioId ->
+            services.portfolioService.listPositions(
+                portfolioId = portfolioId,
+                on = LocalDate.now(ZoneOffset.UTC),
+                pricingService = services.pricingService,
+                fxRateService = services.fxRateService,
+            )
+        },
+        listTrades = { portfolioId, query -> fetchTrades(portfolioId, query) },
+    )
+}
+
+private suspend fun fetchTrades(portfolioId: UUID, query: TradesQuery): Result<TradesData> =
+    runCatching {
+        DatabaseFactory.dbQuery {
+            val condition = buildTradeCondition(portfolioId, query)
+            val total = TradesTable.select { condition }.count()
+            val rows = TradesTable
+                .select { condition }
+                .orderBy(TradesTable.datetime, SortOrder.DESC)
+                .orderBy(TradesTable.instrumentId, SortOrder.ASC)
+                .limit(query.limit, query.offset.toLong())
+                .map { it.toTradeDto() }
+            TradesData(
+                total = total,
+                items = rows.map { it.toTradeRecord() },
+            )
+        }
+    }
+
+private fun buildTradeCondition(portfolioId: UUID, query: TradesQuery): Op<Boolean> {
+    var condition: Op<Boolean> = TradesTable.portfolioId eq portfolioId
+    query.from?.let {
+        condition = condition and (TradesTable.datetime greaterEq it.atStartOfDayUtc())
+    }
+    query.to?.let {
+        condition = condition and (TradesTable.datetime less it.plusDays(1).atStartOfDayUtc())
+    }
+    query.side?.let {
+        condition = condition and (TradesTable.side eq it)
+    }
+    return condition
+}
+
+private fun LocalDate.atStartOfDayUtc(): OffsetDateTime = atStartOfDay().atOffset(ZoneOffset.UTC)
+
+private suspend fun ApplicationCall.requirePortfolioId(): UUID? {
+    val raw = parameters["id"]?.trim()
+    if (raw.isNullOrEmpty()) {
+        respondBadRequest(listOf("portfolioId invalid"))
+        return null
+    }
+    return runCatching { UUID.fromString(raw) }.getOrElse {
+        respondBadRequest(listOf("portfolioId invalid"))
+        null
+    }
+}
+
+private fun List<PositionView>.sorted(sortKey: String, order: String): List<PositionView> {
+    val comparator = when (sortKey) {
+        "qty" -> compareBy<PositionView> { it.quantity }
+        "upl" -> compareBy { it.unrealizedPnl.amount }
+        else -> compareBy { it.instrumentId }
+    }
+    return if (order == "desc") sortedWith(comparator.reversed()) else sortedWith(comparator)
+}
+
+private fun PositionView.toResponse(): PositionItemResponse {
+    val quantityValue = quantity
+    val averageCostMoney = averageCost ?: Money.zero(valuation.currency)
+    val lastPriceMoney = if (quantityValue.compareTo(BigDecimal.ZERO) == 0) {
+        Money.zero(valuation.currency)
+    } else {
+        val priceAmount = valuation.amount.divide(quantityValue, 8, RoundingMode.HALF_UP)
+        Money.of(priceAmount, valuation.currency)
+    }
+    return PositionItemResponse(
+        instrumentId = instrumentId,
+        qty = quantityValue.toAmountString(),
+        avgPrice = averageCostMoney.toDto(),
+        lastPrice = lastPriceMoney.toDto(),
+        upl = unrealizedPnl.toDto(),
+    )
+}
+
+private fun TradeRecord.toResponse(): TradeItemResponse = TradeItemResponse(
+    instrumentId = instrumentId,
+    tradeDate = tradeDate.toString(),
+    side = side,
+    quantity = quantity.toAmountString(),
+    price = price.toDto(),
+    notional = notional.toDto(),
+    fee = fee.toDto(),
+    tax = tax?.toDto(),
+    extId = extId,
+)
+
+private fun TradeDto.toTradeRecord(): TradeRecord {
+    val priceMoney = Money.of(price, priceCurrency)
+    val feeMoney = Money.of(fee, feeCurrency)
+    val taxMoney = tax?.let { value ->
+        val currency = taxCurrency ?: priceCurrency
+        Money.of(value, currency)
+    }
+    val tradeDate = datetime.atOffset(ZoneOffset.UTC).toLocalDate()
+    return TradeRecord(
+        instrumentId = instrumentId,
+        tradeDate = tradeDate,
+        side = side.uppercase(),
+        quantity = quantity,
+        price = priceMoney,
+        notional = priceMoney * quantity,
+        fee = feeMoney,
+        tax = taxMoney,
+        extId = extId,
+    )
+}
+
+private fun Money.toDto(): MoneyDto = MoneyDto(
+    amount = amount.setScale(8, RoundingMode.HALF_UP).toPlainString(),
+    ccy = currency,
+)
+
+private fun BigDecimal.toAmountString(): String = setScale(8, RoundingMode.HALF_UP).toPlainString()

--- a/app/src/main/kotlin/routes/dto/PositionsTradesDtos.kt
+++ b/app/src/main/kotlin/routes/dto/PositionsTradesDtos.kt
@@ -1,0 +1,123 @@
+package routes.dto
+
+import io.ktor.server.application.ApplicationCall
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MoneyDto(
+    val amount: String,
+    val ccy: String,
+)
+
+@Serializable
+data class PositionItemResponse(
+    val instrumentId: Long,
+    val qty: String,
+    val avgPrice: MoneyDto,
+    val lastPrice: MoneyDto,
+    val upl: MoneyDto,
+)
+
+@Serializable
+data class TradeItemResponse(
+    val instrumentId: Long,
+    val tradeDate: String,
+    val side: String,
+    val quantity: String,
+    val price: MoneyDto,
+    val notional: MoneyDto,
+    val fee: MoneyDto,
+    val tax: MoneyDto?,
+    val extId: String?,
+)
+
+@Serializable
+data class TradesPageResponse(
+    val total: Long,
+    val items: List<TradeItemResponse>,
+    val limit: Int,
+    val offset: Int,
+)
+
+fun ApplicationCall.paramLimit(default: Int = 50): Int {
+    val raw = request.queryParameters["limit"] ?: return default
+    val value = raw.trim()
+    if (value.isEmpty()) {
+        throw IllegalArgumentException("limit must be between 1 and 200")
+    }
+    val parsed = value.toIntOrNull()
+        ?: throw IllegalArgumentException("limit must be between 1 and 200")
+    if (parsed !in 1..200) {
+        throw IllegalArgumentException("limit must be between 1 and 200")
+    }
+    return parsed
+}
+
+fun ApplicationCall.paramOffset(default: Int = 0): Int {
+    val raw = request.queryParameters["offset"] ?: return default
+    val value = raw.trim()
+    if (value.isEmpty()) {
+        throw IllegalArgumentException("offset must be a non-negative integer")
+    }
+    val parsed = value.toIntOrNull()
+        ?: throw IllegalArgumentException("offset must be a non-negative integer")
+    if (parsed < 0) {
+        throw IllegalArgumentException("offset must be a non-negative integer")
+    }
+    return parsed
+}
+
+fun ApplicationCall.paramDate(name: String): LocalDate? {
+    val raw = request.queryParameters[name] ?: return null
+    val value = raw.trim()
+    if (value.isEmpty()) {
+        throw IllegalArgumentException("$name must be in format YYYY-MM-DD")
+    }
+    return try {
+        LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE)
+    } catch (ex: DateTimeParseException) {
+        throw IllegalArgumentException("$name must be in format YYYY-MM-DD")
+    }
+}
+
+fun ApplicationCall.paramSide(): String? {
+    val raw = request.queryParameters["side"] ?: return null
+    val value = raw.trim()
+    if (value.isEmpty()) {
+        throw IllegalArgumentException("side must be BUY or SELL")
+    }
+    val normalized = value.uppercase()
+    if (normalized !in setOf("BUY", "SELL")) {
+        throw IllegalArgumentException("side must be BUY or SELL")
+    }
+    return normalized
+}
+
+fun ApplicationCall.paramSort(default: String = "instrumentId"): String {
+    val raw = request.queryParameters["sort"] ?: return default
+    val value = raw.trim()
+    if (value.isEmpty()) {
+        return default
+    }
+    val allowed = setOf("instrumentId", "qty", "upl")
+    if (value !in allowed) {
+        throw IllegalArgumentException("sort must be one of: ${allowed.joinToString(",")}")
+    }
+    return value
+}
+
+fun ApplicationCall.paramOrder(default: String = "asc"): String {
+    val raw = request.queryParameters["order"] ?: return default
+    val value = raw.trim()
+    if (value.isEmpty()) {
+        return default
+    }
+    val normalized = value.lowercase()
+    if (normalized !in setOf("asc", "desc")) {
+        throw IllegalArgumentException("order must be 'asc' or 'desc'")
+    }
+    return normalized
+}

--- a/app/src/test/kotlin/routes/PortfolioPositionsTradesRoutesTest.kt
+++ b/app/src/test/kotlin/routes/PortfolioPositionsTradesRoutesTest.kt
@@ -1,0 +1,337 @@
+package routes
+
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.jwt.jwt
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import java.math.BigDecimal
+import java.net.HttpURLConnection
+import java.net.ServerSocket
+import java.net.URL
+import java.time.LocalDate
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+import portfolio.model.Money
+import portfolio.model.PositionView
+import portfolio.model.ValuationMethod
+import routes.HttpErrorResponse
+import routes.TradeRecord
+import routes.TradesData
+import routes.TradesQuery
+import routes.dto.PositionItemResponse
+import routes.dto.TradesPageResponse
+import security.JwtConfig
+import security.JwtSupport
+
+class PortfolioPositionsTradesRoutesTest {
+    private val jwtConfig = JwtConfig(
+        issuer = "newsbot",
+        audience = "newsbot-clients",
+        realm = "newsbot-api",
+        secret = "test-secret",
+        accessTtlMinutes = 60,
+    )
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `requests without JWT are rejected`() = testApplication {
+        val deps = FakeDeps()
+        application { configureTestApp(deps.toDeps()) }
+
+        val portfolioId = UUID.randomUUID()
+        val positions = get("/api/portfolio/$portfolioId/positions")
+        assertEquals(HttpStatusCode.Unauthorized, positions.status)
+
+        val trades = get("/api/portfolio/$portfolioId/trades")
+        assertEquals(HttpStatusCode.Unauthorized, trades.status)
+    }
+
+    @Test
+    fun `invalid portfolio id returns 400`() = testApplication {
+        val deps = FakeDeps()
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("1")
+        val response = get(
+            path = "/api/portfolio/not-a-uuid/positions",
+            headers = authHeader(token),
+        )
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        val payload = json.decodeFromString<HttpErrorResponse>(response.body)
+        assertEquals("bad_request", payload.error)
+        assertTrue(payload.details?.any { it.contains("portfolioId", ignoreCase = true) } == true)
+    }
+
+    @Test
+    fun `query validation errors return 400`() = testApplication {
+        val deps = FakeDeps()
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("2")
+        val portfolioId = UUID.randomUUID()
+
+        fun request(path: String) = get(path, headers = authHeader(token))
+
+        assertEquals(HttpStatusCode.BadRequest, request("/api/portfolio/$portfolioId/trades?limit=0").status)
+        assertEquals(HttpStatusCode.BadRequest, request("/api/portfolio/$portfolioId/trades?limit=201").status)
+        assertEquals(HttpStatusCode.BadRequest, request("/api/portfolio/$portfolioId/trades?offset=-1").status)
+
+        val reversed = request("/api/portfolio/$portfolioId/trades?from=2024-05-10&to=2024-05-01")
+        assertEquals(HttpStatusCode.BadRequest, reversed.status)
+        val reversedPayload = json.decodeFromString<HttpErrorResponse>(reversed.body)
+        assertTrue(reversedPayload.details?.any { it.contains("from must be on or before to") } == true)
+
+        assertEquals(HttpStatusCode.BadRequest, request("/api/portfolio/$portfolioId/trades?side=HOLD").status)
+    }
+
+    @Test
+    fun `positions endpoint returns data`() = testApplication {
+        val deps = FakeDeps()
+        val positionA = PositionView(
+            instrumentId = 101,
+            instrumentName = "AAA",
+            quantity = BigDecimal("10"),
+            valuation = Money.of(BigDecimal("2500"), "RUB"),
+            averageCost = Money.of(BigDecimal("240"), "RUB"),
+            valuationMethod = ValuationMethod.AVERAGE,
+            unrealizedPnl = Money.of(BigDecimal("100"), "RUB"),
+        )
+        val positionB = PositionView(
+            instrumentId = 99,
+            instrumentName = "BBB",
+            quantity = BigDecimal("5"),
+            valuation = Money.of(BigDecimal("1000"), "RUB"),
+            averageCost = Money.of(BigDecimal("180"), "RUB"),
+            valuationMethod = ValuationMethod.AVERAGE,
+            unrealizedPnl = Money.of(BigDecimal("50"), "RUB"),
+        )
+        deps.positionsResult = Result.success(listOf(positionA, positionB))
+
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("42")
+        val response = get(
+            path = "/api/portfolio/${UUID.randomUUID()}/positions",
+            headers = authHeader(token),
+        )
+        assertEquals(HttpStatusCode.OK, response.status)
+        val payload = json.decodeFromString<List<PositionItemResponse>>(response.body)
+        assertEquals(2, payload.size)
+        assertEquals(99, payload[0].instrumentId)
+        assertEquals("5.00000000", payload[0].qty)
+        assertEquals("200.00000000", payload[0].lastPrice.amount)
+        assertEquals("50.00000000", payload[0].upl.amount)
+    }
+
+    @Test
+    fun `trades endpoint returns page with filters`() = testApplication {
+        val deps = FakeDeps()
+        val tradeRecord = TradeRecord(
+            instrumentId = 123,
+            tradeDate = LocalDate.parse("2024-05-10"),
+            side = "BUY",
+            quantity = BigDecimal("3"),
+            price = Money.of(BigDecimal("150"), "RUB"),
+            notional = Money.of(BigDecimal("450"), "RUB"),
+            fee = Money.of(BigDecimal("5"), "RUB"),
+            tax = null,
+            extId = "t1",
+        )
+        deps.tradesResult = Result.success(TradesData(total = 15, items = listOf(tradeRecord)))
+
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("77")
+        val response = get(
+            path = "/api/portfolio/${UUID.randomUUID()}/trades?limit=10&offset=5&from=2024-05-01&to=2024-05-31&side=BUY",
+            headers = authHeader(token),
+        )
+        assertEquals(HttpStatusCode.OK, response.status)
+        val payload = json.decodeFromString<TradesPageResponse>(response.body)
+        assertEquals(15, payload.total)
+        assertEquals(10, payload.limit)
+        assertEquals(5, payload.offset)
+        assertEquals(1, payload.items.size)
+        val item = payload.items.first()
+        assertEquals("3.00000000", item.quantity)
+        assertEquals("150.00000000", item.price.amount)
+        assertEquals("450.00000000", item.notional.amount)
+        assertEquals("t1", item.extId)
+
+        val captured = deps.lastTradesQuery
+        assertNotNull(captured)
+        assertEquals(10, captured.limit)
+        assertEquals(5, captured.offset)
+        assertEquals(LocalDate.parse("2024-05-01"), captured.from)
+        assertEquals(LocalDate.parse("2024-05-31"), captured.to)
+        assertEquals("BUY", captured.side)
+    }
+
+    @Test
+    fun `domain not found propagates as 404`() = testApplication {
+        val deps = FakeDeps()
+        deps.positionsResult = Result.failure(PortfolioException(PortfolioError.NotFound("No portfolio")))
+
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("88")
+        val response = get(
+            path = "/api/portfolio/${UUID.randomUUID()}/positions",
+            headers = authHeader(token),
+        )
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        val payload = json.decodeFromString<HttpErrorResponse>(response.body)
+        assertEquals("not_found", payload.error)
+        assertEquals("No portfolio", payload.reason)
+    }
+
+    @Test
+    fun `unexpected errors return 500`() = testApplication {
+        val deps = FakeDeps()
+        deps.positionsResult = Result.failure(RuntimeException("boom"))
+
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("99")
+        val response = get(
+            path = "/api/portfolio/${UUID.randomUUID()}/positions",
+            headers = authHeader(token),
+        )
+        assertEquals(HttpStatusCode.InternalServerError, response.status)
+        val payload = json.decodeFromString<HttpErrorResponse>(response.body)
+        assertEquals("internal", payload.error)
+    }
+
+    private fun Application.configureTestApp(deps: PortfolioPositionsTradesDeps) {
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                },
+            )
+        }
+        install(Authentication) {
+            jwt("auth-jwt") {
+                realm = jwtConfig.realm
+                verifier(JwtSupport.verify(jwtConfig))
+                validate { cred -> cred.payload.subject?.let { JWTPrincipal(cred.payload) } }
+            }
+        }
+        attributes.put(PortfolioPositionsTradesDepsKey, deps)
+        routing {
+            authenticate("auth-jwt") {
+                portfolioPositionsTradesRoutes()
+            }
+        }
+    }
+
+    private fun issueToken(subject: String): String = JwtSupport.issueToken(jwtConfig, subject)
+
+    private fun authHeader(token: String): Map<String, String> =
+        mapOf(HttpHeaders.Authorization to "Bearer $token")
+
+    private fun testApplication(block: SimpleTestApplication.() -> Unit) {
+        val app = SimpleTestApplication()
+        try {
+            app.block()
+        } finally {
+            app.close()
+        }
+    }
+
+    private class FakeDeps {
+        var positionsResult: Result<List<PositionView>> = Result.success(emptyList())
+        var tradesResult: Result<TradesData> = Result.success(TradesData(total = 0, items = emptyList()))
+        var lastTradesQuery: TradesQuery? = null
+
+        fun toDeps(): PortfolioPositionsTradesDeps = PortfolioPositionsTradesDeps(
+            listPositions = { positionsResult },
+            listTrades = { _, query ->
+                lastTradesQuery = query
+                tradesResult
+            },
+        )
+    }
+
+    private data class SimpleHttpResponse(
+        val status: HttpStatusCode,
+        val body: String,
+    )
+
+    private class SimpleTestApplication {
+        private var module: (Application.() -> Unit)? = null
+        private var engine: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>? = null
+        private var port: Int = 0
+
+        fun application(configure: Application.() -> Unit) {
+            module = configure
+        }
+
+        fun get(path: String, headers: Map<String, String> = emptyMap()): SimpleHttpResponse =
+            request("GET", path, headers)
+
+        private fun request(
+            method: String,
+            path: String,
+            headers: Map<String, String>,
+            body: String? = null,
+        ): SimpleHttpResponse {
+            ensureStarted()
+            val target = URL("http://127.0.0.1:$port$path")
+            val connection = (target.openConnection() as HttpURLConnection)
+            connection.requestMethod = method
+            connection.instanceFollowRedirects = false
+            headers.forEach { (name, value) -> connection.setRequestProperty(name, value) }
+            if (body != null) {
+                connection.doOutput = true
+                connection.outputStream.use { output ->
+                    output.write(body.toByteArray(Charsets.UTF_8))
+                }
+            }
+            val statusCode = connection.responseCode
+            val stream = if (statusCode >= 400) connection.errorStream else connection.inputStream
+            val responseBody = stream?.bufferedReader()?.use { it.readText() } ?: ""
+            connection.disconnect()
+            return SimpleHttpResponse(HttpStatusCode.fromValue(statusCode), responseBody)
+        }
+
+        private fun ensureStarted() {
+            if (engine == null) {
+                val config = module ?: {}
+                val selectedPort = ServerSocket(0).use { it.localPort }
+                val created = embeddedServer(Netty, host = "127.0.0.1", port = selectedPort, module = config)
+                created.start(wait = false)
+                engine = created
+                port = selectedPort
+            }
+        }
+
+        fun close() {
+            engine?.stop(100, 1000)
+            engine = null
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement authenticated portfolio positions and trades endpoints with strict parameter validation and domain-driven error mapping
- map portfolio domain exceptions to HTTP responses via reusable helpers
- cover success and failure scenarios for the new routes with integration-style tests

## Testing
- ./gradlew :app:compileKotlin --console=plain
- ./gradlew :app:test --tests "routes.PortfolioPositionsTradesRoutesTest" --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68d2b3cd3bac8321aeb9b90599a40ed3