### PR TITLE
Document route grouping and format test application config

### DIFF
--- a/app/src/main/kotlin/App.kt
+++ b/app/src/main/kotlin/App.kt
@@ -20,10 +20,12 @@ fun Application.module() {
     installPortfolioModule()
 
     routing {
+        // Публичные
         healthRoutes()
         authRoutes()
         quotesRoutes()
 
+        // Защищённые (под JWT)
         authenticate("auth-jwt") {
             portfolioRoutes()
             portfolioPositionsTradesRoutes()

--- a/app/src/test/resources/application.conf
+++ b/app/src/test/resources/application.conf
@@ -7,21 +7,12 @@ security {
   webappTtlMinutes = 15
 }
 
-telegram {
-  botToken = "123456789:TEST_TOKEN"
-}
+telegram { botToken = "123456789:TEST_TOKEN" }
 
 upload {
   csvMaxBytes = 262144
   allowedCsvContentTypes = ["text/csv","application/octet-stream"]
 }
 
-portfolio {
-  defaultValuationMethod = "AVERAGE"
-  autoCreateInstruments = true
-}
-
-pricing {
-  preferClosePrice = true
-  fallbackToLast = true
-}
+portfolio { defaultValuationMethod = "AVERAGE", autoCreateInstruments = true }
+pricing   { preferClosePrice = true, fallbackToLast = true }


### PR DESCRIPTION
## Summary
- mark the public and JWT-protected route groups in `Application.module`
- inline the stub values in the test `application.conf` to match the desired format

## Testing
- ./gradlew :app:compileKotlin --console=plain
- ./gradlew :app:test --tests "AppWiringSmokeTest" --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d4147aeae08321912cc68f5a221407