### PR TITLE
Add billing core models and DTO tests

### DIFF
--- a/core/src/main/kotlin/billing/model/BillingModels.kt
+++ b/core/src/main/kotlin/billing/model/BillingModels.kt
@@ -1,0 +1,122 @@
+package billing.model
+
+import java.time.Instant
+import kotlinx.serialization.Serializable
+
+enum class Tier {
+    FREE,
+    PRO,
+    PRO_PLUS,
+    VIP;
+
+    fun level(): Int = when (this) {
+        FREE -> 0
+        PRO -> 1
+        PRO_PLUS -> 2
+        VIP -> 3
+    }
+
+    fun meets(required: Tier): Boolean = level() >= required.level()
+
+    companion object {
+        fun parse(value: String): Tier {
+            val trimmed = value.trim()
+            return entries.firstOrNull { it.name.equals(trimmed, ignoreCase = true) }
+                ?: throw IllegalArgumentException("Unknown tier: $value")
+        }
+    }
+}
+
+enum class SubStatus {
+    ACTIVE,
+    EXPIRED,
+    CANCELLED,
+    PENDING;
+
+    companion object {
+        fun parse(value: String): SubStatus {
+            val trimmed = value.trim()
+            return entries.firstOrNull { it.name.equals(trimmed, ignoreCase = true) }
+                ?: throw IllegalArgumentException("Unknown subscription status: $value")
+        }
+    }
+}
+
+@JvmInline
+value class Xtr(val value: Long) {
+    init {
+        require(value >= 0) { "XTR must be >= 0" }
+    }
+
+    override fun toString(): String = value.toString()
+}
+
+data class BillingPlan(
+    val tier: Tier,
+    val title: String,
+    val priceXtr: Xtr,
+    val isActive: Boolean
+) {
+    init {
+        require(title.isNotBlank()) { "Billing plan title must not be blank" }
+    }
+}
+
+data class UserSubscription(
+    val userId: Long,
+    val tier: Tier,
+    val status: SubStatus,
+    val startedAt: Instant,
+    val expiresAt: Instant?
+)
+
+@Serializable
+data class BillingPlanDto(
+    val tier: String,
+    val title: String,
+    val priceXtr: Long,
+    val isActive: Boolean
+)
+
+@Serializable
+data class UserSubscriptionDto(
+    val userId: Long,
+    val tier: String,
+    val status: String,
+    val startedAt: String,
+    val expiresAt: String?
+)
+
+fun BillingPlan.toDto(): BillingPlanDto = BillingPlanDto(
+    tier = tier.name,
+    title = title,
+    priceXtr = priceXtr.value,
+    isActive = isActive
+)
+
+fun BillingPlanDto.toDomain(): BillingPlan = BillingPlan(
+    tier = Tier.parse(tier),
+    title = title,
+    priceXtr = Xtr(priceXtr),
+    isActive = isActive
+)
+
+fun UserSubscription.toDto(): UserSubscriptionDto = UserSubscriptionDto(
+    userId = userId,
+    tier = tier.name,
+    status = status.name,
+    startedAt = startedAt.toIsoString(),
+    expiresAt = expiresAt?.toIsoString()
+)
+
+fun UserSubscriptionDto.toDomain(): UserSubscription = UserSubscription(
+    userId = userId,
+    tier = Tier.parse(tier),
+    status = SubStatus.parse(status),
+    startedAt = startedAt.toInstantUnsafe(),
+    expiresAt = expiresAt?.toInstantUnsafe()
+)
+
+fun Instant.toIsoString(): String = toString()
+
+fun String.toInstantUnsafe(): Instant = Instant.parse(this)

--- a/core/src/test/kotlin/billing/BillingModelsTest.kt
+++ b/core/src/test/kotlin/billing/BillingModelsTest.kt
@@ -1,0 +1,140 @@
+package billing
+
+import billing.model.BillingPlan
+import billing.model.BillingPlanDto
+import billing.model.SubStatus
+import billing.model.Tier
+import billing.model.UserSubscription
+import billing.model.UserSubscriptionDto
+import billing.model.Xtr
+import billing.model.toDomain
+import billing.model.toDto
+import billing.model.toInstantUnsafe
+import billing.model.toIsoString
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class BillingModelsTest {
+    private val json = Json
+
+    @Test
+    fun `tier parse handles different cases`() {
+        assertEquals(Tier.FREE, Tier.parse("free"))
+        assertEquals(Tier.PRO, Tier.parse("Pro"))
+        assertEquals(Tier.PRO_PLUS, Tier.parse("PRO_PLUS"))
+        assertEquals(Tier.VIP, Tier.parse("vip"))
+    }
+
+    @Test
+    fun `tier parse throws on unknown value`() {
+        val ex = assertFailsWith<IllegalArgumentException> { Tier.parse("gold") }
+        assertTrue(ex.message!!.contains("Unknown tier"))
+    }
+
+    @Test
+    fun `sub status parse handles different cases`() {
+        assertEquals(SubStatus.ACTIVE, SubStatus.parse("active"))
+        assertEquals(SubStatus.EXPIRED, SubStatus.parse("Expired"))
+        assertEquals(SubStatus.CANCELLED, SubStatus.parse("CANCELLED"))
+        assertEquals(SubStatus.PENDING, SubStatus.parse("pending"))
+    }
+
+    @Test
+    fun `sub status parse throws on unknown value`() {
+        val ex = assertFailsWith<IllegalArgumentException> { SubStatus.parse("unknown") }
+        assertTrue(ex.message!!.contains("Unknown subscription status"))
+    }
+
+    @Test
+    fun `tier meets respects ordering`() {
+        assertFalse(Tier.FREE.meets(Tier.PRO))
+        assertTrue(Tier.PRO.meets(Tier.FREE))
+        assertTrue(Tier.PRO_PLUS.meets(Tier.PRO))
+        assertTrue(Tier.VIP.meets(Tier.PRO_PLUS))
+        assertTrue(Tier.VIP.meets(Tier.VIP))
+    }
+
+    @Test
+    fun `xtr rejects negative values`() {
+        val ex = assertFailsWith<IllegalArgumentException> { Xtr(-1) }
+        assertTrue(ex.message!!.contains("XTR must be >= 0"))
+    }
+
+    @Test
+    fun `xtr accepts zero and positive`() {
+        assertEquals(0, Xtr(0).value)
+        assertEquals(100L, Xtr(100).value)
+    }
+
+    @Test
+    fun `instant helpers convert to and from iso`() {
+        val instant = Instant.parse("2024-01-01T00:00:00Z")
+        val iso = instant.toIsoString()
+        assertEquals("2024-01-01T00:00:00Z", iso)
+        assertEquals(instant, iso.toInstantUnsafe())
+    }
+
+    @Test
+    fun `billing plan dto serialization round trip`() {
+        val dto = BillingPlanDto(
+            tier = "PRO",
+            title = "Pro Plan",
+            priceXtr = 1999,
+            isActive = true
+        )
+        val serialized = json.encodeToString(dto)
+        val deserialized = json.decodeFromString(BillingPlanDto.serializer(), serialized)
+        assertEquals(dto, deserialized)
+    }
+
+    @Test
+    fun `user subscription dto serialization round trip`() {
+        val dto = UserSubscriptionDto(
+            userId = 42L,
+            tier = "VIP",
+            status = "ACTIVE",
+            startedAt = "2024-01-01T00:00:00Z",
+            expiresAt = "2024-02-01T00:00:00Z"
+        )
+        val serialized = json.encodeToString(dto)
+        val deserialized = json.decodeFromString(UserSubscriptionDto.serializer(), serialized)
+        assertEquals(dto, deserialized)
+    }
+
+    @Test
+    fun `domain to dto and back`() {
+        val subscription = UserSubscription(
+            userId = 1L,
+            tier = Tier.PRO_PLUS,
+            status = SubStatus.PENDING,
+            startedAt = Instant.parse("2024-01-10T10:15:30Z"),
+            expiresAt = Instant.parse("2024-02-10T10:15:30Z")
+        )
+        val plan = BillingPlan(
+            tier = Tier.PRO_PLUS,
+            title = "Pro Plus",
+            priceXtr = Xtr(5000),
+            isActive = true
+        )
+
+        val planDto = plan.toDto()
+        val planDomain = planDto.toDomain()
+        assertEquals(plan, planDomain)
+
+        val subscriptionDto = subscription.toDto()
+        assertEquals(subscription.userId, subscriptionDto.userId)
+        assertEquals(subscription.tier.name, subscriptionDto.tier)
+        assertEquals(subscription.status.name, subscriptionDto.status)
+        assertEquals(subscription.startedAt.toIsoString(), subscriptionDto.startedAt)
+        assertEquals(subscription.expiresAt?.toIsoString(), subscriptionDto.expiresAt)
+
+        val subscriptionDomain = subscriptionDto.toDomain()
+        assertEquals(subscription, subscriptionDomain)
+    }
+}


### PR DESCRIPTION
## Summary
- implement billing tier, status, value objects, domain models, DTOs, and mappers
- add ISO instant utilities for serialization and parsing
- create comprehensive unit tests for parsing, comparisons, serialization, and mappings

## Testing
- ./gradlew :core:compileKotlin :core:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d51d48e4d48321adc7528445ce43da