### PR TITLE
Add billing configuration, wiring, and smoke docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,17 @@ jobs:
 
       - name: Fail on merge conflict markers
         run: |
-          if git grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- . ':!**/.github/**' ; then
-            echo "Merge conflict markers found. Please resolve conflicts."; exit 1;
-          else
-            echo "No conflict markers found.";
+          if git grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- . ; then
+            echo "Merge conflict markers found. Please resolve conflicts." && exit 1
           fi
 
-      - name: Gradle build
+      - name: Build
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: "--no-daemon --stacktrace clean build"
+          arguments: --no-daemon --stacktrace clean build
+
+      - name: Core tests
+        run: ./gradlew :core:test --console=plain
 
       - name: App tests
         run: ./gradlew :app:test --console=plain

--- a/app/src/main/kotlin/App.kt
+++ b/app/src/main/kotlin/App.kt
@@ -1,11 +1,24 @@
 package app
 
+import billing.StarsGatewayFactory
+import billing.StarsWebhookHandler
+import billing.service.BillingService
+import billing.service.BillingServiceImpl
 import di.installPortfolioModule
 import health.healthRoutes
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
+import io.ktor.server.application.call
 import io.ktor.server.auth.authenticate
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
+import io.ktor.util.AttributeKey
+import repo.BillingRepositoryImpl
+import routes.BillingRouteServices
+import routes.BillingRouteServicesKey
 import routes.authRoutes
+import routes.billingRoutes
 import routes.portfolioImportRoutes
 import routes.portfolioPositionsTradesRoutes
 import routes.portfolioRoutes
@@ -18,6 +31,7 @@ fun Application.module() {
     installSecurity()
     installUploadGuard()
     installPortfolioModule()
+    ensureBillingServices()
 
     routing {
         // Публичные
@@ -25,12 +39,52 @@ fun Application.module() {
         authRoutes()
         quotesRoutes()
 
+        post("/telegram/webhook") {
+            val expectedSecret = environment.config.propertyOrNull("telegram.webhookSecret")?.getString()
+            val providedSecret = call.request.headers["X-Telegram-Bot-Api-Secret-Token"]
+            if (expectedSecret.isNullOrBlank() || providedSecret != expectedSecret) {
+                call.respond(HttpStatusCode.Forbidden)
+                return@post
+            }
+
+            val services = attributes[Services.Key]
+            StarsWebhookHandler.handleIfStarsPayment(call, services.billingService)
+        }
+
         // Защищённые (под JWT)
         authenticate("auth-jwt") {
             portfolioRoutes()
             portfolioPositionsTradesRoutes()
             portfolioImportRoutes()
             portfolioValuationReportRoutes()
+            billingRoutes()
         }
+    }
+}
+
+private fun Application.ensureBillingServices(): Services {
+    if (attributes.contains(Services.Key)) {
+        return attributes[Services.Key]
+    }
+
+    val billingService = BillingServiceImpl(
+        repo = BillingRepositoryImpl(),
+        stars = StarsGatewayFactory.fromConfig(environment),
+        defaultDurationDays = billingDefaultDuration(),
+    )
+    val services = Services(billingService = billingService)
+    attributes.put(Services.Key, services)
+    attributes.put(BillingRouteServicesKey, BillingRouteServices(billingService))
+    return services
+}
+
+private fun Application.billingDefaultDuration(): Long {
+    val raw = environment.config.propertyOrNull("billing.defaultDurationDays")?.getString()
+    return raw?.toLongOrNull() ?: 30L
+}
+
+data class Services(val billingService: BillingService) {
+    companion object {
+        val Key: AttributeKey<Services> = AttributeKey("AppServices")
     }
 }

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -53,6 +53,12 @@ portfolio {
   autoCreateInstruments = ${?PORTFOLIO_AUTO_CREATE_INSTRUMENTS}
 }
 
+billing {
+  # Дней к продлению подписки при успешном платеже
+  defaultDurationDays = 30
+  defaultDurationDays = ${?BILLING_DEFAULT_DURATION_DAYS}
+}
+
 security {
   jwtSecret = ${?JWT_SECRET}
   issuer   = "newsbot"

--- a/app/src/test/resources/application.conf
+++ b/app/src/test/resources/application.conf
@@ -16,3 +16,5 @@ upload {
 
 portfolio { defaultValuationMethod = "AVERAGE", autoCreateInstruments = true }
 pricing   { preferClosePrice = true, fallbackToLast = true }
+
+billing { defaultDurationDays = 7 }

--- a/docs/billing-smoke.http
+++ b/docs/billing-smoke.http
@@ -1,0 +1,34 @@
+### Base
+@BASE = http://localhost:8080
+@JWT  = {{JWT}}
+
+### Plans (public)
+GET {{BASE}}/api/billing/plans
+
+### Create invoice (JWT)
+POST {{BASE}}/api/billing/stars/invoice
+content-type: application/json
+Authorization: Bearer {{JWT}}
+
+{ "tier": "PRO" }
+
+### My subscription (JWT)
+GET {{BASE}}/api/billing/stars/me
+Authorization: Bearer {{JWT}}
+
+### Webhook simulate (DEV)
+POST {{BASE}}/telegram/webhook
+X-Telegram-Bot-Api-Secret-Token: {{WH_SECRET}}
+content-type: application/json
+
+{
+  "message": {
+    "from": { "id": 7446417641 },
+    "successful_payment": {
+      "currency": "XTR",
+      "total_amount": 1234,
+      "invoice_payload": "7446417641:PRO:abc123",
+      "provider_payment_charge_id": "pmt_demo_1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add billing configuration defaults for runtime and test profiles
- wire billing routes and Stars webhook handler into the Ktor application
- document Billing/Stars smoke checks and provide an IDE HTTP collection
- update CI workflow to build, run tests, and guard against conflict markers

## Testing
- ./gradlew :app:compileKotlin :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d54509fdc08321b4f3b8b7da294632