### PR TITLE
Implement news ingestion pipeline with deduplication and Telegram publishing

### DIFF
--- a/news/build.gradle.kts
+++ b/news/build.gradle.kts
@@ -1,1 +1,16 @@
-// News module build script placeholder
+plugins {
+    alias(libs.plugins.ktor)
+}
+
+dependencies {
+    implementation(libs.coroutines.core)
+    implementation("io.ktor:ktor-client-core-jvm:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-client-cio:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-client-content-negotiation:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-client-logging:${libs.versions.ktor.get()}")
+    implementation("com.github.pengrad:java-telegram-bot-api:9.2.0")
+    implementation("org.slf4j:slf4j-api:2.0.13")
+
+    testImplementation("io.ktor:ktor-client-mock:${libs.versions.ktor.get()}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${libs.versions.coroutines.get()}")
+}

--- a/news/src/main/kotlin/news/canonical/CanonicalPicker.kt
+++ b/news/src/main/kotlin/news/canonical/CanonicalPicker.kt
@@ -1,0 +1,26 @@
+package news.canonical
+
+import news.config.NewsConfig
+import news.config.NewsDefaults
+import news.model.Article
+
+class CanonicalPicker(private val config: NewsConfig) {
+    private val weightMap: Map<String, Int> = config.sourceWeights.associate { it.domain.lowercase() to it.weight }
+
+    fun choose(current: Article?, candidate: Article): Article {
+        if (current == null) return candidate
+        val currentWeight = weightFor(current.domain)
+        val candidateWeight = weightFor(candidate.domain)
+        return when {
+            candidateWeight > currentWeight -> candidate
+            candidateWeight < currentWeight -> current
+            candidate.publishedAt.isBefore(current.publishedAt) -> candidate
+            else -> current
+        }
+    }
+
+    fun weightFor(domain: String): Int {
+        val normalized = domain.lowercase()
+        return weightMap[normalized] ?: NewsDefaults.weightFor(normalized, config.sourceWeights)
+    }
+}

--- a/news/src/main/kotlin/news/config/NewsConfig.kt
+++ b/news/src/main/kotlin/news/config/NewsConfig.kt
@@ -1,0 +1,38 @@
+package news.config
+
+data class SourceWeight(
+    val domain: String,
+    val weight: Int
+)
+
+data class NewsConfig(
+    val userAgent: String,
+    val httpTimeoutMs: Long,
+    val sourceWeights: List<SourceWeight>,
+    val channelId: Long,
+    val botDeepLinkBase: String
+)
+
+object NewsDefaults {
+    private val defaultWeights = listOf(
+        SourceWeight("cbr.ru", 100),
+        SourceWeight("moex.com", 95),
+        SourceWeight("interfax.ru", 70),
+        SourceWeight("ria.ru", 65),
+        SourceWeight("vedomosti.ru", 60),
+        SourceWeight("rbk.ru", 55),
+        SourceWeight("kommersant.ru", 50)
+    )
+
+    val defaultConfig: NewsConfig = NewsConfig(
+        userAgent = "news-bot/1.0",
+        httpTimeoutMs = 30_000,
+        sourceWeights = defaultWeights,
+        channelId = 0L,
+        botDeepLinkBase = "https://t.me/example_bot"
+    )
+
+    fun weightFor(domain: String, weights: List<SourceWeight> = defaultWeights): Int {
+        return weights.firstOrNull { domain.endsWith(it.domain, ignoreCase = true) }?.weight ?: 0
+    }
+}

--- a/news/src/main/kotlin/news/dedup/Clusterer.kt
+++ b/news/src/main/kotlin/news/dedup/Clusterer.kt
@@ -1,0 +1,151 @@
+package news.dedup
+
+import java.security.MessageDigest
+import java.time.Instant
+import news.canonical.CanonicalPicker
+import news.config.NewsConfig
+import news.model.Article
+import news.model.Cluster
+import news.nlp.TextNormalize
+import kotlin.text.Charsets
+
+class Clusterer(
+    config: NewsConfig,
+    private val lsh: MinHashLSH = MinHashLSH(),
+    private val canonicalPicker: CanonicalPicker = CanonicalPicker(config)
+) {
+    private val jaccardThreshold = 0.75
+
+    fun cluster(articles: List<Article>): List<Cluster> {
+        if (articles.isEmpty()) return emptyList()
+        val clusters = LinkedHashMap<String, MutableCluster>()
+        val fingerprintIndex = mutableMapOf<String, String>()
+        val entityIndex = mutableMapOf<String, MutableSet<String>>()
+        val bucketIndex = mutableMapOf<String, MutableSet<String>>()
+
+        for (article in articles.sortedBy { it.publishedAt }) {
+            val tokens = TextNormalize.tokensForShingles(article.title, article.summary)
+            val shingles = Shingles.generate(tokens)
+            val simHash = SimHash64.hash(shingles)
+            val signature = lsh.signature(shingles)
+            val articleEntities = article.entities + article.tickers
+            val fastHash = fastHash(article.title, article.domain)
+
+            val existingKey = fingerprintIndex[fastHash]
+            val candidateKeys = LinkedHashSet<String>()
+            if (existingKey != null) {
+                candidateKeys.add(existingKey)
+            }
+            for (entity in articleEntities) {
+                entityIndex[entity]?.let { candidateKeys.addAll(it) }
+            }
+            for (bucket in lsh.bucketKeys(signature)) {
+                bucketIndex[bucket]?.let { candidateKeys.addAll(it) }
+            }
+
+            val matchedCluster = candidateKeys.firstNotNullOfOrNull { key ->
+                val candidate = clusters[key] ?: return@firstNotNullOfOrNull null
+                if (articleEntities.isNotEmpty() && candidate.entities.intersect(articleEntities).isNotEmpty()) {
+                    candidate
+                } else {
+                    val hamDist = SimHash64.hammingDistance(candidate.simHash, simHash)
+                    if (hamDist <= 3) {
+                        candidate
+                    } else {
+                        val jaccard = lsh.jaccardSimilarity(candidate.shingles, shingles)
+                        if (jaccard >= jaccardThreshold) candidate else null
+                    }
+                }
+            }
+
+            if (matchedCluster != null) {
+                val updatedSignature = matchedCluster.addArticle(article, shingles)
+                fingerprintIndex[fastHash] = matchedCluster.key
+                for (entity in articleEntities) {
+                    entityIndex.getOrPut(entity) { mutableSetOf() }.add(matchedCluster.key)
+                }
+                for (bucket in lsh.bucketKeys(updatedSignature)) {
+                    bucketIndex.getOrPut(bucket) { mutableSetOf() }.add(matchedCluster.key)
+                }
+            } else {
+                val clusterKey = clusterKey(article)
+                val mutableCluster = MutableCluster(
+                    key = clusterKey,
+                    canonical = article,
+                    articles = mutableListOf(article),
+                    shingles = shingles.toMutableSet(),
+                    simHash = simHash,
+                    signature = signature,
+                    entities = articleEntities.toMutableSet(),
+                    topics = (articleEntities).toMutableSet(),
+                    createdAt = article.publishedAt
+                )
+                clusters[clusterKey] = mutableCluster
+                fingerprintIndex[fastHash] = clusterKey
+                for (entity in articleEntities) {
+                    entityIndex.getOrPut(entity) { mutableSetOf() }.add(clusterKey)
+                }
+                for (bucket in lsh.bucketKeys(signature)) {
+                    bucketIndex.getOrPut(bucket) { mutableSetOf() }.add(clusterKey)
+                }
+            }
+        }
+
+        return clusters.values.map { it.toCluster(canonicalPicker) }
+    }
+
+    private fun fastHash(title: String, domain: String): String {
+        val digest = MessageDigest.getInstance("MD5")
+        val normalized = "${domain.lowercase()}|${title.lowercase()}"
+        val bytes = digest.digest(normalized.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString(separator = "") { String.format("%02x", it) }
+    }
+
+    private fun clusterKey(article: Article): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val seed = "${article.domain}|${article.id}|${article.title.lowercase()}"
+        val bytes = digest.digest(seed.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString(separator = "") { String.format("%02x", it) }
+    }
+
+    private inner class MutableCluster(
+        val key: String,
+        var canonical: Article,
+        val articles: MutableList<Article>,
+        val shingles: MutableSet<String>,
+        var simHash: Long,
+        var signature: IntArray,
+        val entities: MutableSet<String>,
+        val topics: MutableSet<String>,
+        var createdAt: Instant
+    ) {
+        fun addArticle(article: Article, articleShingles: Set<String>): IntArray {
+            articles.add(article)
+            entities.addAll(article.entities)
+            entities.addAll(article.tickers)
+            topics.addAll(article.entities)
+            topics.addAll(article.tickers)
+            shingles.addAll(articleShingles)
+            simHash = SimHash64.hash(shingles)
+            signature = lsh.signature(shingles)
+            canonical = canonicalPicker.choose(canonical, article)
+            if (article.publishedAt.isBefore(createdAt)) {
+                createdAt = article.publishedAt
+            }
+            return signature
+        }
+
+        fun toCluster(picker: CanonicalPicker): Cluster {
+            val canonicalArticle = articles.fold<Article, Article?>(null) { acc, item ->
+                picker.choose(acc, item)
+            } ?: canonical
+            return Cluster(
+                clusterKey = key,
+                canonical = canonicalArticle,
+                articles = articles.sortedBy { it.publishedAt },
+                topics = topics.toSet(),
+                createdAt = createdAt
+            )
+        }
+    }
+}

--- a/news/src/main/kotlin/news/dedup/MinHashLSH.kt
+++ b/news/src/main/kotlin/news/dedup/MinHashLSH.kt
@@ -1,0 +1,54 @@
+package news.dedup
+
+import java.security.SecureRandom
+
+class MinHashLSH(
+    private val numHashes: Int = 64,
+    private val bands: Int = 16,
+    seed: Long = 1L
+) {
+    private val rowsPerBand = numHashes / bands
+    private val prime = 2_147_483_647
+    private val random = SecureRandom().apply { setSeed(seed) }
+    private val coefficientsA = IntArray(numHashes) { random.nextInt(prime - 1) + 1 }
+    private val coefficientsB = IntArray(numHashes) { random.nextInt(prime - 1) + 1 }
+
+    init {
+        require(numHashes % bands == 0) { "numHashes must be divisible by bands" }
+    }
+
+    fun signature(shingles: Set<String>): IntArray {
+        val signature = IntArray(numHashes) { Int.MAX_VALUE }
+        if (shingles.isEmpty()) return signature
+        for (shingle in shingles) {
+            val shingleHash = shingle.hashCode()
+            for (i in 0 until numHashes) {
+                val hash = ((coefficientsA[i].toLong() * (shingleHash and Int.MAX_VALUE) + coefficientsB[i]) % prime).toInt()
+                if (hash < signature[i]) {
+                    signature[i] = hash
+                }
+            }
+        }
+        return signature
+    }
+
+    fun bucketKeys(signature: IntArray): Sequence<String> {
+        return sequence {
+            for (band in 0 until bands) {
+                val start = band * rowsPerBand
+                val slice = signature.sliceArray(start until start + rowsPerBand)
+                val key = slice.joinToString(separator = ":", prefix = "$band:")
+                yield(key)
+            }
+        }
+    }
+
+    fun jaccardSimilarity(first: Set<String>, second: Set<String>): Double {
+        if (first.isEmpty() && second.isEmpty()) return 1.0
+        if (first.isEmpty() || second.isEmpty()) return 0.0
+        val intersection = first.intersect(second).size.toDouble()
+        val union = (first.size + second.size - intersection)
+        if (union == 0.0) return 0.0
+        return intersection / union
+    }
+}

--- a/news/src/main/kotlin/news/dedup/Shingles.kt
+++ b/news/src/main/kotlin/news/dedup/Shingles.kt
@@ -1,0 +1,17 @@
+package news.dedup
+
+object Shingles {
+    fun generate(tokens: List<String>, minSize: Int = 5, maxSize: Int = 8): Set<String> {
+        if (tokens.isEmpty() || minSize <= 0) return emptySet()
+        val normalizedMax = maxOf(minSize, maxSize)
+        val result = LinkedHashSet<String>()
+        for (size in minSize..normalizedMax) {
+            if (tokens.size < size) break
+            for (index in 0..tokens.size - size) {
+                val shingle = tokens.subList(index, index + size).joinToString(separator = " ")
+                result.add(shingle)
+            }
+        }
+        return result
+    }
+}

--- a/news/src/main/kotlin/news/dedup/SimHash64.kt
+++ b/news/src/main/kotlin/news/dedup/SimHash64.kt
@@ -1,0 +1,52 @@
+package news.dedup
+
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+import kotlin.text.Charsets
+
+object SimHash64 {
+    private val digestThreadLocal: ThreadLocal<MessageDigest> = ThreadLocal.withInitial {
+        MessageDigest.getInstance("SHA-256")
+    }
+
+    fun hash(shingles: Set<String>): Long {
+        if (shingles.isEmpty()) return 0L
+        val vector = IntArray(64)
+        for (shingle in shingles) {
+            val hash = hash64(shingle)
+            for (bit in 0 until 64) {
+                val mask = 1L shl bit
+                if (hash and mask != 0L) {
+                    vector[bit] += 1
+                } else {
+                    vector[bit] -= 1
+                }
+            }
+        }
+        var result = 0L
+        for (bit in 0 until 64) {
+            if (vector[bit] > 0) {
+                result = result or (1L shl bit)
+            }
+        }
+        return result
+    }
+
+    fun hammingDistance(left: Long, right: Long): Int {
+        var value = left xor right
+        var distance = 0
+        while (value != 0L) {
+            value = value and (value - 1)
+            distance++
+        }
+        return distance
+    }
+
+    private fun hash64(value: String): Long {
+        val digest = digestThreadLocal.get()
+        digest.reset()
+        val bytes = digest.digest(value.toByteArray(Charsets.UTF_8))
+        val buffer = ByteBuffer.wrap(bytes, 0, 8)
+        return buffer.long
+    }
+}

--- a/news/src/main/kotlin/news/model/Article.kt
+++ b/news/src/main/kotlin/news/model/Article.kt
@@ -1,0 +1,23 @@
+package news.model
+
+import java.time.Instant
+
+data class Article(
+    val id: String,
+    val url: String,
+    val domain: String,
+    val title: String,
+    val summary: String?,
+    val publishedAt: Instant,
+    val language: String?,
+    val tickers: Set<String>,
+    val entities: Set<String>
+)
+
+data class Cluster(
+    val clusterKey: String,
+    val canonical: Article,
+    val articles: List<Article>,
+    val topics: Set<String>,
+    val createdAt: Instant
+)

--- a/news/src/main/kotlin/news/nlp/TextNormalize.kt
+++ b/news/src/main/kotlin/news/nlp/TextNormalize.kt
@@ -1,0 +1,65 @@
+package news.nlp
+
+import java.net.URI
+
+object TextNormalize {
+    private val htmlTagRegex = "<[^>]+>".toRegex(RegexOption.IGNORE_CASE)
+    private val whitespaceRegex = "\\s+".toRegex()
+    private val punctuationRegex = "[^\\p{L}\\p{Nd}\\s]".toRegex()
+    private val tickerRegex = "\\b[A-Z]{3,5}\\b".toRegex()
+    private val htmlEntities = mapOf(
+        "&nbsp;" to " ",
+        "&amp;" to "&",
+        "&quot;" to "\"",
+        "&#39;" to "'",
+        "&lt;" to "<",
+        "&gt;" to ">"
+    )
+    private val domainEntities = mapOf(
+        "cbr.ru" to setOf("Bank of Russia"),
+        "www.cbr.ru" to setOf("Bank of Russia"),
+        "moex.com" to setOf("Moscow Exchange"),
+        "www.moex.com" to setOf("Moscow Exchange")
+    )
+    private val moexWhitelist = setOf("GAZP", "SBER", "LKOH", "VTBR", "ALRS", "GMKN")
+
+    fun clean(raw: String?): String {
+        if (raw.isNullOrBlank()) return ""
+        var text = raw!!
+        htmlEntities.forEach { (key, value) ->
+            text = text.replace(key, value, ignoreCase = true)
+        }
+        text = text.replace(htmlTagRegex, " ")
+        text = text.replace(punctuationRegex, " ")
+        text = text.lowercase()
+        text = text.replace(whitespaceRegex, " ").trim()
+        return text
+    }
+
+    fun combineText(vararg parts: String?): String {
+        return parts.filterNotNull().filter { it.isNotBlank() }.joinToString(" ")
+    }
+
+    fun tokensForShingles(title: String, summary: String?): List<String> {
+        val combined = clean(combineText(title, summary))
+        if (combined.isEmpty()) return emptyList()
+        return combined.split(' ').filter { it.isNotBlank() }
+    }
+
+    fun extractTickers(text: String, domain: String): Set<String> {
+        val matches = tickerRegex.findAll(text).map { it.value }.toSet()
+        if (matches.isEmpty()) return emptySet()
+        val normalizedDomain = URI("https://$domain").host.lowercase()
+        return if (normalizedDomain.contains("moex")) {
+            matches.filter { moexWhitelist.contains(it) }.toSet()
+        } else {
+            matches
+        }
+    }
+
+    fun extractEntities(domain: String, tickers: Set<String>): Set<String> {
+        val normalizedDomain = domain.lowercase()
+        val baseEntities = domainEntities[normalizedDomain] ?: emptySet()
+        return baseEntities + tickers
+    }
+}

--- a/news/src/main/kotlin/news/pipeline/NewsPipeline.kt
+++ b/news/src/main/kotlin/news/pipeline/NewsPipeline.kt
@@ -1,0 +1,83 @@
+package news.pipeline
+
+import java.security.MessageDigest
+import java.util.Base64
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import news.canonical.CanonicalPicker
+import news.config.NewsConfig
+import news.dedup.Clusterer
+import news.model.Article
+import news.model.Cluster
+import news.publisher.IdempotencyStore
+import news.publisher.TelegramPublisher
+import news.sources.NewsSource
+import org.slf4j.LoggerFactory
+import kotlin.text.Charsets
+
+class NewsPipeline(
+    private val config: NewsConfig,
+    private val sources: List<NewsSource>,
+    private val clusterer: Clusterer,
+    private val telegramPublisher: TelegramPublisher,
+    private val idempotencyStore: IdempotencyStore
+) {
+    private val logger = LoggerFactory.getLogger(NewsPipeline::class.java)
+    private val canonicalPicker = CanonicalPicker(config)
+
+    suspend fun runOnce(): Int = coroutineScope {
+        val fetchedArticles = fetchSources()
+        if (fetchedArticles.isEmpty()) {
+            logger.info("No articles fetched")
+            return@coroutineScope 0
+        }
+        val clusters = clusterer.cluster(fetchedArticles)
+        if (clusters.isEmpty()) {
+            logger.info("No clusters generated")
+            return@coroutineScope 0
+        }
+        val breakingCandidates = selectBreaking(clusters)
+            .filterNot { idempotencyStore.seen(it.clusterKey) }
+        var published = 0
+        for (cluster in breakingCandidates) {
+            val deepLink = deepLink(cluster)
+            val posted = telegramPublisher.publishBreaking(cluster, deepLink)
+            if (posted) {
+                published += 1
+            }
+        }
+        logger.info("Published {} breaking posts", published)
+        published
+    }
+
+    private suspend fun fetchSources(): List<Article> = coroutineScope {
+        sources.map { source ->
+            async {
+                runCatching { source.fetch() }
+                    .onFailure { logger.warn("Source {} failed", source.name, it) }
+                    .getOrDefault(emptyList())
+            }
+        }.awaitAll().flatten()
+    }
+
+    private fun selectBreaking(clusters: List<Cluster>): List<Cluster> {
+        val sorted = clusters.sortedWith(
+            compareByDescending<Cluster> { canonicalPicker.weightFor(it.canonical.domain) }
+                .thenByDescending { it.canonical.publishedAt }
+        )
+        return sorted.take(2)
+    }
+
+    private fun deepLink(cluster: Cluster): String {
+        val base = config.botDeepLinkBase.trimEnd('/')
+        val payload = payload(cluster.clusterKey)
+        return "$base?start=$payload"
+    }
+
+    private fun payload(key: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val bytes = digest.digest(key.toByteArray(Charsets.UTF_8)).copyOf(12)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+}

--- a/news/src/main/kotlin/news/publisher/IdempotencyStore.kt
+++ b/news/src/main/kotlin/news/publisher/IdempotencyStore.kt
@@ -1,0 +1,43 @@
+package news.publisher
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+interface IdempotencyStore {
+    fun seen(clusterKey: String): Boolean
+    fun mark(clusterKey: String)
+}
+
+class InMemoryIdempotencyStore(
+    private val ttl: Duration = Duration.ofHours(6),
+    private val clock: Clock = Clock.systemUTC()
+) : IdempotencyStore {
+    private val entries = mutableMapOf<String, Instant>()
+
+    override fun seen(clusterKey: String): Boolean {
+        purgeExpired()
+        val expiresAt = entries[clusterKey] ?: return false
+        if (expiresAt.isBefore(clock.instant())) {
+            entries.remove(clusterKey)
+            return false
+        }
+        return true
+    }
+
+    override fun mark(clusterKey: String) {
+        purgeExpired()
+        entries[clusterKey] = clock.instant().plus(ttl)
+    }
+
+    private fun purgeExpired() {
+        val now = clock.instant()
+        val iterator = entries.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.value.isBefore(now)) {
+                iterator.remove()
+            }
+        }
+    }
+}

--- a/news/src/main/kotlin/news/publisher/TelegramPublisher.kt
+++ b/news/src/main/kotlin/news/publisher/TelegramPublisher.kt
@@ -1,0 +1,81 @@
+package news.publisher
+
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.request.InlineKeyboardButton
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+import com.pengrad.telegrambot.model.request.ParseMode
+import com.pengrad.telegrambot.request.SendMessage
+import java.security.MessageDigest
+import java.util.Base64
+import news.config.NewsConfig
+import news.model.Cluster
+import news.render.PostTemplates
+import org.slf4j.LoggerFactory
+
+data class TelegramResult(val ok: Boolean, val description: String? = null)
+
+interface TelegramClient {
+    fun send(request: SendMessage): TelegramResult
+}
+
+class PengradTelegramClient(private val bot: TelegramBot) : TelegramClient {
+    override fun send(request: SendMessage): TelegramResult {
+        val response = bot.execute(request)
+        return TelegramResult(response.isOk, response.description())
+    }
+}
+
+class TelegramPublisher(
+    private val client: TelegramClient,
+    private val config: NewsConfig,
+    private val idempotencyStore: IdempotencyStore
+) {
+    private val logger = LoggerFactory.getLogger(TelegramPublisher::class.java)
+
+    suspend fun publishBreaking(cluster: Cluster, deepLink: String): Boolean {
+        if (idempotencyStore.seen(cluster.clusterKey)) {
+            logger.info("Skipping cluster {} due to idempotency", cluster.clusterKey)
+            return false
+        }
+        return sendMessage(cluster.clusterKey, PostTemplates.renderBreaking(cluster, deepLink), deepLink)
+    }
+
+    suspend fun publishDigest(clusters: List<Cluster>, deepLinkBuilder: (Cluster) -> String): Boolean {
+        if (clusters.isEmpty()) return false
+        val digestKey = digestKey(clusters)
+        if (idempotencyStore.seen(digestKey)) {
+            logger.info("Skipping digest {} due to idempotency", digestKey)
+            return false
+        }
+        val deepLink = deepLinkBuilder(clusters.first())
+        val text = PostTemplates.renderDigest(clusters, deepLinkBuilder)
+        return sendMessage(digestKey, text, deepLink)
+    }
+
+    private fun sendMessage(key: String, text: String, deepLink: String): Boolean {
+        return try {
+            val request = SendMessage(config.channelId, text)
+                .parseMode(ParseMode.MarkdownV2)
+                .replyMarkup(InlineKeyboardMarkup(InlineKeyboardButton("Открыть в боте").url(deepLink)))
+            val response = client.send(request)
+            if (response.ok) {
+                idempotencyStore.mark(key)
+                logger.info("Published cluster {}", key)
+                true
+            } else {
+                logger.warn("Telegram send failed for {} with error {}", key, response.description)
+                false
+            }
+        } catch (ex: Exception) {
+            logger.error("Telegram send threw for {}", key, ex)
+            false
+        }
+    }
+
+    private fun digestKey(clusters: List<Cluster>): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val joined = clusters.joinToString(separator = "|") { it.clusterKey }
+        val hash = digest.digest(joined.toByteArray(Charsets.UTF_8))
+        return "digest:" + Base64.getUrlEncoder().withoutPadding().encodeToString(hash.copyOf(12))
+    }
+}

--- a/news/src/main/kotlin/news/render/PostTemplates.kt
+++ b/news/src/main/kotlin/news/render/PostTemplates.kt
@@ -1,0 +1,78 @@
+package news.render
+
+import news.model.Cluster
+
+object PostTemplates {
+    fun renderBreaking(cluster: Cluster, deepLink: String): String {
+        val canonical = cluster.canonical
+        val builder = StringBuilder()
+        builder.append("*Breaking:* ")
+        builder.append(escapeMarkdown(canonical.title))
+        canonical.summary?.let {
+            builder.append("\n\n")
+            builder.append(escapeMarkdown(it))
+        }
+        builder.append("\n\n")
+        builder.append("Источник: ")
+        builder.append(escapeMarkdown(canonical.domain))
+        builder.append("\n")
+        builder.append(renderCta(deepLink))
+        return builder.toString()
+    }
+
+    fun renderDigest(clusters: List<Cluster>, deepLinkBuilder: (Cluster) -> String): String {
+        val builder = StringBuilder()
+        builder.append("*Daily Digest*\n")
+        clusters.take(3).forEachIndexed { index, cluster ->
+            builder.append("\n")
+            builder.append("${index + 1}. ")
+            builder.append(escapeMarkdown(cluster.canonical.title))
+            cluster.topics.takeIf { it.isNotEmpty() }?.let {
+                builder.append(" — ")
+                builder.append(escapeMarkdown(it.joinToString(", ")))
+            }
+            builder.append("\n")
+            builder.append(renderCta(deepLinkBuilder(cluster)))
+            builder.append("\n")
+        }
+        return builder.toString().trimEnd()
+    }
+
+    fun renderWeeklyPreview(clusters: List<Cluster>, deepLinkBuilder: (Cluster) -> String): String {
+        val builder = StringBuilder()
+        builder.append("*Weekly Preview*\n")
+        clusters.forEach { cluster ->
+            builder.append("\n• ")
+            builder.append(escapeMarkdown(cluster.canonical.title))
+            if (cluster.topics.isNotEmpty()) {
+                builder.append(" (")
+                builder.append(escapeMarkdown(cluster.topics.joinToString(", ")))
+                builder.append(")")
+            }
+        }
+        builder.append("\n\n")
+        builder.append("Подробнее: ")
+        builder.append(renderCta(deepLinkBuilder(clusters.firstOrNull() ?: return builder.toString().trim())))
+        return builder.toString().trim()
+    }
+
+    private fun renderCta(deepLink: String): String {
+        val sanitized = deepLink.take(64)
+        return "👉 [Открыть в боте](${escapeMarkdownLink(sanitized)})"
+    }
+
+    private fun escapeMarkdown(text: String): String {
+        return buildString(text.length) {
+            text.forEach { char ->
+                when (char) {
+                    '\\', '*', '_', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' -> append('\\')
+                }
+                append(char)
+            }
+        }
+    }
+
+    private fun escapeMarkdownLink(text: String): String {
+        return text.replace("(", "%28").replace(")", "%29").replace(" ", "%20")
+    }
+}

--- a/news/src/main/kotlin/news/rss/RssFetcher.kt
+++ b/news/src/main/kotlin/news/rss/RssFetcher.kt
@@ -1,0 +1,146 @@
+package news.rss
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import java.io.ByteArrayInputStream
+import java.security.MessageDigest
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import javax.xml.parsers.DocumentBuilderFactory
+import news.config.NewsConfig
+import org.slf4j.LoggerFactory
+import org.w3c.dom.Element
+import kotlin.text.Charsets
+
+class RssFetcher(
+    private val config: NewsConfig,
+    private val client: HttpClient = defaultClient(config)
+) {
+    private val logger = LoggerFactory.getLogger(RssFetcher::class.java)
+
+    suspend fun fetchRss(url: String): List<RssItem> {
+        logger.info("Fetching RSS feed: {}", sanitizeUrl(url))
+        val response = client.get(url)
+        val payload = response.bodyAsText()
+        val normalized = parseRss(payload)
+        logger.info("Parsed {} RSS items from {}", normalized.size, sanitizeUrl(url))
+        return normalized
+    }
+
+    private fun parseRss(payload: String): List<RssItem> {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.isNamespaceAware = false
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false)
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        val builder = factory.newDocumentBuilder()
+        val document = builder.parse(ByteArrayInputStream(payload.toByteArray(Charsets.UTF_8)))
+        val nodes = document.getElementsByTagName("item")
+        val items = mutableListOf<RssItem>()
+        for (index in 0 until nodes.length) {
+            val element = nodes.item(index)
+            if (element is Element) {
+                val title = element.textContentOf("title")?.trim().orEmpty()
+                val link = element.textContentOf("link")?.trim().orEmpty()
+                val guid = element.textContentOf("guid")?.trim()
+                val description = element.textContentOf("description")?.trim()
+                val content = element.textContentOf("content:encoded")?.trim()
+                val publishedAt = parseDate(element.textContentOf("pubDate"))
+                if (title.isNotBlank() && link.isNotBlank()) {
+                    items.add(
+                        RssItem(
+                            id = guid ?: sha1(link),
+                            title = title,
+                            link = link,
+                            description = description,
+                            content = content,
+                            publishedAt = publishedAt
+                        )
+                    )
+                }
+            }
+        }
+        return items
+    }
+
+    companion object {
+        fun defaultClient(config: NewsConfig): HttpClient {
+            return HttpClient(CIO) {
+                install(HttpTimeout) {
+                    requestTimeoutMillis = config.httpTimeoutMs
+                    connectTimeoutMillis = config.httpTimeoutMs
+                    socketTimeoutMillis = config.httpTimeoutMs
+                }
+                install(HttpRequestRetry) {
+                    retryOnException(maxRetries = 3)
+                    retryIf(maxRetries = 3) { _, response ->
+                        response?.status == HttpStatusCode.TooManyRequests || (response?.status?.value ?: 0) >= 500
+                    }
+                    exponentialDelay()
+                }
+                install(DefaultRequest) {
+                    header(HttpHeaders.UserAgent, config.userAgent)
+                }
+                install(Logging) {
+                    level = LogLevel.INFO
+                    sanitizeHeader { header -> header == HttpHeaders.Authorization }
+                }
+            }
+        }
+    }
+}
+
+data class RssItem(
+    val id: String,
+    val title: String,
+    val link: String,
+    val description: String?,
+    val content: String?,
+    val publishedAt: Instant?
+)
+
+private fun Element.textContentOf(tag: String): String? {
+    val nodes = getElementsByTagName(tag)
+    if (nodes.length == 0) return null
+    return nodes.item(0)?.textContent
+}
+
+private fun parseDate(value: String?): Instant? {
+    if (value.isNullOrBlank()) return null
+    val formats = listOf(
+        DateTimeFormatter.RFC_1123_DATE_TIME,
+        DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+        DateTimeFormatter.ISO_ZONED_DATE_TIME
+    )
+    for (formatter in formats) {
+        try {
+            return ZonedDateTime.parse(value.trim(), formatter).toInstant()
+        } catch (_: DateTimeParseException) {
+        }
+    }
+    return null
+}
+
+private fun sanitizeUrl(url: String): String {
+    return url.substringBefore('?')
+}
+
+private fun sha1(value: String): String {
+    val digest = MessageDigest.getInstance("SHA-1")
+    val hashed = digest.digest(value.toByteArray(Charsets.UTF_8))
+    return hashed.joinToString(separator = "") { String.format("%02x", it) }
+}

--- a/news/src/main/kotlin/news/sources/CbrSource.kt
+++ b/news/src/main/kotlin/news/sources/CbrSource.kt
@@ -1,0 +1,42 @@
+package news.sources
+
+import java.net.URI
+import java.time.Instant
+import news.model.Article
+import news.nlp.TextNormalize
+import news.rss.RssFetcher
+import news.rss.RssItem
+
+interface NewsSource {
+    val name: String
+    suspend fun fetch(): List<Article>
+}
+
+class CbrSource(
+    private val fetcher: RssFetcher,
+    private val feedUrl: String = "https://www.cbr.ru/rss/RSS_press.xml"
+) : NewsSource {
+    override val name: String = "cbr.ru"
+
+    override suspend fun fetch(): List<Article> {
+        return fetcher.fetchRss(feedUrl).map { it.toArticle() }
+    }
+
+    private fun RssItem.toArticle(): Article {
+        val linkDomain = runCatching { URI(link).host }.getOrNull() ?: name
+        val cleanedSummary = TextNormalize.clean(description ?: content)
+        val tickers = emptySet<String>()
+        val entities = TextNormalize.extractEntities(linkDomain, tickers)
+        return Article(
+            id = id,
+            url = link,
+            domain = linkDomain,
+            title = title.trim(),
+            summary = cleanedSummary.ifBlank { null },
+            publishedAt = publishedAt ?: Instant.now(),
+            language = "ru",
+            tickers = tickers,
+            entities = entities
+        )
+    }
+}

--- a/news/src/main/kotlin/news/sources/MoexSource.kt
+++ b/news/src/main/kotlin/news/sources/MoexSource.kt
@@ -1,0 +1,39 @@
+package news.sources
+
+import java.net.URI
+import java.time.Instant
+import news.model.Article
+import news.nlp.TextNormalize
+import news.rss.RssFetcher
+import news.rss.RssItem
+
+class MoexSource(
+    private val fetcher: RssFetcher,
+    private val feedUrl: String = "https://www.moex.com/export/news.aspx?type=official&format=rss"
+) : NewsSource {
+    override val name: String = "moex.com"
+
+    override suspend fun fetch(): List<Article> {
+        return fetcher.fetchRss(feedUrl).map { it.toArticle() }
+    }
+
+    private fun RssItem.toArticle(): Article {
+        val linkDomain = runCatching { URI(link).host }.getOrNull() ?: name
+        val rawSummary = description ?: content ?: ""
+        val combinedText = TextNormalize.combineText(title, rawSummary)
+        val tickers = TextNormalize.extractTickers(combinedText, linkDomain)
+        val cleanedSummary = TextNormalize.clean(rawSummary)
+        val entities = TextNormalize.extractEntities(linkDomain, tickers)
+        return Article(
+            id = id,
+            url = link,
+            domain = linkDomain,
+            title = title.trim(),
+            summary = cleanedSummary.ifBlank { null },
+            publishedAt = publishedAt ?: Instant.now(),
+            language = "ru",
+            tickers = tickers,
+            entities = entities
+        )
+    }
+}

--- a/news/src/test/kotlin/news/dedup/ClustererTest.kt
+++ b/news/src/test/kotlin/news/dedup/ClustererTest.kt
@@ -1,0 +1,50 @@
+package news.dedup
+
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import news.config.NewsDefaults
+import news.model.Article
+
+class ClustererTest {
+    private val config = NewsDefaults.defaultConfig
+
+    @Test
+    fun `similar articles form single cluster`() {
+        val clusterer = Clusterer(config)
+        val baseTime = Instant.parse("2025-01-20T07:00:00Z")
+        val articles = listOf(
+            Article(
+                id = "cbr-1",
+                url = "https://www.cbr.ru/press/PR/?file=20012025_100000keyrate.htm",
+                domain = "www.cbr.ru",
+                title = "Банк России снижает ключевую ставку",
+                summary = "Банк России сообщил о снижении ставки, затрагивая SBER и GAZP.",
+                publishedAt = baseTime,
+                language = "ru",
+                tickers = setOf("SBER", "GAZP"),
+                entities = setOf("Bank of Russia", "SBER", "GAZP")
+            ),
+            Article(
+                id = "moex-1",
+                url = "https://www.moex.com/n46700",
+                domain = "www.moex.com",
+                title = "Мосбиржа сообщила о ставке Банка России",
+                summary = "Мосбиржа подтверждает действия регулятора и упоминает SBER.",
+                publishedAt = baseTime.plusSeconds(120),
+                language = "ru",
+                tickers = setOf("SBER"),
+                entities = setOf("Moscow Exchange", "SBER")
+            )
+        )
+
+        val clusters = clusterer.cluster(articles)
+
+        assertEquals(1, clusters.size)
+        val cluster = clusters.first()
+        assertEquals("www.cbr.ru", cluster.canonical.domain)
+        assertEquals(2, cluster.articles.size)
+        assertTrue("SBER" in cluster.topics)
+    }
+}

--- a/news/src/test/kotlin/news/publisher/PublisherIdempotencyTest.kt
+++ b/news/src/test/kotlin/news/publisher/PublisherIdempotencyTest.kt
@@ -1,0 +1,55 @@
+package news.publisher
+
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import news.config.NewsDefaults
+import news.model.Article
+import news.model.Cluster
+
+class PublisherIdempotencyTest {
+    private val config = NewsDefaults.defaultConfig.copy(channelId = -100L)
+
+    @Test
+    fun `duplicate cluster is not republished`() = runTest {
+        val store = InMemoryIdempotencyStore()
+        val client = CountingTelegramClient()
+        val publisher = TelegramPublisher(client, config, store)
+        val article = Article(
+            id = "cluster-1",
+            url = "https://www.cbr.ru/news/1",
+            domain = "www.cbr.ru",
+            title = "Банк России объявил решение",
+            summary = "",
+            publishedAt = Instant.parse("2025-01-20T07:00:00Z"),
+            language = "ru",
+            tickers = emptySet(),
+            entities = setOf("Bank of Russia")
+        )
+        val cluster = Cluster(
+            clusterKey = "cluster-key",
+            canonical = article,
+            articles = listOf(article),
+            topics = setOf("Bank of Russia"),
+            createdAt = article.publishedAt
+        )
+
+        val first = publisher.publishBreaking(cluster, "https://t.me/test_bot?start=payload")
+        val second = publisher.publishBreaking(cluster, "https://t.me/test_bot?start=payload")
+
+        assertTrue(first)
+        assertFalse(second)
+        assertEquals(1, client.sentMessages)
+    }
+
+    private class CountingTelegramClient : TelegramClient {
+        var sentMessages: Int = 0
+        override fun send(request: com.pengrad.telegrambot.request.SendMessage): TelegramResult {
+            sentMessages += 1
+            return TelegramResult(ok = true)
+        }
+    }
+}

--- a/news/src/test/kotlin/news/rss/RssFetcherTest.kt
+++ b/news/src/test/kotlin/news/rss/RssFetcherTest.kt
@@ -1,0 +1,70 @@
+package news.rss
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import news.config.NewsDefaults
+import news.sources.CbrSource
+import news.sources.MoexSource
+
+class RssFetcherTest {
+    private val config = NewsDefaults.defaultConfig
+
+    @Test
+    fun `parse cbr feed`() = runTest {
+        val payload = loadFixture("feeds/cbr_rss.xml")
+        val client = httpClient(payload)
+        val fetcher = RssFetcher(config, client)
+        val source = CbrSource(fetcher, "https://test.local/cbr.xml")
+
+        val articles = source.fetch()
+
+        assertEquals(2, articles.size)
+        val first = articles.first()
+        assertEquals("www.cbr.ru", first.domain)
+        assertEquals("ru", first.language)
+        assertEquals(emptySet(), first.tickers)
+        assertEquals(setOf("Bank of Russia"), first.entities)
+    }
+
+    @Test
+    fun `parse moex feed with tickers`() = runTest {
+        val payload = loadFixture("feeds/moex_rss.xml")
+        val client = httpClient(payload)
+        val fetcher = RssFetcher(config, client)
+        val source = MoexSource(fetcher, "https://test.local/moex.xml")
+
+        val articles = source.fetch()
+
+        assertEquals(2, articles.size)
+        val first = articles.first()
+        assertEquals(setOf("SBER", "GAZP"), first.tickers)
+        assertEquals(setOf("Moscow Exchange", "SBER", "GAZP"), first.entities)
+    }
+
+    private fun httpClient(payload: String): HttpClient {
+        return HttpClient(MockEngine { _ ->
+            respond(
+                content = payload,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Xml.toString())
+            )
+        }) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 1000
+                connectTimeoutMillis = 1000
+            }
+        }
+    }
+
+    private fun loadFixture(path: String): String {
+        val resource = checkNotNull(javaClass.classLoader?.getResource(path)) { "Missing fixture $path" }
+        return resource.readText()
+    }
+}

--- a/news/src/test/resources/feeds/cbr_rss.xml
+++ b/news/src/test/resources/feeds/cbr_rss.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Bank of Russia</title>
+    <item>
+      <title>Банк России снизил ключевую ставку</title>
+      <link>https://www.cbr.ru/press/PR/?file=20012025_100000keyrate.htm</link>
+      <guid>cbr-1</guid>
+      <pubDate>Mon, 20 Jan 2025 10:00:00 +0300</pubDate>
+      <description><![CDATA[Банк России снизил ключевую ставку до 12,5%.]]></description>
+    </item>
+    <item>
+      <title>Решение Банка России по ключевой ставке</title>
+      <link>https://www.cbr.ru/press/PR/?file=20012025_100500keyrate.htm</link>
+      <guid>cbr-2</guid>
+      <pubDate>Mon, 20 Jan 2025 10:05:00 +0300</pubDate>
+      <description><![CDATA[Ключевая ставка Банка России установлена на уровне 12,5 процента.]]></description>
+    </item>
+  </channel>
+</rss>

--- a/news/src/test/resources/feeds/moex_rss.xml
+++ b/news/src/test/resources/feeds/moex_rss.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>MOEX News</title>
+    <item>
+      <title>MOEX: Торги по акциям SBER остановлены</title>
+      <link>https://www.moex.com/n46700?from=official</link>
+      <guid>moex-1</guid>
+      <pubDate>Mon, 20 Jan 2025 09:30:00 +0300</pubDate>
+      <description><![CDATA[Проведены внеплановые торги по бумагам SBER и GAZP.]]></description>
+    </item>
+    <item>
+      <title>MOEX повторно сообщает о торгах SBER</title>
+      <link>https://www.moex.com/n46700?from=duplicate</link>
+      <guid>moex-2</guid>
+      <pubDate>Mon, 20 Jan 2025 09:32:00 +0300</pubDate>
+      <description><![CDATA[Дополнительная информация по операциям с SBER и GAZP на Московской бирже.]]></description>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- add configurable news defaults, article models, and RSS fetching for CBR and MOEX feeds with normalization helpers
- implement deduplication stack (shingles, SimHash64, MinHash LSH, canonical selection) and post rendering templates
- wire Telegram publisher with idempotency and pipeline glue plus tests covering RSS parsing, clustering, and publishing idempotency

## Testing
- ./gradlew :news:compileKotlin --console=plain
- ./gradlew :news:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d54eaeb7a48321affa4afe774207e3