### PR TITLE
Add billing REST routes and plan guard

### DIFF
--- a/app/src/main/kotlin/routes/BillingRoutes.kt
+++ b/app/src/main/kotlin/routes/BillingRoutes.kt
@@ -1,0 +1,143 @@
+package routes
+
+import billing.model.Tier
+import billing.service.BillingService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.util.AttributeKey
+import kotlinx.serialization.Serializable
+import routes.dto.BillingPlanDto
+import routes.dto.UserSubscriptionDto
+import routes.dto.toDto
+import routes.respondBadRequest
+import routes.respondInternal
+import routes.respondUnauthorized
+import security.userIdOrNull
+
+fun Route.billingRoutes() {
+    route("/api/billing") {
+        get("/plans") {
+            val svc = call.billingService()
+            val result = svc.listPlans()
+            result.fold(
+                onSuccess = { plans ->
+                    val payload = plans.map { plan -> plan.toDto() }
+                    call.respond(HttpStatusCode.OK, payload)
+                },
+                onFailure = { error ->
+                    call.application.environment.log.error("billing.listPlans failure", error)
+                    call.respondInternal()
+                }
+            )
+        }
+    }
+
+    route("/api/billing/stars") {
+        post("/invoice") {
+            val subject = call.userIdOrNull?.toLongOrNull()
+                ?: return@post call.respondUnauthorized()
+
+            val svc = call.billingService()
+            val request = try {
+                call.receive<CreateInvoiceRequest>()
+            } catch (_: Throwable) {
+                call.respondBadRequest(listOf("body invalid"))
+                return@post
+            }
+
+            val tier = runCatching { Tier.parse(request.tier) }.getOrElse {
+                call.respondBadRequest(listOf("tier invalid"))
+                return@post
+            }
+
+            val result = svc.createInvoiceFor(subject, tier)
+            result.fold(
+                onSuccess = { link ->
+                    call.respond(HttpStatusCode.Created, InvoiceLinkResponse(link))
+                },
+                onFailure = { error ->
+                    when (error) {
+                        is NoSuchElementException -> call.respondBadRequest(listOf("plan not found or inactive"))
+                        is IllegalArgumentException -> call.respondBadRequest(listOf(error.message ?: "bad request"))
+                        else -> {
+                            call.application.environment.log.error("billing.createInvoice failure", error)
+                            call.respondInternal()
+                        }
+                    }
+                }
+            )
+        }
+
+        get("/me") {
+            val subject = call.userIdOrNull?.toLongOrNull()
+                ?: return@get call.respondUnauthorized()
+
+            val svc = call.billingService()
+            val result = svc.getMySubscription(subject)
+            result.fold(
+                onSuccess = { subscription ->
+                    if (subscription == null) {
+                        call.respond(HttpStatusCode.OK, MySubscriptionResponse.free())
+                    } else {
+                        val dto = subscription.toDto()
+                        call.respond(HttpStatusCode.OK, MySubscriptionResponse.from(dto))
+                    }
+                },
+                onFailure = { error ->
+                    call.application.environment.log.error("billing.getMySubscription failure", error)
+                    call.respondInternal()
+                }
+            )
+        }
+    }
+}
+
+@Serializable
+private data class CreateInvoiceRequest(val tier: String)
+
+@Serializable
+private data class InvoiceLinkResponse(val invoiceLink: String)
+
+@Serializable
+private data class MySubscriptionResponse(
+    val tier: String,
+    val status: String,
+    val startedAt: String?,
+    val expiresAt: String?
+) {
+    companion object {
+        fun from(dto: UserSubscriptionDto): MySubscriptionResponse = MySubscriptionResponse(
+            tier = dto.tier,
+            status = dto.status,
+            startedAt = dto.startedAt,
+            expiresAt = dto.expiresAt
+        )
+
+        fun free(): MySubscriptionResponse = MySubscriptionResponse(
+            tier = Tier.FREE.name,
+            status = "NONE",
+            startedAt = null,
+            expiresAt = null
+        )
+    }
+}
+
+internal val BillingRouteServicesKey: AttributeKey<BillingRouteServices> =
+    AttributeKey("BillingRouteServices")
+
+internal data class BillingRouteServices(val billingService: BillingService)
+
+private fun ApplicationCall.billingService(): BillingService {
+    val attributes = application.attributes
+    if (attributes.contains(BillingRouteServicesKey)) {
+        return attributes[BillingRouteServicesKey].billingService
+    }
+    error("BillingService is not configured")
+}

--- a/app/src/main/kotlin/routes/dto/BillingDtos.kt
+++ b/app/src/main/kotlin/routes/dto/BillingDtos.kt
@@ -1,0 +1,39 @@
+package routes.dto
+
+import billing.model.BillingPlan
+import billing.model.UserSubscription
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BillingPlanDto(
+    val tier: String,
+    val title: String,
+    val priceXtr: Long,
+    val isActive: Boolean
+)
+
+@Serializable
+data class UserSubscriptionDto(
+    val userId: Long,
+    val tier: String,
+    val status: String,
+    val startedAt: String,
+    val expiresAt: String?
+)
+
+fun BillingPlan.toDto(): BillingPlanDto =
+    BillingPlanDto(
+        tier = this.tier.name,
+        title = this.title,
+        priceXtr = this.priceXtr.value,
+        isActive = this.isActive
+    )
+
+fun UserSubscription.toDto(): UserSubscriptionDto =
+    UserSubscriptionDto(
+        userId = this.userId,
+        tier = this.tier.name,
+        status = this.status.name,
+        startedAt = this.startedAt.toString(),
+        expiresAt = this.expiresAt?.toString()
+    )

--- a/app/src/main/kotlin/security/PlanGuard.kt
+++ b/app/src/main/kotlin/security/PlanGuard.kt
@@ -1,0 +1,38 @@
+package security
+
+import billing.model.Tier
+import billing.service.BillingService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respond
+import routes.respondInternal
+
+suspend fun ApplicationCall.requireTierAtLeast(
+    required: Tier,
+    svc: BillingService,
+    onDenied: suspend () -> Unit = { respondForbiddenTier(required.name) }
+): Boolean {
+    val subject = userIdOrNull?.toLongOrNull() ?: return false
+    val subscription = svc.getMySubscription(subject)
+    val current = subscription.getOrElse { error ->
+        application.environment.log.error("plan_guard.subscription_error", error)
+        respondInternal()
+        return false
+    }
+    val allowed = current?.tier?.level()?.let { it >= required.level() } ?: false
+    if (!allowed) {
+        onDenied()
+    }
+    return allowed
+}
+
+suspend fun ApplicationCall.respondForbiddenTier(required: String) {
+    respond(
+        HttpStatusCode.Forbidden,
+        mapOf(
+            "error" to "forbidden",
+            "reason" to "tier_required",
+            "required" to required
+        )
+    )
+}

--- a/app/src/test/kotlin/routes/BillingRoutesTest.kt
+++ b/app/src/test/kotlin/routes/BillingRoutesTest.kt
@@ -1,0 +1,229 @@
+package routes
+
+import billing.model.BillingPlan
+import billing.model.Tier
+import billing.model.UserSubscription
+import billing.model.Xtr
+import billing.service.BillingService
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.server.auth.authentication
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BillingRoutesTest {
+
+    @Test
+    fun `plans endpoint returns plans`() = testApplication {
+        val service = FakeBillingService().apply {
+            listPlansResult = Result.success(
+                listOf(
+                    BillingPlan(tier = Tier.PRO, title = "Pro", priceXtr = Xtr(100), isActive = true),
+                    BillingPlan(tier = Tier.VIP, title = "Vip", priceXtr = Xtr(200), isActive = true)
+                )
+            )
+        }
+
+        configureTestApp(service)
+
+        val response = client.get("/api/billing/plans")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val payload = Json.parseToJsonElement(response.bodyAsText())
+        assertTrue(payload is JsonArray)
+        assertEquals(2, payload.jsonArray.size)
+    }
+
+    @Test
+    fun `create invoice requires auth`() = testApplication {
+        val service = FakeBillingService()
+        configureTestApp(service)
+
+        val response = client.post("/api/billing/stars/invoice") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"tier":"PRO"}""")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `create invoice rejects unknown tier`() = testApplication {
+        val service = FakeBillingService()
+        configureTestApp(service)
+
+        val response = client.post("/api/billing/stars/invoice") {
+            header("X-Test-User", "12345")
+            contentType(ContentType.Application.Json)
+            setBody("""{"tier":"foo"}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        val payload = Json.parseToJsonElement(response.bodyAsText())
+        assertEquals("bad_request", payload.jsonObject["error"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `create invoice returns link`() = testApplication {
+        val service = FakeBillingService().apply {
+            createInvoiceResult = Result.success("https://t.me/pay/invoice")
+        }
+        configureTestApp(service)
+
+        val response = client.post("/api/billing/stars/invoice") {
+            header("X-Test-User", "12345")
+            contentType(ContentType.Application.Json)
+            setBody("""{"tier":"PRO"}""")
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        val payload = Json.parseToJsonElement(response.bodyAsText())
+        assertEquals("https://t.me/pay/invoice", payload.jsonObject["invoiceLink"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `create invoice handles plan not found`() = testApplication {
+        val service = FakeBillingService().apply {
+            createInvoiceResult = Result.failure(NoSuchElementException("plan not found"))
+        }
+        configureTestApp(service)
+
+        val response = client.post("/api/billing/stars/invoice") {
+            header("X-Test-User", "12345")
+            contentType(ContentType.Application.Json)
+            setBody("""{"tier":"PRO"}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `my subscription requires auth`() = testApplication {
+        val service = FakeBillingService()
+        configureTestApp(service)
+
+        val response = client.get("/api/billing/stars/me")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `my subscription returns active subscription`() = testApplication {
+        val subscription = UserSubscription(
+            userId = 12345,
+            tier = Tier.PRO,
+            status = billing.model.SubStatus.ACTIVE,
+            startedAt = java.time.Instant.parse("2023-09-01T00:00:00Z"),
+            expiresAt = java.time.Instant.parse("2023-10-01T00:00:00Z")
+        )
+        val service = FakeBillingService().apply {
+            getMySubscriptionResult = Result.success(subscription)
+        }
+        configureTestApp(service)
+
+        val response = client.get("/api/billing/stars/me") {
+            header("X-Test-User", "12345")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val payload = Json.parseToJsonElement(response.bodyAsText())
+        assertEquals("PRO", payload.jsonObject["tier"]?.jsonPrimitive?.content)
+        assertEquals("ACTIVE", payload.jsonObject["status"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `my subscription returns free when absent`() = testApplication {
+        val service = FakeBillingService().apply {
+            getMySubscriptionResult = Result.success(null)
+        }
+        configureTestApp(service)
+
+        val response = client.get("/api/billing/stars/me") {
+            header("X-Test-User", "12345")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val payload = Json.parseToJsonElement(response.bodyAsText())
+        assertEquals("FREE", payload.jsonObject["tier"]?.jsonPrimitive?.content)
+        assertEquals("NONE", payload.jsonObject["status"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `list plans handles internal errors`() = testApplication {
+        val service = FakeBillingService().apply {
+            listPlansResult = Result.failure(RuntimeException("boom"))
+        }
+        configureTestApp(service)
+
+        val response = client.get("/api/billing/plans")
+
+        assertEquals(HttpStatusCode.InternalServerError, response.status)
+    }
+
+    private fun ApplicationTestBuilder.configureTestApp(service: BillingService) {
+        application {
+            install(ContentNegotiation) {
+                json()
+            }
+            install(testAuthPlugin)
+            attributes.put(BillingRouteServicesKey, BillingRouteServices(service))
+            routing {
+                billingRoutes()
+            }
+        }
+    }
+
+    private class FakeBillingService : BillingService {
+        var listPlansResult: Result<List<BillingPlan>> = Result.success(emptyList())
+        var createInvoiceResult: Result<String> = Result.success("")
+        var getMySubscriptionResult: Result<UserSubscription?> = Result.success(null)
+
+        override suspend fun listPlans(): Result<List<BillingPlan>> = listPlansResult
+
+        override suspend fun createInvoiceFor(userId: Long, tier: Tier): Result<String> = createInvoiceResult
+
+        override suspend fun applySuccessfulPayment(
+            userId: Long,
+            tier: Tier,
+            amountXtr: Long,
+            providerPaymentId: String?,
+            payload: String?
+        ): Result<Unit> = Result.success(Unit)
+
+        override suspend fun getMySubscription(userId: Long): Result<UserSubscription?> = getMySubscriptionResult
+    }
+
+    private val testAuthPlugin = createApplicationPlugin(name = "TestAuth") {
+        onCall { call ->
+            val subject = call.request.headers["X-Test-User"]
+            if (!subject.isNullOrBlank()) {
+                val token = JWT.create().withSubject(subject).sign(Algorithm.HMAC256("secret"))
+                val decoded = JWT.decode(token)
+                call.authentication.principal(JWTPrincipal(decoded))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement billing REST endpoints for plan listing, invoice creation and subscription status
- add DTO mappers and plan guard helpers with forbidden response
- cover billing routes with Ktor tests for success and failure scenarios

## Testing
- ./gradlew :app:compileKotlin :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d539a5d98c83218a18b19752c1cf67