### PR TITLE
Add portfolio trades CSV import endpoint

### DIFF
--- a/app/src/main/kotlin/App.kt
+++ b/app/src/main/kotlin/App.kt
@@ -10,6 +10,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.routing.routing
 import routes.authRoutes
+import routes.portfolioImportRoutes
 import routes.portfolioRoutes
 import routes.portfolioPositionsTradesRoutes
 import security.installSecurity
@@ -34,6 +35,7 @@ fun Application.module() {
         authenticate("auth-jwt") {
             portfolioRoutes()
             portfolioPositionsTradesRoutes()
+            portfolioImportRoutes()
         }
     }
 }

--- a/app/src/main/kotlin/routes/PortfolioImportRoutes.kt
+++ b/app/src/main/kotlin/routes/PortfolioImportRoutes.kt
@@ -1,0 +1,338 @@
+package routes
+
+import db.DatabaseFactory.dbQuery
+import di.portfolioModule
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.content.PartData
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.config.configOrNull
+import io.ktor.server.request.contentLength
+import io.ktor.server.request.contentType
+import io.ktor.server.request.receiveMultipart
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.util.AttributeKey
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import java.io.InputStreamReader
+import java.io.Reader
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.CharacterCodingException
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import portfolio.errors.DomainResult
+import portfolio.service.CsvImportService
+import repo.InstrumentRepository
+import repo.TradeRepository
+import repo.tables.TradesTable
+import routes.dto.ImportFailedItem
+import routes.dto.ImportReportResponse
+import security.userIdOrNull
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+
+private const val MAX_LINES = 100_000
+private const val MAX_LINE_LENGTH = 64_000
+
+fun Route.portfolioImportRoutes() {
+    post("/api/portfolio/{id}/trades/import/csv") {
+        val subject = call.userIdOrNull
+        if (subject == null) {
+            call.respondUnauthorized()
+            return@post
+        }
+
+        val portfolioId = call.parameters["id"].toPortfolioIdOrNull()
+        if (portfolioId == null) {
+            call.respondBadRequest(listOf("portfolioId invalid"))
+            return@post
+        }
+
+        val deps = call.importDeps()
+        val uploadSettings = deps.uploadSettings
+        val contentLength = call.request.contentLength()
+        if (contentLength != null && contentLength > uploadSettings.csvMaxBytes) {
+            call.respondPayloadTooLarge(uploadSettings.csvMaxBytes)
+            return@post
+        }
+
+        val requestContentType = runCatching { call.request.contentType() }.getOrNull()
+        if (requestContentType == null || !requestContentType.match(ContentType.MultiPart.FormData)) {
+            call.respondBadRequest(listOf("multipart form-data required"))
+            return@post
+        }
+
+        val multipart = call.receiveMultipart()
+        var processed = false
+        while (true) {
+            val part = multipart.readPart() ?: break
+            when (part) {
+                is PartData.FileItem -> {
+                    val name = part.name?.lowercase()
+                    if (name != null && name != "file") {
+                        part.dispose()
+                        continue
+                    }
+                    processed = true
+                    val contentType = part.contentType
+                    if (contentType == null || !uploadSettings.isAllowed(contentType)) {
+                        part.dispose()
+                        call.respondUnsupportedMediaType()
+                        return@post
+                    }
+                    val declaredLength = part.headers[HttpHeaders.ContentLength]?.toLongOrNull()
+                    if (declaredLength != null && declaredLength > uploadSettings.csvMaxBytes) {
+                        part.dispose()
+                        call.respondPayloadTooLarge(uploadSettings.csvMaxBytes)
+                        return@post
+                    }
+
+                    val importResult: DomainResult<CsvImportService.ImportReport>
+                    try {
+                        importResult = part.provider().toInputStream().use { stream ->
+                            val reader = stream.toUtf8Reader()
+                            LineLimitingReader(reader, MAX_LINES, MAX_LINE_LENGTH).use { limitingReader ->
+                                deps.importCsv(portfolioId, limitingReader)
+                            }
+                        }
+                    } catch (limit: LineLimitExceededException) {
+                        call.respondPayloadTooLarge(uploadSettings.csvMaxBytes)
+                        return@post
+                    } catch (coding: CharacterCodingException) {
+                        call.respondBadRequest(listOf("file must be UTF-8 encoded"))
+                        return@post
+                    } catch (cause: Throwable) {
+                        call.application.environment.log.error("CSV import failed", cause)
+                        call.respondInternal()
+                        return@post
+                    } finally {
+                        part.dispose()
+                    }
+
+                    importResult.fold(
+                        onSuccess = { report ->
+                            val response = ImportReportResponse(
+                                inserted = report.inserted,
+                                skippedDuplicates = report.skippedDuplicates,
+                                failed = report.failed.map { ImportFailedItem(line = it.lineNumber, error = it.message) },
+                            )
+                            call.respond(response)
+                        },
+                        onFailure = { error -> call.handleDomainError(error) },
+                    )
+                    return@post
+                }
+
+                else -> part.dispose()
+            }
+        }
+
+        if (!processed) {
+            call.respondBadRequest(listOf("file part is required"))
+            return@post
+        }
+
+        call.respondInternal()
+    }
+}
+
+private fun String?.toPortfolioIdOrNull(): UUID? = this?.trim()?.takeIf { it.isNotEmpty() }?.let { value ->
+    runCatching { UUID.fromString(value) }.getOrNull()
+}
+
+internal val PortfolioImportDepsKey = AttributeKey<PortfolioImportDeps>("PortfolioImportDeps")
+
+internal data class PortfolioImportDeps(
+    val importCsv: suspend (UUID, Reader) -> DomainResult<CsvImportService.ImportReport>,
+    val uploadSettings: UploadSettings,
+)
+
+private fun ApplicationCall.importDeps(): PortfolioImportDeps {
+    val attributes = application.attributes
+    if (attributes.contains(PortfolioImportDepsKey)) {
+        return attributes[PortfolioImportDepsKey]
+    }
+
+    val module = application.portfolioModule()
+    val instrumentRepository = module.repositories.instrumentRepository
+    val tradeRepository = module.repositories.tradeRepository
+    val portfolioService = module.services.portfolioService
+    val valuationMethod = module.settings.portfolio.defaultValuationMethod
+    val settings = UploadSettings.fromConfig(application.environment.config)
+    val service = CsvImportService(
+        instrumentResolver = DatabaseInstrumentResolver(instrumentRepository),
+        tradeLookup = DatabaseTradeLookup(tradeRepository),
+        portfolioService = portfolioService,
+    )
+    val deps = PortfolioImportDeps(
+        importCsv = { portfolioId, reader -> service.import(portfolioId, reader, valuationMethod) },
+        uploadSettings = settings,
+    )
+    attributes.put(PortfolioImportDepsKey, deps)
+    return deps
+}
+
+internal data class UploadSettings(
+    val csvMaxBytes: Long,
+    val allowedContentTypes: Set<ContentType>,
+) {
+    fun isAllowed(contentType: ContentType): Boolean = allowedContentTypes.any { allowed -> contentType.match(allowed) }
+
+    companion object {
+        private const val DEFAULT_MAX_BYTES = 1_048_576L
+        private val DEFAULT_ALLOWED = setOf(
+            ContentType.Text.CSV,
+            ContentType.Application.OctetStream,
+            ContentType.parse("application/vnd.ms-excel"),
+        )
+
+        fun fromConfig(config: ApplicationConfig): UploadSettings {
+            val uploadConfig = config.configOrNull("upload")
+            val maxBytes = uploadConfig?.longProperty("csvMaxBytes") ?: DEFAULT_MAX_BYTES
+            val allowed = uploadConfig?.contentTypeSet("allowedCsvContentTypes") ?: DEFAULT_ALLOWED
+            return UploadSettings(csvMaxBytes = maxBytes, allowedContentTypes = allowed)
+        }
+    }
+}
+
+private fun ApplicationConfig.longProperty(name: String): Long? {
+    val raw = propertyOrNull(name)?.getString()?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val value = raw.toLongOrNull() ?: throw IllegalArgumentException("upload.$name must be a positive integer")
+    require(value > 0) { "upload.$name must be greater than zero" }
+    return value
+}
+
+private fun ApplicationConfig.contentTypeSet(name: String): Set<ContentType>? {
+    val values = propertyOrNull(name)?.getList()?.map { it.trim() }?.filter { it.isNotEmpty() } ?: return null
+    if (values.isEmpty()) return null
+    return values.map { ContentType.parse(it) }.toSet()
+}
+
+private fun java.io.InputStream.toUtf8Reader(): Reader {
+    val decoder = Charsets.UTF_8.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT)
+    return InputStreamReader(this, decoder)
+}
+
+private class LineLimitingReader(
+    private val delegate: Reader,
+    private val maxLines: Int,
+    private val maxLineLength: Int,
+) : Reader() {
+    private var lineCount = 0
+    private var currentLineLength = 0
+    private var lastWasCarriageReturn = false
+    private var sawAnyCharacter = false
+
+    override fun read(cbuf: CharArray, off: Int, len: Int): Int {
+        val read = delegate.read(cbuf, off, len)
+        if (read <= 0) {
+            return read
+        }
+        for (index in 0 until read) {
+            val char = cbuf[off + index]
+            when (char) {
+                '\n' -> {
+                    if (!lastWasCarriageReturn) {
+                        incrementLines()
+                    }
+                    currentLineLength = 0
+                    lastWasCarriageReturn = false
+                }
+                '\r' -> {
+                    incrementLines()
+                    currentLineLength = 0
+                    lastWasCarriageReturn = true
+                }
+                else -> {
+                    sawAnyCharacter = true
+                    currentLineLength += 1
+                    if (currentLineLength > maxLineLength) {
+                        throw LineLimitExceededException()
+                    }
+                    lastWasCarriageReturn = false
+                }
+            }
+        }
+        return read
+    }
+
+    override fun close() {
+        val effectiveLines = when {
+            !sawAnyCharacter && lineCount == 0 -> 0
+            currentLineLength > 0 -> lineCount + 1
+            lastWasCarriageReturn -> lineCount
+            else -> lineCount
+        }
+        if (effectiveLines > maxLines) {
+            throw LineLimitExceededException()
+        }
+        delegate.close()
+    }
+
+    private fun incrementLines() {
+        lineCount += 1
+        if (lineCount > maxLines) {
+            throw LineLimitExceededException()
+        }
+    }
+}
+
+private class LineLimitExceededException : RuntimeException()
+
+private class DatabaseInstrumentResolver(
+    private val repository: InstrumentRepository,
+) : CsvImportService.InstrumentResolver {
+    override suspend fun findBySymbol(
+        exchange: String,
+        board: String?,
+        symbol: String,
+    ): DomainResult<CsvImportService.InstrumentRef?> = runCatching {
+        repository.findBySymbol(exchange, board, symbol)?.let { CsvImportService.InstrumentRef(it.instrumentId) }
+    }
+
+    override suspend fun findByAlias(
+        alias: String,
+        source: String,
+    ): DomainResult<CsvImportService.InstrumentRef?> = runCatching {
+        repository.findAlias(alias, source)?.let { aliasEntity ->
+            repository.findById(aliasEntity.instrumentId)?.let { CsvImportService.InstrumentRef(it.instrumentId) }
+        }
+    }
+}
+
+private class DatabaseTradeLookup(
+    private val repository: TradeRepository,
+) : CsvImportService.TradeLookup {
+    override suspend fun existsByExternalId(
+        portfolioId: UUID,
+        externalId: String,
+    ): DomainResult<Boolean> = runCatching {
+        repository.findByExternalId(externalId)?.portfolioId == portfolioId
+    }
+
+    override suspend fun existsBySoftKey(key: CsvImportService.SoftTradeKey): DomainResult<Boolean> = runCatching {
+        dbQuery {
+            TradesTable
+                .select {
+                    (TradesTable.portfolioId eq key.portfolioId) and
+                        (TradesTable.instrumentId eq key.instrumentId) and
+                        (TradesTable.datetime eq key.executedAt.toUtcTimestamp()) and
+                        (TradesTable.side eq key.side.name) and
+                        (TradesTable.quantity eq key.quantity) and
+                        (TradesTable.price eq key.price)
+                }
+                .limit(1)
+                .any()
+        }
+    }
+}
+
+private fun Instant.toUtcTimestamp(): OffsetDateTime = OffsetDateTime.ofInstant(this, ZoneOffset.UTC)

--- a/app/src/main/kotlin/routes/dto/ImportDtos.kt
+++ b/app/src/main/kotlin/routes/dto/ImportDtos.kt
@@ -1,0 +1,16 @@
+package routes.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ImportFailedItem(
+    val line: Int,
+    val error: String,
+)
+
+@Serializable
+data class ImportReportResponse(
+    val inserted: Int,
+    val skippedDuplicates: Int,
+    val failed: List<ImportFailedItem>,
+)

--- a/app/src/test/kotlin/routes/PortfolioImportRoutesTest.kt
+++ b/app/src/test/kotlin/routes/PortfolioImportRoutesTest.kt
@@ -1,0 +1,390 @@
+package routes
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.jwt.jwt
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import java.io.ByteArrayOutputStream
+import java.net.HttpURLConnection
+import java.net.ServerSocket
+import java.net.URL
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlin.io.readText
+import portfolio.errors.PortfolioError
+import portfolio.errors.PortfolioException
+import portfolio.service.CsvImportService
+import routes.dto.ImportReportResponse
+import security.JwtConfig
+import security.JwtSupport
+
+class PortfolioImportRoutesTest {
+    private val jwtConfig = JwtConfig(
+        issuer = "newsbot",
+        audience = "newsbot-clients",
+        realm = "newsbot-api",
+        secret = "test-secret",
+        accessTtlMinutes = 60,
+    )
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `requests without JWT return 401`() = testApplication {
+        val deps = FakeDeps()
+        application { configureTestApp(deps.toDeps()) }
+
+        val response = postMultipart(
+            path = "/api/portfolio/${UUID.randomUUID()}/trades/import/csv",
+            parts = listOf(multipartFile("file", "trades.csv", "text/csv", "ext_id,datetime\n".toByteArray())),
+        )
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `invalid portfolio id returns 400`() = testApplication {
+        val deps = FakeDeps()
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("123")
+        val response = postMultipart(
+            path = "/api/portfolio/not-a-uuid/trades/import/csv",
+            headers = authHeader(token),
+            parts = listOf(multipartFile("file", "trades.csv", "text/csv", "ext_id,datetime\n".toByteArray())),
+        )
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        val payload = json.decodeFromString<HttpErrorResponse>(response.body)
+        assertEquals("bad_request", payload.error)
+        assertTrue(payload.details?.any { it.contains("portfolioId", ignoreCase = true) } == true)
+    }
+
+    @Test
+    fun `missing file part returns 400`() = testApplication {
+        val deps = FakeDeps()
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("456")
+        val response = postMultipart(
+            path = "/api/portfolio/${UUID.randomUUID()}/trades/import/csv",
+            headers = authHeader(token),
+            parts = listOf(
+                MultipartPart(name = "meta", filename = null, contentType = "text/plain", content = "value".toByteArray()),
+            ),
+        )
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        val payload = json.decodeFromString<HttpErrorResponse>(response.body)
+        assertEquals("bad_request", payload.error)
+        assertTrue(payload.details?.any { it.contains("file part", ignoreCase = true) } == true)
+    }
+
+    @Test
+    fun `unsupported mime type returns 415`() = testApplication {
+        val deps = FakeDeps()
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("789")
+        val response = postMultipart(
+            path = "/api/portfolio/${UUID.randomUUID()}/trades/import/csv",
+            headers = authHeader(token),
+            parts = listOf(multipartFile("file", "image.png", "image/png", ByteArray(8) { 1 })),
+        )
+        assertEquals(HttpStatusCode.UnsupportedMediaType, response.status)
+        val payload = json.decodeFromString<HttpErrorResponse>(response.body)
+        assertEquals("unsupported_media_type", payload.error)
+    }
+
+    @Test
+    fun `payload larger than limit returns 413`() = testApplication {
+        val deps = FakeDeps().apply { maxBytes = 64 }
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("111")
+        val large = ByteArray(256) { 'A'.code.toByte() }
+        val response = postMultipart(
+            path = "/api/portfolio/${UUID.randomUUID()}/trades/import/csv",
+            headers = authHeader(token),
+            parts = listOf(
+                multipartFile(
+                    name = "file",
+                    filename = "trades.csv",
+                    contentType = "text/csv",
+                    content = large,
+                    headers = mapOf(HttpHeaders.ContentLength to (large.size.toLong()).toString()),
+                ),
+            ),
+        )
+        assertEquals(HttpStatusCode.PayloadTooLarge, response.status)
+        val payload = json.decodeFromString<HttpErrorResponse>(response.body)
+        assertEquals("payload_too_large", payload.error)
+        assertEquals(64, payload.limit)
+    }
+
+    @Test
+    fun `successful import returns report`() = testApplication {
+        val deps = FakeDeps().apply {
+            result = Result.success(
+                CsvImportService.ImportReport(
+                    inserted = 3,
+                    skippedDuplicates = 1,
+                    failed = listOf(
+                        CsvImportService.ImportFailure(lineNumber = 4, extId = "dup", message = "SELL exceeds free qty"),
+                        CsvImportService.ImportFailure(lineNumber = 6, extId = null, message = "Invalid price"),
+                    ),
+                ),
+            )
+        }
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("222")
+        val csv = "ext_id,datetime,ticker,exchange,board,alias_source,side,quantity,price,currency,fee,fee_currency,tax,tax_currency,broker,note\n"
+        val response = postMultipart(
+            path = "/api/portfolio/${UUID.randomUUID()}/trades/import/csv",
+            headers = authHeader(token),
+            parts = listOf(multipartFile("file", "trades.csv", "text/csv", csv.toByteArray())),
+        )
+        assertEquals(HttpStatusCode.OK, response.status)
+        val payload = json.decodeFromString<ImportReportResponse>(response.body)
+        assertEquals(3, payload.inserted)
+        assertEquals(1, payload.skippedDuplicates)
+        assertEquals(2, payload.failed.size)
+        val first = payload.failed.first()
+        assertEquals(4, first.line)
+        assertEquals("SELL exceeds free qty", first.error)
+        val second = payload.failed.last()
+        assertEquals(6, second.line)
+        assertEquals("Invalid price", second.error)
+    }
+
+    @Test
+    fun `domain not found returns 404`() = testApplication {
+        val deps = FakeDeps().apply {
+            result = Result.failure(PortfolioException(PortfolioError.NotFound("Portfolio missing")))
+        }
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("333")
+        val response = postMultipart(
+            path = "/api/portfolio/${UUID.randomUUID()}/trades/import/csv",
+            headers = authHeader(token),
+            parts = listOf(multipartFile("file", "trades.csv", "text/csv", "ext_id,datetime\n".toByteArray())),
+        )
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        val payload = json.decodeFromString<HttpErrorResponse>(response.body)
+        assertEquals("not_found", payload.error)
+        assertEquals("Portfolio missing", payload.reason)
+    }
+
+    @Test
+    fun `unexpected errors return 500`() = testApplication {
+        val deps = FakeDeps().apply { throwOnImport = RuntimeException("boom") }
+        application { configureTestApp(deps.toDeps()) }
+
+        val token = issueToken("444")
+        val response = postMultipart(
+            path = "/api/portfolio/${UUID.randomUUID()}/trades/import/csv",
+            headers = authHeader(token),
+            parts = listOf(multipartFile("file", "trades.csv", "text/csv", "ext_id,datetime\n".toByteArray())),
+        )
+        assertEquals(HttpStatusCode.InternalServerError, response.status)
+        val payload = json.decodeFromString<HttpErrorResponse>(response.body)
+        assertEquals("internal", payload.error)
+    }
+
+    private fun Application.configureTestApp(deps: PortfolioImportDeps) {
+        install(ContentNegotiation) {
+            json(json)
+        }
+        install(Authentication) {
+            jwt("auth-jwt") {
+                realm = jwtConfig.realm
+                verifier(JwtSupport.verify(jwtConfig))
+                validate { credentials -> credentials.payload.subject?.let { JWTPrincipal(credentials.payload) } }
+            }
+        }
+        attributes.put(PortfolioImportDepsKey, deps)
+        routing {
+            authenticate("auth-jwt") {
+                portfolioImportRoutes()
+            }
+        }
+    }
+
+    private fun issueToken(subject: String): String = JwtSupport.issueToken(jwtConfig, subject)
+
+    private fun authHeader(token: String): Map<String, String> = mapOf(HttpHeaders.Authorization to "Bearer $token")
+
+    private fun multipartFile(
+        name: String,
+        filename: String,
+        contentType: String,
+        content: ByteArray,
+        headers: Map<String, String> = emptyMap(),
+    ): MultipartPart = MultipartPart(
+        name = name,
+        filename = filename,
+        contentType = contentType,
+        content = content,
+        headers = headers,
+    )
+
+    private fun testApplication(block: SimpleTestApplication.() -> Unit) {
+        val app = SimpleTestApplication()
+        try {
+            app.block()
+        } finally {
+            app.close()
+        }
+    }
+
+    private data class MultipartPart(
+        val name: String,
+        val filename: String?,
+        val contentType: String?,
+        val content: ByteArray,
+        val headers: Map<String, String> = emptyMap(),
+    )
+
+    private data class SimpleHttpResponse(
+        val status: HttpStatusCode,
+        val body: String,
+    )
+
+    private class SimpleTestApplication {
+        private var module: (Application.() -> Unit)? = null
+        private var engine: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>? = null
+        private var port: Int = 0
+
+        fun application(configure: Application.() -> Unit) {
+            module = configure
+        }
+
+        fun postMultipart(
+            path: String,
+            headers: Map<String, String> = emptyMap(),
+            parts: List<MultipartPart>,
+            contentLengthOverride: Long? = null,
+        ): SimpleHttpResponse {
+            val boundary = "Boundary-${'$'}{System.currentTimeMillis()}"
+            val body = buildMultipart(boundary, parts)
+            val combinedHeaders = headers + mapOf("Content-Type" to "multipart/form-data; boundary=$boundary")
+            val length = contentLengthOverride ?: body.size.toLong()
+            return request("POST", path, combinedHeaders, body, length)
+        }
+
+        private fun request(
+            method: String,
+            path: String,
+            headers: Map<String, String>,
+            body: ByteArray?,
+            contentLength: Long?,
+        ): SimpleHttpResponse {
+            ensureStarted()
+            val connection = (URL("http://127.0.0.1:$port$path").openConnection() as HttpURLConnection)
+            connection.requestMethod = method
+            connection.instanceFollowRedirects = false
+            headers.forEach { (name, value) -> connection.setRequestProperty(name, value) }
+            if (body != null) {
+                if (contentLength != null) {
+                    connection.setFixedLengthStreamingMode(contentLength)
+                }
+                connection.doOutput = true
+                try {
+                    connection.outputStream.use { output ->
+                        output.write(body)
+                        output.flush()
+                    }
+                } catch (_: java.io.IOException) {
+                    // Server may close the connection early when rejecting oversized payloads.
+                }
+            }
+            val status = connection.responseCode
+            val stream = if (status >= 400) connection.errorStream else connection.inputStream
+            val responseBody = stream?.bufferedReader()?.use { it.readText() } ?: ""
+            connection.disconnect()
+            return SimpleHttpResponse(HttpStatusCode.fromValue(status), responseBody)
+        }
+
+        private fun buildMultipart(boundary: String, parts: List<MultipartPart>): ByteArray {
+            val output = ByteArrayOutputStream()
+            for (part in parts) {
+                output.write("--$boundary\r\n".toByteArray())
+                val disposition = buildString {
+                    append("Content-Disposition: form-data; name=\"")
+                    append(part.name)
+                    append("\"")
+                    part.filename?.let {
+                        append("; filename=\"")
+                        append(it)
+                        append("\"")
+                    }
+                }
+                output.write("$disposition\r\n".toByteArray())
+                part.contentType?.let { output.write("Content-Type: $it\r\n".toByteArray()) }
+                part.headers.forEach { (headerName, headerValue) ->
+                    if (!headerName.equals("Content-Type", ignoreCase = true)) {
+                        output.write("$headerName: $headerValue\r\n".toByteArray())
+                    }
+                }
+                output.write("\r\n".toByteArray())
+                output.write(part.content)
+                output.write("\r\n".toByteArray())
+            }
+            output.write("--$boundary--\r\n".toByteArray())
+            return output.toByteArray()
+        }
+
+        private fun ensureStarted() {
+            if (engine == null) {
+                val config = module ?: {}
+                val selectedPort = ServerSocket(0).use { it.localPort }
+                val created = embeddedServer(Netty, host = "127.0.0.1", port = selectedPort, module = config)
+                created.start(wait = false)
+                engine = created
+                port = selectedPort
+            }
+        }
+
+        fun close() {
+            engine?.stop(100, 1000)
+            engine = null
+        }
+    }
+
+    private class FakeDeps {
+        var result: Result<CsvImportService.ImportReport> = Result.success(CsvImportService.ImportReport())
+        var throwOnImport: Throwable? = null
+        var maxBytes: Long = 1_048_576
+        var allowed: Set<ContentType> = setOf(ContentType.Text.CSV)
+
+        fun toDeps(): PortfolioImportDeps = PortfolioImportDeps(
+            importCsv = { _, reader ->
+                throwOnImport?.let { throw it }
+                reader.use { it.readText() }
+                result
+            },
+            uploadSettings = UploadSettings(
+                csvMaxBytes = maxBytes,
+                allowedContentTypes = allowed,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- implement the `/api/portfolio/{id}/trades/import/csv` route with multipart validation, streaming limits, and CsvImportService integration
- add import response DTOs and extend HTTP utility responses for media-type and payload errors
- cover the CSV import endpoint with route tests for success and failure scenarios

## Testing
- ./gradlew :app:compileKotlin
- ./gradlew :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d3e4d4aa348321a011e73362356dbc