### PR TITLE
Add API smoke documentation and sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,45 +25,140 @@ Copy `.env.example` to `.env` and provide the required values.
 
 ## P05 — API smoke
 
-Use these smoke commands against a locally running instance (`./gradlew :app:run`):
+Быстрые smoke-команды для проверки ключевых REST-ручек локального стенда (`./gradlew :app:run`). Все примеры используют `curl` + `jq` и безопасны для публикации.
 
-Auth (Mini App verify):
-
-```bash
-curl -sX POST http://localhost:8080/api/auth/telegram/verify \
-  -H 'content-type: application/json' \
-  -d '{"initData":"<Telegram.WebApp.initData>"}' | jq .
-```
-
-Expected: HTTP 200 with a token for valid `initData`; otherwise 400/401.
-
-Quotes (public):
+### 1. Подготовка окружения
 
 ```bash
-curl -s 'http://localhost:8080/api/quotes/closeOrLast?instrumentId=1&date=2025-09-20' | jq .
+export BASE="http://localhost:8080"
+# JWT появится после успешной проверки initData
 ```
 
-Portfolio (JWT protected):
+PowerShell (под Windows):
+
+```powershell
+$env:BASE="http://localhost:8080"
+```
+
+### 2. Health (публично)
 
 ```bash
-export JWT='<paste_test_jwt>'
-curl -s -H "Authorization: Bearer $JWT" http://localhost:8080/api/portfolio | jq .
+curl -s "$BASE/health/db" | jq .
+# 200, ответ содержит поле "db":"up" (или soft-ok)
 ```
 
-Import CSV (multipart):
+### 3. Auth: verify initData (публично)
 
 ```bash
-curl -s -X POST "http://localhost:8080/api/portfolio/<id>/trades/import/csv" \
-  -H "Authorization: Bearer $JWT" \
-  -F "file=@samples/trades.csv;type=text/csv" | jq .
+# Подставьте initData из window.Telegram.WebApp.initData вашего Mini App
+curl -s -X POST "$BASE/api/auth/telegram/verify" \
+  -H "content-type: application/json" \
+  -d '{"initData":"<TELEGRAM_WEBAPP_INITDATA>"}' | jq .
+
+# Ожидаем 200 + { "token":"<JWT>", "expiresAt": "...", "user":{"id": ... } }
+# Сохранить JWT:
+export JWT="<ПОДСТАВЬТЕ_ЗНАЧЕНИЕ_ИЗ_ОТВЕТА>"
 ```
 
-Revalue / Report (JWT protected):
+Ошибки:
+
+- `400` — некорректное тело/параметры.
+- `401` — невалидная подпись `initData` или протухший `auth_date`.
+
+PowerShell:
+
+```powershell
+# После успешного ответа выполните
+$env:JWT="<ПОДСТАВЬТЕ_ЗНАЧЕНИЕ_ИЗ_ОТВЕТА>"
+```
+
+### 4. Quotes (публично)
+
+```bash
+curl -s "$BASE/api/quotes/closeOrLast?instrumentId=1&date=2025-09-20" | jq .
+# 200 → { "amount":"123.45000000", "ccy":"RUB" }
+# 400 → неверные параметры; 404 → нет цены; 500 → внутренняя ошибка
+```
+
+### 5. Portfolio (под JWT)
+
+Список:
+
+```bash
+curl -s -H "Authorization: Bearer $JWT" "$BASE/api/portfolio" | jq .
+# 200 → [] или список
+```
+
+Создание:
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $JWT" \
+  -H "content-type: application/json" \
+  -d '{ "name":"My RUB PF", "baseCurrency":"RUB", "valuationMethod":"AVERAGE" }' \
+  "$BASE/api/portfolio" | jq .
+# 201 → { "id":"<UUID>", ... }
+export PORTFOLIO_ID="<ПОДСТАВЬТЕ_UUID_ИЗ_ОТВЕТА>"
+```
+
+Ошибки:
+
+- `400` — валидации (валюта/имя).
+- `409` — дубль имени у пользователя.
+
+PowerShell:
+
+```powershell
+$env:PORTFOLIO_ID="<ПОДСТАВЬТЕ_UUID_ИЗ_ОТВЕТА>"
+```
+
+### 6. Positions & Trades (под JWT)
 
 ```bash
 curl -s -H "Authorization: Bearer $JWT" \
-  -X POST "http://localhost:8080/api/portfolio/<id>/revalue?date=2025-09-20" | jq .
+  "$BASE/api/portfolio/$PORTFOLIO_ID/positions?sort=instrumentId&order=asc" | jq .
+# 200 → массив позиций
 
 curl -s -H "Authorization: Bearer $JWT" \
-  "http://localhost:8080/api/portfolio/<id>/report?from=2025-09-01&to=2025-09-20" | jq .
+  "$BASE/api/portfolio/$PORTFOLIO_ID/trades?limit=50&offset=0" | jq .
+# 200 → { "total":..., "items":[...], "limit":50, "offset":0 }
 ```
+
+Ошибки:
+
+- `400` — неверные `limit`/`offset`/`uuid`.
+- `401` — без JWT.
+
+### 7. Import CSV (multipart, под JWT)
+
+Подготовьте sample-файл (см. `samples/trades.csv` ниже), затем:
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $JWT" \
+  -F "file=@samples/trades.csv;type=text/csv" \
+  "$BASE/api/portfolio/$PORTFOLIO_ID/trades/import/csv" | jq .
+# 200 → { "inserted": N, "skippedDuplicates": M, "failed":[...] }
+# 415 → неверный MIME; 413 → превышен лимит; 400 → нет части file или неверный UUID
+```
+
+### 8. Revalue / Report (под JWT)
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $JWT" \
+  "$BASE/api/portfolio/$PORTFOLIO_ID/revalue?date=2025-09-20" | jq .
+# 200 → ValuationDailyResponse
+
+curl -s -H "Authorization: Bearer $JWT" \
+  "$BASE/api/portfolio/$PORTFOLIO_ID/report?from=2025-09-01&to=2025-09-20" | jq .
+# 200 → PortfolioReportResponse
+```
+
+Ошибки:
+
+- `400` — некорректный диапазон/формат дат.
+- `404` — портфель отсутствует.
+
+### 9. Коды и подсказки
+
+- `200/201` — успех; `400` — неверные параметры; `401` — требуется JWT; `404` — не найдено; `409` — конфликт; `413/415` — лимиты/тип; `500` — внутренняя ошибка.
+- Для Windows PowerShell замените `export` на `$env:NAME="value"`.
+- JWT безопасно хранить только в переменных окружения текущей сессии.

--- a/docs/smoke.http
+++ b/docs/smoke.http
@@ -1,0 +1,60 @@
+### Base
+@BASE = http://localhost:8080
+@JWT = {{JWT}}
+
+### Health
+GET {{BASE}}/health/db
+
+### Quotes (public)
+GET {{BASE}}/api/quotes/closeOrLast?instrumentId=1&date=2025-09-20
+
+### Auth verify (public)
+POST {{BASE}}/api/auth/telegram/verify
+content-type: application/json
+
+{
+  "initData": "<TELEGRAM_WEBAPP_INITDATA>"
+}
+
+### Portfolio (JWT)
+GET {{BASE}}/api/portfolio
+Authorization: Bearer {{JWT}}
+
+### Portfolio create (JWT)
+POST {{BASE}}/api/portfolio
+Authorization: Bearer {{JWT}}
+content-type: application/json
+
+{
+  "name": "My RUB PF",
+  "baseCurrency": "RUB",
+  "valuationMethod": "AVERAGE"
+}
+
+### Positions (JWT)
+GET {{BASE}}/api/portfolio/{{PORTFOLIO_ID}}/positions?sort=instrumentId&order=asc
+Authorization: Bearer {{JWT}}
+
+### Trades list (JWT)
+GET {{BASE}}/api/portfolio/{{PORTFOLIO_ID}}/trades?limit=50&offset=0
+Authorization: Bearer {{JWT}}
+
+### Import trades CSV (JWT)
+POST {{BASE}}/api/portfolio/{{PORTFOLIO_ID}}/trades/import/csv
+Authorization: Bearer {{JWT}}
+Content-Type: multipart/form-data; boundary=WebAppBoundary
+
+--WebAppBoundary
+Content-Disposition: form-data; name="file"; filename="trades.csv"
+Content-Type: text/csv
+
+< ./samples/trades.csv
+--WebAppBoundary--
+
+### Revalue (JWT)
+POST {{BASE}}/api/portfolio/{{PORTFOLIO_ID}}/revalue?date=2025-09-20
+Authorization: Bearer {{JWT}}
+
+### Report (JWT)
+GET {{BASE}}/api/portfolio/{{PORTFOLIO_ID}}/report?from=2025-09-01&to=2025-09-20
+Authorization: Bearer {{JWT}}

--- a/samples/trades.csv
+++ b/samples/trades.csv
@@ -1,0 +1,6 @@
+trade_id,datetime,exchange,board,symbol,side,quantity,price,price_currency,fee,fee_currency,tax,tax_currency,account_id,broker,note,ext_id
+t1,2025-09-05 10:05:00,MOEX,TQBR,SBER,BUY,100,290.50,RUB,5.00,RUB,,,acc1,MyBroker,Buy SBER,t1
+t2,2025-09-05 12:30:00,MOEX,TQBR,SBER,SELL,50,300.00,RUB,5.00,RUB,,,acc1,MyBroker,Partial sell,t2
+t3,2025-09-06 11:00:00,CRYPTO,,TONUSDT,BUY,100.0,7.250,USDT,0.4,USDT,,,acc1,Binance,Buy TON,t3
+t3_dup,2025-09-06 11:00:00,CRYPTO,,TONUSDT,BUY,100.0,7.250,USDT,0.4,USDT,,,acc1,Binance,Duplicate by ext_id,t3
+bad_sell,2025-09-07 09:00:00,MOEX,TQBR,SBER,SELL,1000,310.00,RUB,5.00,RUB,,,acc1,MyBroker,Exceeds qty,bad4


### PR DESCRIPTION
## Summary
- add a comprehensive P05 API smoke section to the README with reusable curl recipes
- provide a sample trades CSV covering duplicates and failures for manual import testing
- add an IDE-friendly smoke.http collection mirroring the smoke checklist

## Testing
- ./gradlew :app:compileKotlin --console=plain
- ./gradlew :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d411ebf5348321996904cdb56dce96