### PR TITLE
Add Telegram Stars gateway with retries

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,12 +3,18 @@ plugins {
 }
 
 dependencies {
+    val ktorVersion = libs.versions.ktor.get()
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.auth)
     implementation(libs.ktor.server.auth.jwt)
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
+    implementation("io.ktor:ktor-client-core-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-client-encoding:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation(libs.java.jwt)
     implementation(project(":core"))
     implementation(project(":storage"))
@@ -21,6 +27,7 @@ dependencies {
     testImplementation(libs.kotlin.test)
     testImplementation(kotlin("test-junit5"))
     testImplementation(libs.ktor.server.test.host)
+    testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("org.junit.platform:junit-platform-suite:1.11.3")
 }
 

--- a/app/src/main/kotlin/billing/StarsGateway.kt
+++ b/app/src/main/kotlin/billing/StarsGateway.kt
@@ -1,0 +1,149 @@
+package billing
+
+import billing.model.Tier
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.compression.ContentEncoding
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.call.body
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import java.io.IOException
+import java.time.Duration
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import kotlin.math.min
+
+interface StarsGateway {
+    /**
+     * Создаёт invoice-link для оплаты Stars (XTR).
+     * @param tier   – тариф (для label/описания).
+     * @param priceXtr – цена в XTR (целые).
+     * @param payload  – короткий payload (идемпотентный ключ, ≤ 64 байт).
+     * @return Result<invoiceUrl>
+     */
+    suspend fun createInvoiceLink(tier: Tier, priceXtr: Long, payload: String): Result<String>
+}
+
+class TelegramStarsGateway(
+    private val botToken: String,
+    private val baseUrl: String = "https://api.telegram.org",
+    client: HttpClient? = null,
+    private val appName: String = "news-bot"
+) : StarsGateway {
+
+    private val logger = LoggerFactory.getLogger(TelegramStarsGateway::class.java)
+    private val jsonSerializer: Json = Json { ignoreUnknownKeys = true }
+    private val httpClient: HttpClient = client ?: defaultClient(appName)
+
+    override suspend fun createInvoiceLink(tier: Tier, priceXtr: Long, payload: String): Result<String> {
+        require(priceXtr >= 0) { "priceXtr must be non-negative" }
+        require(payload.length <= 64) { "payload length must be <= 64" }
+
+        val requestId = UUID.randomUUID().toString()
+        val prices = listOf(LabeledPrice(label = tier.name, amount = priceXtr))
+        val formParameters = Parameters.build {
+            append("title", "Subscription: ${tier.name}")
+            append("description", "Subscription tier ${tier.name}")
+            append("payload", payload)
+            append("currency", "XTR")
+            append("prices", pricesJson(prices))
+        }
+
+        return runCatching {
+            val response: HttpResponse = httpClient.post("$baseUrl/bot$botToken/createInvoiceLink") {
+                setBody(FormDataContent(formParameters))
+            }
+            logger.debug(
+                "createInvoiceLink response requestId={} status={}",
+                requestId,
+                response.status.value
+            )
+            val body: TgOkResponse<String> = response.body()
+            if (body.ok) {
+                body.result ?: throw IllegalStateException("Telegram: empty result")
+            } else {
+                val description = body.description ?: "unknown error"
+                throw IllegalStateException("Telegram: $description")
+            }
+        }.onFailure {
+            logger.warn("createInvoiceLink failure requestId={}", requestId)
+        }
+    }
+
+    @Serializable
+    private data class LabeledPrice(val label: String, val amount: Long)
+
+    @Serializable
+    private data class TgOkResponse<T>(val ok: Boolean, val result: T? = null, val description: String? = null)
+
+    private fun pricesJson(prices: List<LabeledPrice>): String = jsonSerializer.encodeToString(prices)
+
+    private fun defaultClient(appName: String): HttpClient = HttpClient(CIO) {
+        expectSuccess = false
+
+        install(HttpTimeout) {
+            connectTimeoutMillis = Duration.ofSeconds(5).toMillis()
+            requestTimeoutMillis = Duration.ofSeconds(15).toMillis()
+            socketTimeoutMillis = Duration.ofSeconds(15).toMillis()
+        }
+
+        install(ContentNegotiation) {
+            json(jsonSerializer)
+        }
+
+        install(HttpRequestRetry) {
+            maxRetries = 3
+            retryIf { _, response ->
+                response.status == HttpStatusCode.TooManyRequests || response.status.value >= 500
+            }
+            retryOnExceptionIf { _, cause -> cause is IOException }
+            delayMillis(respectRetryAfterHeader = true) { attempt ->
+                exponentialBackoff(attempt)
+            }
+        }
+
+        install(ContentEncoding) {
+            runCatching {
+                val method = this::class.java.methods.firstOrNull { it.name == "gzip" && it.parameterCount == 0 }
+                method?.invoke(this)
+            }
+            runCatching {
+                val method = this::class.java.methods.firstOrNull { it.name == "brotli" && it.parameterCount == 0 }
+                method?.invoke(this)
+            }
+        }
+
+        install(DefaultRequest) {
+            header(HttpHeaders.UserAgent, "$appName/stars-gw (Ktor)")
+        }
+    }
+
+    private fun exponentialBackoff(attempt: Int): Long {
+        val baseDelay = 300L
+        val maxDelay = 2000L
+        val multiplier = 1L shl attempt
+        val computed = baseDelay * multiplier
+        return min(computed, maxDelay)
+    }
+}
+
+object StarsGatewayFactory {
+    fun fromConfig(env: io.ktor.server.application.ApplicationEnvironment, client: io.ktor.client.HttpClient? = null): StarsGateway {
+        val token = env.config.property("telegram.botToken").getString()
+        return TelegramStarsGateway(botToken = token, client = client)
+    }
+}

--- a/app/src/test/kotlin/billing/StarsGatewayTest.kt
+++ b/app/src/test/kotlin/billing/StarsGatewayTest.kt
@@ -1,0 +1,212 @@
+package billing
+
+import billing.model.Tier
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import java.io.IOException
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+
+class StarsGatewayTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `createInvoiceLink success`() = runTest {
+        var capturedRequest: HttpRequestData? = null
+        val client = testClient { request ->
+            capturedRequest = request
+            respond(
+                content = """{"ok":true,"result":"https://t.me/pay/123"}""",
+                status = HttpStatusCode.OK,
+                headers = Headers.build {
+                    append(HttpHeaders.ContentType, "application/json")
+                }
+            )
+        }
+        val gateway = TelegramStarsGateway(botToken = "TEST_TOKEN", client = client)
+
+        val result = gateway.createInvoiceLink(Tier.PRO, 150, "payload-1")
+
+        assertTrue(result.isSuccess)
+        assertEquals("https://t.me/pay/123", result.getOrNull())
+        val request = requireNotNull(capturedRequest)
+        assertEquals(HttpMethod.Post, request.method)
+        assertTrue(request.url.encodedPath.endsWith("/createInvoiceLink"))
+        val body = request.body as FormDataContent
+        val parameters = body.formData
+        assertEquals("Subscription: PRO", parameters["title"])
+        assertEquals("Subscription tier PRO", parameters["description"])
+        assertEquals("payload-1", parameters["payload"])
+        assertEquals("XTR", parameters["currency"])
+        val prices = parameters["prices"]
+        assertNotNull(prices)
+        val parsedPrices = json.parseToJsonElement(prices) as JsonArray
+        val priceObject = parsedPrices.first().jsonObject
+        assertEquals("PRO", priceObject["label"]?.jsonPrimitive?.content)
+        assertEquals(150L, priceObject["amount"]?.jsonPrimitive?.long)
+    }
+
+    @Test
+    fun `createInvoiceLink returns failure on telegram error`() = runTest {
+        val client = testClient {
+            respond(
+                content = """{"ok":false,"description":"BAD REQUEST: invalid"}""",
+                status = HttpStatusCode.OK,
+                headers = Headers.build {
+                    append(HttpHeaders.ContentType, "application/json")
+                }
+            )
+        }
+        val gateway = TelegramStarsGateway(botToken = "TEST_TOKEN", client = client)
+
+        val result = gateway.createInvoiceLink(Tier.PRO, 100, "payload")
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertNotNull(exception)
+        assertTrue(exception.message?.contains("Telegram: BAD REQUEST") == true)
+    }
+
+    @Test
+    fun `createInvoiceLink retries on 429 with retry-after`() = runTest {
+        val attempts = AtomicInteger(0)
+        val client = testClient { request ->
+            val currentAttempt = attempts.incrementAndGet()
+            if (currentAttempt == 1) {
+                respond(
+                    content = "Too Many Requests",
+                    status = HttpStatusCode.TooManyRequests,
+                    headers = Headers.build {
+                        append(HttpHeaders.RetryAfter, "1")
+                    }
+                )
+            } else {
+                respond(
+                    content = """{"ok":true,"result":"https://t.me/pay/retry"}""",
+                    status = HttpStatusCode.OK,
+                    headers = Headers.build {
+                        append(HttpHeaders.ContentType, "application/json")
+                    }
+                )
+            }
+        }
+        val gateway = TelegramStarsGateway(botToken = "TEST_TOKEN", client = client)
+
+        val result = gateway.createInvoiceLink(Tier.PRO_PLUS, 250, "payload")
+
+        assertTrue(result.isSuccess)
+        assertEquals("https://t.me/pay/retry", result.getOrNull())
+        assertEquals(2, attempts.get())
+    }
+
+    @Test
+    fun `createInvoiceLink fails after retries on server error`() = runTest {
+        val attempts = AtomicInteger(0)
+        val client = testClient {
+            val currentAttempt = attempts.incrementAndGet()
+            val status = if (currentAttempt == 1) {
+                HttpStatusCode.BadGateway
+            } else {
+                HttpStatusCode.InternalServerError
+            }
+            respond(
+                content = """{"ok":false,"description":"Server error"}""",
+                status = status,
+                headers = Headers.build {
+                    append(HttpHeaders.ContentType, "application/json")
+                }
+            )
+        }
+        val gateway = TelegramStarsGateway(botToken = "TEST_TOKEN", client = client)
+
+        val result = gateway.createInvoiceLink(Tier.VIP, 500, "payload")
+
+        assertTrue(result.isFailure)
+        assertTrue(attempts.get() > 1)
+    }
+
+    @Test
+    fun `createInvoiceLink handles network exception`() = runTest {
+        val client = testClient {
+            throw IOException("network down")
+        }
+        val gateway = TelegramStarsGateway(botToken = "TEST_TOKEN", client = client)
+
+        val result = gateway.createInvoiceLink(Tier.PRO, 100, "payload")
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IOException)
+    }
+
+    @Test
+    fun `createInvoiceLink validates input`() = runTest {
+        val gateway = TelegramStarsGateway(
+            botToken = "TEST_TOKEN",
+            client = testClient { error("should not call") }
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            gateway.createInvoiceLink(Tier.PRO, -1, "payload")
+        }
+        val longPayload = "a".repeat(65)
+        assertFailsWith<IllegalArgumentException> {
+            gateway.createInvoiceLink(Tier.PRO, 100, longPayload)
+        }
+    }
+
+    private fun testClient(handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData): HttpClient {
+        return HttpClient(MockEngine) {
+            expectSuccess = false
+            install(HttpTimeout) {
+                connectTimeoutMillis = Duration.ofSeconds(1).toMillis()
+                requestTimeoutMillis = Duration.ofSeconds(5).toMillis()
+                socketTimeoutMillis = Duration.ofSeconds(5).toMillis()
+            }
+            install(ContentNegotiation) {
+                json(json)
+            }
+            install(HttpRequestRetry) {
+                maxRetries = 3
+                retryIf { _, response ->
+                    response.status == HttpStatusCode.TooManyRequests || response.status.value >= 500
+                }
+                retryOnExceptionIf { _, cause -> cause is IOException }
+                delayMillis(respectRetryAfterHeader = true) { attempt ->
+                    val baseDelay = 300L
+                    val maxDelay = 2000L
+                    val multiplier = 1L shl attempt
+                    val computed = baseDelay * multiplier
+                    kotlin.math.min(computed, maxDelay)
+                }
+            }
+            engine {
+                addHandler(handler)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a Telegram-based Stars gateway that issues createInvoiceLink requests with timeouts, retries, and safe logging
- cover success, API error, throttling, server error, network failure, and validation scenarios with MockEngine-based tests
- add the required Ktor client dependencies for the app module

## Testing
- ./gradlew :app:compileKotlin :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d522ecd70483219cc5c6fc2bd91349