### PR TITLE
Implement alerts module with engine and tests

### DIFF
--- a/alerts/build.gradle.kts
+++ b/alerts/build.gradle.kts
@@ -1,1 +1,8 @@
-// Alerts module build script placeholder
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+}
+
+dependencies {
+    implementation(libs.coroutines.core)
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${libs.versions.coroutines.get()}")
+}

--- a/alerts/src/main/kotlin/alerts/antinoise/AntiNoise.kt
+++ b/alerts/src/main/kotlin/alerts/antinoise/AntiNoise.kt
@@ -1,0 +1,63 @@
+package alerts.antinoise
+
+import alerts.config.Budget
+import alerts.config.QuietHours
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+public class CooldownRegistry(private val clock: Clock, private val minutes: Int) {
+    private val lastTriggered: MutableMap<Long, Instant> = mutableMapOf()
+
+    public fun allow(instrumentId: Long): Boolean {
+        if (minutes <= 0) {
+            return true
+        }
+        val last = lastTriggered[instrumentId] ?: return true
+        val now = clock.instant()
+        val elapsed = Duration.between(last, now)
+        return elapsed.toMinutes() >= minutes.toLong()
+    }
+
+    public fun markTriggered(instrumentId: Long) {
+        lastTriggered[instrumentId] = clock.instant()
+    }
+}
+
+public class QuietHoursGuard(private val quiet: QuietHours, private val zone: ZoneId) {
+    public fun isQuiet(now: Instant): Boolean {
+        val localTime = now.atZone(zone).toLocalTime()
+        return if (quiet.start <= quiet.end) {
+            !localTime.isBefore(quiet.start) && localTime.isBefore(quiet.end)
+        } else {
+            !localTime.isBefore(quiet.start) || localTime.isBefore(quiet.end)
+        }
+    }
+}
+
+public class BudgetLimiter(private val budget: Budget, private val clock: Clock) {
+    private var lastDate: LocalDate? = null
+    private var consumed: Int = 0
+
+    public fun resetIfNewDay() {
+        val today = LocalDate.from(clock.instant().atZone(ZoneId.of("UTC")))
+        if (lastDate != today) {
+            lastDate = today
+            consumed = 0
+        }
+    }
+
+    public fun tryConsume(): Boolean {
+        resetIfNewDay()
+        if (budget.maxPushesPerDay <= 0) {
+            return true
+        }
+        if (consumed >= budget.maxPushesPerDay) {
+            return false
+        }
+        consumed += 1
+        return true
+    }
+}

--- a/alerts/src/main/kotlin/alerts/config/AlertConfig.kt
+++ b/alerts/src/main/kotlin/alerts/config/AlertConfig.kt
@@ -1,0 +1,75 @@
+package alerts.config
+
+import java.time.LocalTime
+
+public data class QuietHours(val start: LocalTime, val end: LocalTime)
+
+public data class Budget(val maxPushesPerDay: Int)
+
+public data class Hysteresis(val enterPct: Double, val exitPct: Double)
+
+public enum class InstrumentClass {
+    MOEX_BLUE,
+    MOEX_SECOND,
+    OFZ,
+    INDEX,
+    FX,
+    CRYPTO_MAJOR,
+    CRYPTO_MID,
+    STABLECOIN
+}
+
+public data class Thresholds(
+    val pctFast: Double,
+    val pctDay: Double,
+    val volMultFast: Double = 0.0
+)
+
+public data class MatrixV11(
+    val perClass: Map<InstrumentClass, Thresholds>,
+    val hysteresis: Hysteresis,
+    val portfolioDayPct: Double = 2.0,
+    val portfolioDrawdownPct: Double = 5.0
+)
+
+public data class DynamicScale(
+    val enabled: Boolean,
+    val min: Double = 0.7,
+    val max: Double = 1.3
+)
+
+public data class AlertsConfig(
+    val quiet: QuietHours,
+    val budget: Budget,
+    val matrix: MatrixV11,
+    val dynamic: DynamicScale,
+    val cooldownMinutes: Int = 60
+)
+
+public object AlertDefaults {
+    public fun matrix(): AlertsConfig {
+        val thresholds = mapOf(
+            InstrumentClass.MOEX_BLUE to Thresholds(pctFast = 2.0, pctDay = 4.0, volMultFast = 1.8),
+            InstrumentClass.MOEX_SECOND to Thresholds(pctFast = 3.0, pctDay = 6.0, volMultFast = 2.2),
+            InstrumentClass.OFZ to Thresholds(pctFast = 0.3, pctDay = 0.6),
+            InstrumentClass.INDEX to Thresholds(pctFast = 0.7, pctDay = 1.5),
+            InstrumentClass.FX to Thresholds(pctFast = 1.0, pctDay = 2.0),
+            InstrumentClass.CRYPTO_MAJOR to Thresholds(pctFast = 2.0, pctDay = 4.0, volMultFast = 2.0),
+            InstrumentClass.CRYPTO_MID to Thresholds(pctFast = 4.0, pctDay = 8.0, volMultFast = 2.5),
+            InstrumentClass.STABLECOIN to Thresholds(pctFast = 0.5, pctDay = 0.8)
+        )
+        val matrix = MatrixV11(
+            perClass = thresholds,
+            hysteresis = Hysteresis(enterPct = 2.0, exitPct = 1.5),
+            portfolioDayPct = 2.0,
+            portfolioDrawdownPct = 5.0
+        )
+        return AlertsConfig(
+            quiet = QuietHours(start = LocalTime.of(22, 0), end = LocalTime.of(7, 0)),
+            budget = Budget(maxPushesPerDay = 50),
+            matrix = matrix,
+            dynamic = DynamicScale(enabled = true, min = 0.7, max = 1.3),
+            cooldownMinutes = 60
+        )
+    }
+}

--- a/alerts/src/main/kotlin/alerts/engine/AlertEngine.kt
+++ b/alerts/src/main/kotlin/alerts/engine/AlertEngine.kt
@@ -1,0 +1,257 @@
+package alerts.engine
+
+import alerts.antinoise.BudgetLimiter
+import alerts.antinoise.CooldownRegistry
+import alerts.antinoise.QuietHoursGuard
+import alerts.config.AlertsConfig
+import alerts.config.InstrumentClass
+import alerts.config.Thresholds
+import alerts.model.AlertEvent
+import alerts.model.PortfolioAlertEvent
+import alerts.ports.MarketDataPort
+import alerts.ports.MarketSnapshot
+import alerts.ports.NotifierPort
+import alerts.ports.PortfolioPort
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+public class AlertEngine(
+    private val cfg: AlertsConfig,
+    private val market: MarketDataPort,
+    private val portfolio: PortfolioPort,
+    private val notifier: NotifierPort,
+    private val cooldown: CooldownRegistry,
+    private val budget: BudgetLimiter,
+    private val quiet: QuietHoursGuard,
+    private val clock: Clock
+) {
+    private data class InstrumentState(var fastActive: Boolean = false, var dayActive: Boolean = false)
+    private data class PortfolioState(var dayActive: Boolean = false, var drawdownActive: Boolean = false)
+
+    private val states: MutableMap<Long, InstrumentState> = ConcurrentHashMap()
+    private val portfolioStates: MutableMap<UUID, PortfolioState> = ConcurrentHashMap()
+
+    public suspend fun checkInstrument(instrumentId: Long) {
+        val fastSnapshot = tryFetch { market.fastWindow(instrumentId) }
+        val daySnapshot = tryFetch { market.dayWindow(instrumentId) }
+        if (fastSnapshot == null && daySnapshot == null) {
+            return
+        }
+        val snapshot = fastSnapshot ?: daySnapshot ?: return
+        val thresholds = cfg.matrix.perClass[snapshot.classId] ?: return
+        val atr = if (cfg.dynamic.enabled) tryFetch { market.atr14(instrumentId) } else null
+        val sigma = if (cfg.dynamic.enabled) tryFetch { market.sigma30d(instrumentId) } else null
+        val scale = computeScale(atr, sigma)
+        val now = clock.instant()
+
+        fastSnapshot?.let {
+            processFast(instrumentId, it, thresholds, scale, now)
+        }
+        daySnapshot?.let {
+            processDay(instrumentId, it, thresholds, scale, now)
+        }
+    }
+
+    public suspend fun checkPortfolio(portfolioId: UUID) {
+        val now = clock.instant()
+        val dayChange = portfolio.dayChangePct(portfolioId)
+        val drawdown = portfolio.drawdownPct(portfolioId)
+        val exceedsDay = abs(dayChange) >= cfg.matrix.portfolioDayPct
+        val exceedsDrawdown = drawdown >= cfg.matrix.portfolioDrawdownPct
+        val state = portfolioStates.computeIfAbsent(portfolioId) { PortfolioState() }
+        if (!exceedsDay) {
+            state.dayActive = false
+        }
+        if (!exceedsDrawdown) {
+            state.drawdownActive = false
+        }
+        val shouldSendDay = exceedsDay && !state.dayActive
+        val shouldSendDrawdown = exceedsDrawdown && !state.drawdownActive && !state.dayActive
+        if (!shouldSendDay && !shouldSendDrawdown) {
+            return
+        }
+        if (quiet.isQuiet(now)) {
+            return
+        }
+        val cooldownId = portfolioId.mostSignificantBits xor portfolioId.leastSignificantBits
+        if (!cooldown.allow(cooldownId)) {
+            return
+        }
+        if (!budget.tryConsume()) {
+            return
+        }
+        val type = if (shouldSendDay) PortfolioAlertEvent.Type.DAY_MOVE else PortfolioAlertEvent.Type.DRAWDOWN
+        val value = if (shouldSendDay) dayChange else drawdown
+        notifier.pushPortfolio(
+            portfolioId,
+            PortfolioAlertEvent(
+                type = type,
+                valuePct = value,
+                snapshotTime = now
+            )
+        )
+        if (shouldSendDay) {
+            state.dayActive = true
+        } else {
+            state.drawdownActive = true
+        }
+        cooldown.markTriggered(cooldownId)
+    }
+
+    private fun computeScale(atr: Double?, sigma: Double?): Double {
+        if (!cfg.dynamic.enabled) {
+            return 1.0
+        }
+        val ratio = when {
+            atr != null && sigma != null && sigma > 0.0 -> atr / sigma
+            else -> 1.0
+        }
+        if (!ratio.isFinite() || ratio <= 0.0) {
+            return 1.0
+        }
+        return clamp(ratio, cfg.dynamic.min, cfg.dynamic.max)
+    }
+
+    private suspend fun processFast(
+        instrumentId: Long,
+        snapshot: MarketSnapshot,
+        thresholds: Thresholds,
+        scale: Double,
+        now: Instant
+    ) {
+        val state = states.computeIfAbsent(instrumentId) { InstrumentState() }
+        val enterThreshold = thresholds.pctFast * scale
+        val exitThreshold = enterThreshold * exitRatio()
+        val absChange = abs(snapshot.pctChange)
+        if (state.fastActive) {
+            if (absChange < exitThreshold) {
+                state.fastActive = false
+            }
+            return
+        }
+        if (absChange < enterThreshold) {
+            return
+        }
+        if (thresholds.volMultFast > 0.0 && snapshot.volumeMult < thresholds.volMultFast) {
+            return
+        }
+        if (!cooldown.allow(instrumentId)) {
+            return
+        }
+        if (quiet.isQuiet(now)) {
+            return
+        }
+        if (!budget.tryConsume()) {
+            return
+        }
+        val hysteresisState = AlertEvent.HysteresisState.ENTER
+        val event = if (snapshot.classId == InstrumentClass.STABLECOIN) {
+            AlertEvent.StablecoinDepeg(
+                instrumentId = instrumentId,
+                pct = snapshot.pctChange,
+                snapshotTime = now,
+                classId = snapshot.classId,
+                hysteresisState = hysteresisState
+            )
+        } else if (thresholds.volMultFast > 0.0 && snapshot.volumeMult >= thresholds.volMultFast) {
+            AlertEvent.VolumeSpike(
+                instrumentId = instrumentId,
+                pct = snapshot.pctChange,
+                snapshotTime = now,
+                classId = snapshot.classId,
+                hysteresisState = hysteresisState,
+                volumeMultiplier = snapshot.volumeMult
+            )
+        } else {
+            AlertEvent.FastMove(
+                instrumentId = instrumentId,
+                pct = snapshot.pctChange,
+                snapshotTime = now,
+                classId = snapshot.classId,
+                hysteresisState = hysteresisState,
+                volumeMultiplier = snapshot.volumeMult
+            )
+        }
+        notifier.push(instrumentId, event)
+        cooldown.markTriggered(instrumentId)
+        state.fastActive = true
+    }
+
+    private suspend fun processDay(
+        instrumentId: Long,
+        snapshot: MarketSnapshot,
+        thresholds: Thresholds,
+        scale: Double,
+        now: Instant
+    ) {
+        val state = states.computeIfAbsent(instrumentId) { InstrumentState() }
+        val enterThreshold = thresholds.pctDay * scale
+        val exitThreshold = enterThreshold * exitRatio()
+        val absChange = abs(snapshot.pctChange)
+        if (state.dayActive) {
+            if (absChange < exitThreshold) {
+                state.dayActive = false
+            }
+            return
+        }
+        if (absChange < enterThreshold) {
+            return
+        }
+        if (!cooldown.allow(instrumentId)) {
+            return
+        }
+        if (quiet.isQuiet(now)) {
+            return
+        }
+        if (!budget.tryConsume()) {
+            return
+        }
+        val hysteresisState = AlertEvent.HysteresisState.ENTER
+        val event = if (snapshot.classId == InstrumentClass.STABLECOIN) {
+            AlertEvent.StablecoinDepeg(
+                instrumentId = instrumentId,
+                pct = snapshot.pctChange,
+                snapshotTime = now,
+                classId = snapshot.classId,
+                hysteresisState = hysteresisState
+            )
+        } else {
+            AlertEvent.DayMove(
+                instrumentId = instrumentId,
+                pct = snapshot.pctChange,
+                snapshotTime = now,
+                classId = snapshot.classId,
+                hysteresisState = hysteresisState
+            )
+        }
+        notifier.push(instrumentId, event)
+        cooldown.markTriggered(instrumentId)
+        state.dayActive = true
+    }
+
+    private fun exitRatio(): Double {
+        val enter = cfg.matrix.hysteresis.enterPct
+        val exit = cfg.matrix.hysteresis.exitPct
+        if (enter <= 0.0) {
+            return 1.0
+        }
+        return max(0.0, exit / enter)
+    }
+
+    private fun clamp(value: Double, minValue: Double, maxValue: Double): Double {
+        return max(minValue, min(maxValue, value))
+    }
+
+    private suspend fun <T> tryFetch(block: suspend () -> T): T? {
+        return try {
+            block()
+        } catch (ex: Exception) {
+            null
+        }
+    }
+}

--- a/alerts/src/main/kotlin/alerts/model/Events.kt
+++ b/alerts/src/main/kotlin/alerts/model/Events.kt
@@ -1,0 +1,62 @@
+package alerts.model
+
+import alerts.config.InstrumentClass
+import java.time.Instant
+
+public sealed class AlertEvent {
+    public abstract val pct: Double
+    public abstract val snapshotTime: Instant
+    public abstract val classId: InstrumentClass
+    public abstract val hysteresisState: HysteresisState
+    public open val volumeMultiplier: Double? = null
+
+    public enum class HysteresisState {
+        ENTER,
+        EXIT
+    }
+
+    public data class FastMove(
+        val instrumentId: Long,
+        override val pct: Double,
+        override val snapshotTime: Instant,
+        override val classId: InstrumentClass,
+        override val hysteresisState: HysteresisState,
+        override val volumeMultiplier: Double? = null
+    ) : AlertEvent()
+
+    public data class DayMove(
+        val instrumentId: Long,
+        override val pct: Double,
+        override val snapshotTime: Instant,
+        override val classId: InstrumentClass,
+        override val hysteresisState: HysteresisState
+    ) : AlertEvent()
+
+    public data class VolumeSpike(
+        val instrumentId: Long,
+        override val pct: Double,
+        override val snapshotTime: Instant,
+        override val classId: InstrumentClass,
+        override val hysteresisState: HysteresisState,
+        override val volumeMultiplier: Double
+    ) : AlertEvent()
+
+    public data class StablecoinDepeg(
+        val instrumentId: Long,
+        override val pct: Double,
+        override val snapshotTime: Instant,
+        override val classId: InstrumentClass,
+        override val hysteresisState: HysteresisState
+    ) : AlertEvent()
+}
+
+public data class PortfolioAlertEvent(
+    val type: Type,
+    val valuePct: Double,
+    val snapshotTime: Instant
+) {
+    public enum class Type {
+        DAY_MOVE,
+        DRAWDOWN
+    }
+}

--- a/alerts/src/main/kotlin/alerts/ports/Ports.kt
+++ b/alerts/src/main/kotlin/alerts/ports/Ports.kt
@@ -1,0 +1,26 @@
+package alerts.ports
+
+import alerts.config.InstrumentClass
+
+public data class MarketSnapshot(
+    val classId: InstrumentClass,
+    val pctChange: Double,
+    val volumeMult: Double
+)
+
+public interface MarketDataPort {
+    public suspend fun fastWindow(instrumentId: Long): MarketSnapshot
+    public suspend fun dayWindow(instrumentId: Long): MarketSnapshot
+    public suspend fun atr14(instrumentId: Long): Double?
+    public suspend fun sigma30d(instrumentId: Long): Double?
+}
+
+public interface PortfolioPort {
+    public suspend fun dayChangePct(portfolioId: java.util.UUID): Double
+    public suspend fun drawdownPct(portfolioId: java.util.UUID): Double
+}
+
+public interface NotifierPort {
+    public suspend fun push(instrumentId: Long, event: alerts.model.AlertEvent)
+    public suspend fun pushPortfolio(portfolioId: java.util.UUID, event: alerts.model.PortfolioAlertEvent)
+}

--- a/alerts/src/main/kotlin/alerts/scheduler/AlertScheduler.kt
+++ b/alerts/src/main/kotlin/alerts/scheduler/AlertScheduler.kt
@@ -1,0 +1,63 @@
+package alerts.scheduler
+
+import alerts.engine.AlertEngine
+import java.time.Clock
+import java.time.Duration
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+public class AlertScheduler(
+    private val engine: AlertEngine,
+    private val scope: CoroutineScope,
+    private val clock: Clock
+) {
+    public data class Plan(val fastEvery: Duration, val dayEvery: Duration)
+
+    public fun start(instruments: List<Long>, portfolios: List<UUID>, plan: Plan): Job {
+        return scope.launch {
+            val fastJob = launch { runFastLoop(instruments, plan.fastEvery) }
+            val dayJob = launch { runDayLoop(instruments, portfolios, plan.dayEvery) }
+            try {
+                fastJob.join()
+                dayJob.join()
+            } finally {
+                fastJob.cancel()
+                dayJob.cancel()
+            }
+        }
+    }
+
+    private suspend fun runFastLoop(instruments: List<Long>, period: Duration) {
+        if (instruments.isEmpty()) {
+            return
+        }
+        var index = 0
+        while (scope.isActive) {
+            val id = instruments[index % instruments.size]
+            engine.checkInstrument(id)
+            index += 1
+            clock.instant()
+            delay(period.toMillis())
+        }
+    }
+
+    private suspend fun runDayLoop(instruments: List<Long>, portfolios: List<UUID>, period: Duration) {
+        var index = 0
+        while (scope.isActive) {
+            if (instruments.isNotEmpty()) {
+                val id = instruments[index % instruments.size]
+                engine.checkInstrument(id)
+                index += 1
+            }
+            for (portfolioId in portfolios) {
+                engine.checkPortfolio(portfolioId)
+            }
+            clock.instant()
+            delay(period.toMillis())
+        }
+    }
+}

--- a/alerts/src/test/kotlin/alerts/antinoise/AntiNoiseTest.kt
+++ b/alerts/src/test/kotlin/alerts/antinoise/AntiNoiseTest.kt
@@ -1,0 +1,71 @@
+package alerts.antinoise
+
+import alerts.config.Budget
+import alerts.config.QuietHours
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class AntiNoiseTest {
+    @Test
+    fun cooldownRegistryRespectsWindow() {
+        val clock = MutableClock(Instant.parse("2023-01-01T00:00:00Z"))
+        val registry = CooldownRegistry(clock, minutes = 60)
+        assertTrue(registry.allow(1L))
+        registry.markTriggered(1L)
+        assertFalse(registry.allow(1L))
+        clock.advance(Duration.ofMinutes(30))
+        assertFalse(registry.allow(1L))
+        clock.advance(Duration.ofMinutes(31))
+        assertTrue(registry.allow(1L))
+    }
+
+    @Test
+    fun budgetLimiterResetsDaily() {
+        val clock = MutableClock(Instant.parse("2023-01-01T00:00:00Z"))
+        val limiter = BudgetLimiter(Budget(maxPushesPerDay = 2), clock)
+        assertTrue(limiter.tryConsume())
+        assertTrue(limiter.tryConsume())
+        assertFalse(limiter.tryConsume())
+        clock.advance(Duration.ofDays(1))
+        assertTrue(limiter.tryConsume())
+    }
+
+    @Test
+    fun quietHoursHandlesWrapAround() {
+        val guard = QuietHoursGuard(QuietHours(LocalTime.of(22, 0), LocalTime.of(6, 0)), ZoneOffset.UTC)
+        val insideLate = Instant.parse("2023-01-01T23:00:00Z")
+        val insideEarly = Instant.parse("2023-01-01T03:00:00Z")
+        val outside = Instant.parse("2023-01-01T12:00:00Z")
+        assertTrue(guard.isQuiet(insideLate))
+        assertTrue(guard.isQuiet(insideEarly))
+        assertFalse(guard.isQuiet(outside))
+    }
+
+    private class MutableClock(
+        private var current: Instant,
+        private val zoneId: ZoneId = ZoneOffset.UTC
+    ) : Clock() {
+        override fun withZone(zone: ZoneId?): Clock {
+            return MutableClock(current, zone ?: zoneId)
+        }
+
+        override fun getZone(): ZoneId {
+            return zoneId
+        }
+
+        override fun instant(): Instant {
+            return current
+        }
+
+        fun advance(duration: Duration) {
+            current = current.plus(duration)
+        }
+    }
+}

--- a/alerts/src/test/kotlin/alerts/engine/AlertEngineTest.kt
+++ b/alerts/src/test/kotlin/alerts/engine/AlertEngineTest.kt
@@ -1,0 +1,292 @@
+package alerts.engine
+
+import alerts.antinoise.BudgetLimiter
+import alerts.antinoise.CooldownRegistry
+import alerts.antinoise.QuietHoursGuard
+import alerts.config.AlertsConfig
+import alerts.config.Budget
+import alerts.config.DynamicScale
+import alerts.config.Hysteresis
+import alerts.config.InstrumentClass
+import alerts.config.MatrixV11
+import alerts.config.QuietHours
+import alerts.config.Thresholds
+import alerts.model.AlertEvent
+import alerts.model.PortfolioAlertEvent
+import alerts.ports.MarketDataPort
+import alerts.ports.MarketSnapshot
+import alerts.ports.NotifierPort
+import alerts.ports.PortfolioPort
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class AlertEngineTest {
+    private val zone: ZoneId = ZoneOffset.UTC
+
+    @org.junit.jupiter.api.Test
+    fun hysteresisFastWindow() = runTest {
+        val clock = MutableClock(Instant.parse("2023-01-01T00:00:00Z"))
+        val market = FakeMarketDataPort()
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.1, 2.0)
+        market.daySnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        val notifier = FakeNotifierPort()
+        val engine = createEngine(
+            clock = clock,
+            market = market,
+            notifier = notifier,
+            cooldownMinutes = 0
+        )
+
+        engine.checkInstrument(1L)
+        assertEquals(1, notifier.events.size)
+        val firstEvent = notifier.events.first()
+        assertTrue(firstEvent is AlertEvent.FastMove || firstEvent is AlertEvent.VolumeSpike)
+
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 1.8, 2.0)
+        engine.checkInstrument(1L)
+        assertEquals(1, notifier.events.size)
+
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 1.4, 2.0)
+        engine.checkInstrument(1L)
+        assertEquals(1, notifier.events.size)
+
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.0, 2.0)
+        engine.checkInstrument(1L)
+        assertEquals(2, notifier.events.size)
+    }
+
+    @org.junit.jupiter.api.Test
+    fun cooldownPreventsRapidRepeat() = runTest {
+        val clock = MutableClock(Instant.parse("2023-01-01T00:00:00Z"))
+        val market = FakeMarketDataPort()
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.2, 2.0)
+        market.daySnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        val notifier = FakeNotifierPort()
+        val engine = createEngine(
+            clock = clock,
+            market = market,
+            notifier = notifier,
+            cooldownMinutes = 60
+        )
+
+        engine.checkInstrument(1L)
+        assertEquals(1, notifier.events.size)
+
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 1.0, 1.0)
+        engine.checkInstrument(1L)
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.4, 2.0)
+        engine.checkInstrument(1L)
+        assertEquals(1, notifier.events.size)
+
+        clock.advance(Duration.ofMinutes(61))
+        engine.checkInstrument(1L)
+        assertEquals(2, notifier.events.size)
+    }
+
+    @org.junit.jupiter.api.Test
+    fun budgetLimiterBlocksAfterLimit() = runTest {
+        val clock = MutableClock(Instant.parse("2023-01-01T00:00:00Z"))
+        val market = FakeMarketDataPort()
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.5, 2.0)
+        market.daySnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        val notifier = FakeNotifierPort()
+        val engine = createEngine(
+            clock = clock,
+            market = market,
+            notifier = notifier,
+            cooldownMinutes = 0,
+            budget = Budget(maxPushesPerDay = 2)
+        )
+
+        engine.checkInstrument(1L)
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 1.0, 1.0)
+        engine.checkInstrument(1L)
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.6, 2.0)
+        engine.checkInstrument(1L)
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 1.0, 1.0)
+        engine.checkInstrument(1L)
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.7, 2.0)
+        engine.checkInstrument(1L)
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 1.0, 1.0)
+        engine.checkInstrument(1L)
+        assertEquals(2, notifier.events.size)
+
+        clock.advance(Duration.ofDays(1))
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.8, 2.0)
+        engine.checkInstrument(1L)
+        assertEquals(3, notifier.events.size)
+    }
+
+    @org.junit.jupiter.api.Test
+    fun quietHoursSuppressNotifications() = runTest {
+        val clock = MutableClock(Instant.parse("2023-01-01T01:00:00Z"), zone)
+        val market = FakeMarketDataPort()
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.2, 2.5)
+        market.daySnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        val notifier = FakeNotifierPort()
+        val quiet = QuietHoursGuard(QuietHours(start = LocalTime.of(0, 0), end = LocalTime.of(5, 0)), zone)
+        val engine = createEngine(
+            clock = clock,
+            market = market,
+            notifier = notifier,
+            cooldownMinutes = 0,
+            quietGuard = quiet
+        )
+
+        engine.checkInstrument(1L)
+        assertTrue(notifier.events.isEmpty())
+    }
+
+    @org.junit.jupiter.api.Test
+    fun portfolioAlertsTriggered() = runTest {
+        val clock = MutableClock(Instant.parse("2023-01-01T10:00:00Z"))
+        val market = FakeMarketDataPort()
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        market.daySnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        val notifier = FakeNotifierPort()
+        val portfolioPort = FakePortfolioPort(dayChange = 2.2, drawdown = 6.0)
+        val engine = createEngine(
+            clock = clock,
+            market = market,
+            notifier = notifier,
+            cooldownMinutes = 0,
+            portfolio = portfolioPort
+        )
+
+        val portfolioId = UUID.randomUUID()
+        engine.checkPortfolio(portfolioId)
+        assertEquals(1, notifier.portfolioEvents.size)
+        assertEquals(PortfolioAlertEvent.Type.DAY_MOVE, notifier.portfolioEvents.first().type)
+
+        engine.checkPortfolio(portfolioId)
+        assertEquals(1, notifier.portfolioEvents.size)
+
+        portfolioPort.dayChange = 0.5
+        portfolioPort.drawdown = 5.2
+        engine.checkPortfolio(portfolioId)
+        assertEquals(2, notifier.portfolioEvents.size)
+        assertEquals(PortfolioAlertEvent.Type.DRAWDOWN, notifier.portfolioEvents.last().type)
+
+        portfolioPort.drawdown = 1.0
+        engine.checkPortfolio(portfolioId)
+        portfolioPort.drawdown = 6.0
+        engine.checkPortfolio(portfolioId)
+        assertEquals(3, notifier.portfolioEvents.size)
+    }
+
+    private fun createEngine(
+        clock: MutableClock,
+        market: FakeMarketDataPort,
+        notifier: FakeNotifierPort,
+        cooldownMinutes: Int,
+        portfolio: PortfolioPort = FakePortfolioPort(),
+        budget: Budget = Budget(maxPushesPerDay = 10),
+        quietGuard: QuietHoursGuard = QuietHoursGuard(QuietHours(LocalTime.of(23, 0), LocalTime.of(23, 30)), zone)
+    ): AlertEngine {
+        val matrix = MatrixV11(
+            perClass = mapOf(
+                InstrumentClass.MOEX_BLUE to Thresholds(pctFast = 2.0, pctDay = 4.0, volMultFast = 1.5)
+            ),
+            hysteresis = Hysteresis(enterPct = 2.0, exitPct = 1.5),
+            portfolioDayPct = 2.0,
+            portfolioDrawdownPct = 5.0
+        )
+        val config = AlertsConfig(
+            quiet = QuietHours(LocalTime.of(23, 0), LocalTime.of(23, 30)),
+            budget = budget,
+            matrix = matrix,
+            dynamic = DynamicScale(enabled = false),
+            cooldownMinutes = cooldownMinutes
+        )
+        val cooldown = CooldownRegistry(clock, cooldownMinutes)
+        val limiter = BudgetLimiter(budget, clock)
+        return AlertEngine(
+            cfg = config,
+            market = market,
+            portfolio = portfolio,
+            notifier = notifier,
+            cooldown = cooldown,
+            budget = limiter,
+            quiet = quietGuard,
+            clock = clock
+        )
+    }
+
+    private class FakeMarketDataPort : MarketDataPort {
+        val fastSnapshots: MutableMap<Long, MarketSnapshot> = mutableMapOf()
+        val daySnapshots: MutableMap<Long, MarketSnapshot> = mutableMapOf()
+        val atr: MutableMap<Long, Double> = mutableMapOf()
+        val sigma: MutableMap<Long, Double> = mutableMapOf()
+
+        override suspend fun fastWindow(instrumentId: Long): MarketSnapshot {
+            return fastSnapshots[instrumentId] ?: MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        }
+
+        override suspend fun dayWindow(instrumentId: Long): MarketSnapshot {
+            return daySnapshots[instrumentId] ?: MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        }
+
+        override suspend fun atr14(instrumentId: Long): Double? {
+            return atr[instrumentId]
+        }
+
+        override suspend fun sigma30d(instrumentId: Long): Double? {
+            return sigma[instrumentId]
+        }
+    }
+
+    private class FakeNotifierPort : NotifierPort {
+        val events: MutableList<AlertEvent> = mutableListOf()
+        val portfolioEvents: MutableList<PortfolioAlertEvent> = mutableListOf()
+
+        override suspend fun push(instrumentId: Long, event: AlertEvent) {
+            events.add(event)
+        }
+
+        override suspend fun pushPortfolio(portfolioId: UUID, event: PortfolioAlertEvent) {
+            portfolioEvents.add(event)
+        }
+    }
+
+    private class FakePortfolioPort(
+        var dayChange: Double = 0.0,
+        var drawdown: Double = 0.0
+    ) : PortfolioPort {
+        override suspend fun dayChangePct(portfolioId: UUID): Double {
+            return dayChange
+        }
+
+        override suspend fun drawdownPct(portfolioId: UUID): Double {
+            return drawdown
+        }
+    }
+
+    private class MutableClock(
+        private var current: Instant,
+        private val zoneId: ZoneId = ZoneOffset.UTC
+    ) : Clock() {
+        override fun withZone(zone: ZoneId?): Clock {
+            return MutableClock(current, zone ?: zoneId)
+        }
+
+        override fun getZone(): ZoneId {
+            return zoneId
+        }
+
+        override fun instant(): Instant {
+            return current
+        }
+
+        fun advance(duration: Duration) {
+            current = current.plus(duration)
+        }
+    }
+}

--- a/alerts/src/test/kotlin/alerts/engine/DynamicScaleTest.kt
+++ b/alerts/src/test/kotlin/alerts/engine/DynamicScaleTest.kt
@@ -1,0 +1,154 @@
+package alerts.engine
+
+import alerts.antinoise.BudgetLimiter
+import alerts.antinoise.CooldownRegistry
+import alerts.antinoise.QuietHoursGuard
+import alerts.config.AlertsConfig
+import alerts.config.Budget
+import alerts.config.DynamicScale
+import alerts.config.Hysteresis
+import alerts.config.InstrumentClass
+import alerts.config.MatrixV11
+import alerts.config.QuietHours
+import alerts.config.Thresholds
+import alerts.model.AlertEvent
+import alerts.ports.MarketDataPort
+import alerts.ports.MarketSnapshot
+import alerts.ports.NotifierPort
+import alerts.ports.PortfolioPort
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+
+class DynamicScaleTest {
+    @org.junit.jupiter.api.Test
+    fun thresholdsScaleUpWithAtr() = runTest {
+        val clock = MutableClock(Instant.parse("2023-01-01T00:00:00Z"))
+        val market = FakeMarket()
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.3, 2.0)
+        market.daySnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        market.atr[1L] = 1.2
+        market.sigma[1L] = 1.0
+        val notifier = CollectingNotifier()
+        val engine = createEngine(clock, market, notifier, dynamic = DynamicScale(enabled = true))
+
+        engine.checkInstrument(1L)
+        assertEquals(0, notifier.events.size)
+
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 2.5, 2.0)
+        engine.checkInstrument(1L)
+        assertEquals(1, notifier.events.size)
+        assertEquals(AlertEvent.HysteresisState.ENTER, notifier.events.first().hysteresisState)
+    }
+
+    @org.junit.jupiter.api.Test
+    fun thresholdsClampWhenAtrLow() = runTest {
+        val clock = MutableClock(Instant.parse("2023-01-01T00:00:00Z"))
+        val market = FakeMarket()
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 1.3, 2.0)
+        market.daySnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        market.atr[1L] = 0.5
+        market.sigma[1L] = 1.0
+        val notifier = CollectingNotifier()
+        val engine = createEngine(clock, market, notifier, dynamic = DynamicScale(enabled = true, min = 0.7, max = 1.3))
+
+        engine.checkInstrument(1L)
+        assertEquals(0, notifier.events.size)
+
+        market.fastSnapshots[1L] = MarketSnapshot(InstrumentClass.MOEX_BLUE, 1.5, 2.0)
+        engine.checkInstrument(1L)
+        assertEquals(1, notifier.events.size)
+    }
+
+    private fun createEngine(
+        clock: MutableClock,
+        market: FakeMarket,
+        notifier: CollectingNotifier,
+        dynamic: DynamicScale
+    ): AlertEngine {
+        val matrix = MatrixV11(
+            perClass = mapOf(
+                InstrumentClass.MOEX_BLUE to Thresholds(pctFast = 2.0, pctDay = 4.0, volMultFast = 1.5)
+            ),
+            hysteresis = Hysteresis(enterPct = 2.0, exitPct = 1.5),
+            portfolioDayPct = 2.0,
+            portfolioDrawdownPct = 5.0
+        )
+        val config = AlertsConfig(
+            quiet = QuietHours(LocalTime.of(22, 0), LocalTime.of(22, 30)),
+            budget = Budget(maxPushesPerDay = 10),
+            matrix = matrix,
+            dynamic = dynamic,
+            cooldownMinutes = 0
+        )
+        return AlertEngine(
+            cfg = config,
+            market = market,
+            portfolio = object : PortfolioPort {
+                override suspend fun dayChangePct(portfolioId: UUID): Double = 0.0
+                override suspend fun drawdownPct(portfolioId: UUID): Double = 0.0
+            },
+            notifier = notifier,
+            cooldown = CooldownRegistry(clock, 0),
+            budget = BudgetLimiter(config.budget, clock),
+            quiet = QuietHoursGuard(config.quiet, ZoneOffset.UTC),
+            clock = clock
+        )
+    }
+
+    private class FakeMarket : MarketDataPort {
+        val fastSnapshots: MutableMap<Long, MarketSnapshot> = mutableMapOf()
+        val daySnapshots: MutableMap<Long, MarketSnapshot> = mutableMapOf()
+        val atr: MutableMap<Long, Double> = mutableMapOf()
+        val sigma: MutableMap<Long, Double> = mutableMapOf()
+
+        override suspend fun fastWindow(instrumentId: Long): MarketSnapshot {
+            return fastSnapshots[instrumentId] ?: MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        }
+
+        override suspend fun dayWindow(instrumentId: Long): MarketSnapshot {
+            return daySnapshots[instrumentId] ?: MarketSnapshot(InstrumentClass.MOEX_BLUE, 0.0, 1.0)
+        }
+
+        override suspend fun atr14(instrumentId: Long): Double? {
+            return atr[instrumentId]
+        }
+
+        override suspend fun sigma30d(instrumentId: Long): Double? {
+            return sigma[instrumentId]
+        }
+    }
+
+    private class CollectingNotifier : NotifierPort {
+        val events: MutableList<AlertEvent> = mutableListOf()
+
+        override suspend fun push(instrumentId: Long, event: AlertEvent) {
+            events.add(event)
+        }
+
+        override suspend fun pushPortfolio(portfolioId: UUID, event: alerts.model.PortfolioAlertEvent) {
+        }
+    }
+
+    private class MutableClock(
+        private var current: Instant,
+        private val zoneId: ZoneId = ZoneOffset.UTC
+    ) : Clock() {
+        override fun withZone(zone: ZoneId?): Clock {
+            return MutableClock(current, zone ?: zoneId)
+        }
+
+        override fun getZone(): ZoneId {
+            return zoneId
+        }
+
+        override fun instant(): Instant {
+            return current
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add alert configuration defaults with v1.1 matrix and dynamic scaling switches
- implement alert engine, anti-noise utilities, and scheduler using provided ports
- add comprehensive tests covering hysteresis, cooldown, budget, quiet hours, portfolio signals, and dynamic scaling

## Testing
- ./gradlew :alerts:compileKotlin :alerts:test --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68d549b9cb1c8321bcd5d06e9fca8934