### PR TITLE
Add Telegram mini app frontend

### DIFF
--- a/miniapp/.env.example
+++ b/miniapp/.env.example
@@ -1,0 +1,2 @@
+VITE_API_BASE=http://localhost:8080
+VITE_APP_NAME=portfolio-miniapp

--- a/miniapp/README.md
+++ b/miniapp/README.md
@@ -1,0 +1,43 @@
+# Portfolio Mini App
+
+This directory contains a Telegram Mini App built with Vite, React, and TypeScript. The project integrates with a backend service that verifies Telegram Web App sessions and issues a JWT token for authenticated requests.
+
+## Prerequisites
+
+- pnpm (recommended) or npm/yarn
+- Node.js 18+
+
+## Getting started
+
+```bash
+pnpm install
+pnpm dev
+```
+
+The development server runs on [http://localhost:5173](http://localhost:5173).
+
+To build and preview the production bundle:
+
+```bash
+pnpm build
+pnpm preview
+```
+
+Run type checking and tests:
+
+```bash
+pnpm typecheck
+pnpm test
+```
+
+## Telegram auth flow
+
+When opened inside Telegram, the Mini App reads `initData` supplied by the client. The frontend sends this data to the backend endpoint `/api/auth/telegram/verify` which performs validation and responds with a JWT. The token is stored only in memory for the current session. UI preferences such as the theme and last opened tab are persisted to `localStorage`.
+
+Launching the app directly in a browser without Telegram will display instructions describing how to open the Mini App from Telegram.
+
+## Deep link
+
+[Open Mini App](https://t.me/your_bot_username?startapp=tab%3Ddashboard)
+
+Replace `your_bot_username` with the actual bot name and adjust the `startapp` payload as needed.

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portfolio Mini App</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/miniapp/package.json
+++ b/miniapp/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "portfolio-miniapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.22.3",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@types/telegram-web-app": "file:src/types/telegram-web-app.d.ts",
+    "@vitejs/plugin-react": "^5.0.4",
+    "jsdom": "^24.0.0",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.10",
+    "vitest": "^1.5.0"
+  }
+}

--- a/miniapp/src/App.tsx
+++ b/miniapp/src/App.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { TopBar } from "./components/TopBar";
+import { TabBar } from "./components/TabBar";
+import { AppRoutes } from "./router";
+import { parseStartParam } from "./lib/telegram";
+import { getUIPreferences, setLastTabPreference, setThemePreference } from "./lib/session";
+import type { ThemeMode } from "./lib/session";
+import type { InitDataUnsafe } from "./lib/telegram";
+
+const tabs = [
+  { path: "/", label: "Dashboard", title: "Dashboard" },
+  { path: "/positions", label: "Positions", title: "Positions" },
+  { path: "/trades", label: "Trades", title: "Trades" },
+  { path: "/import", label: "Import", title: "Import" },
+  { path: "/calendar", label: "Calendar", title: "Calendar" },
+  { path: "/reports", label: "Reports", title: "Reports" },
+  { path: "/settings", label: "Settings", title: "Settings" }
+];
+
+function mapTabToPath(tab?: string): string | null {
+  if (!tab) {
+    return null;
+  }
+  const lower = tab.toLowerCase();
+  const item = tabs.find((entry) => entry.label.toLowerCase() === lower || entry.path.replace("/", "") === lower);
+  return item ? item.path : null;
+}
+
+interface AppProps {
+  theme: ThemeMode;
+  onThemeChange: (theme: ThemeMode) => void;
+  initDataUnsafe: InitDataUnsafe | null;
+}
+
+export function App({ theme, onThemeChange, initDataUnsafe }: AppProps): JSX.Element {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const initialisedRef = useRef(false);
+
+  useEffect(() => {
+    if (initialisedRef.current) {
+      return;
+    }
+    initialisedRef.current = true;
+    const start = parseStartParam();
+    const target = mapTabToPath(start.tab);
+    const stored = getUIPreferences().lastTab || "/";
+    const desired = target ?? stored;
+    if (desired !== location.pathname) {
+      navigate(desired, { replace: true });
+    }
+  }, [location.pathname, navigate]);
+
+  useEffect(() => {
+    setLastTabPreference(location.pathname);
+  }, [location.pathname]);
+
+  const activeTab = useMemo(() => tabs.find((tab) => tab.path === location.pathname) ?? tabs[0], [location.pathname]);
+
+  const handleToggleTheme = () => {
+    const nextTheme: ThemeMode = theme === "dark" ? "light" : "dark";
+    setThemePreference(nextTheme);
+    onThemeChange(nextTheme);
+  };
+
+  return (
+    <div className="app-shell">
+      <TopBar title={activeTab.title} theme={theme} onToggleTheme={handleToggleTheme} />
+      <main className="app-content">
+        <AppRoutes
+          settingsProps={{
+            theme,
+            onThemeChange: (nextTheme) => {
+              setThemePreference(nextTheme);
+              onThemeChange(nextTheme);
+            },
+            initDataUnsafe
+          }}
+        />
+      </main>
+      <TabBar
+        items={tabs.map(({ path, label }) => ({ path, label }))}
+        activePath={activeTab.path}
+        onNavigate={(path) => {
+          if (path !== location.pathname) {
+            navigate(path);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/miniapp/src/__tests__/api.test.ts
+++ b/miniapp/src/__tests__/api.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import { authWebApp } from "../lib/api";
+import { clearJwt, getJwt } from "../lib/session";
+
+type FetchMock = Mock<[RequestInfo | URL, RequestInit?], Promise<Response>>;
+
+describe("authWebApp", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    clearJwt();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearJwt();
+  });
+
+  it("stores JWT on successful verification", async () => {
+    const mockFetch = globalThis.fetch as unknown as FetchMock;
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ token: "jwt-token" })
+    } as Response);
+
+    const token = await authWebApp("init-data");
+
+    expect(token).toBe("jwt-token");
+    expect(getJwt()).toBe("jwt-token");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/auth/telegram/verify",
+      expect.objectContaining({
+        method: "POST"
+      })
+    );
+  });
+
+  it("throws on unauthorized response", async () => {
+    const mockFetch = globalThis.fetch as unknown as FetchMock;
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      text: async () => ""
+    } as Response);
+
+    await expect(authWebApp("init-data")).rejects.toThrow("Unauthorized");
+    expect(getJwt()).toBeNull();
+  });
+
+  it("throws on validation error", async () => {
+    const mockFetch = globalThis.fetch as unknown as FetchMock;
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      text: async () => JSON.stringify({ message: "Invalid init data" })
+    } as Response);
+
+    await expect(authWebApp("init-data")).rejects.toThrow("Invalid init data");
+  });
+});

--- a/miniapp/src/__tests__/telegram.test.ts
+++ b/miniapp/src/__tests__/telegram.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getWebApp, parseStartParam } from "../lib/telegram";
+
+declare global {
+  interface Window {
+    Telegram?: any;
+  }
+}
+
+describe("telegram helpers", () => {
+  beforeEach(() => {
+    delete window.Telegram;
+  });
+
+  afterEach(() => {
+    delete window.Telegram;
+  });
+
+  it("returns null when Telegram WebApp is not available", () => {
+    expect(getWebApp()).toBeNull();
+  });
+
+  it("parses start parameter payload", () => {
+    const params = parseStartParam("tab=import&foo=bar");
+    expect(params.tab).toBe("import");
+    expect(params.foo).toBe("bar");
+  });
+
+  it("reads start_param from global WebApp", () => {
+    window.Telegram = {
+      WebApp: {
+        initData: "",
+        initDataUnsafe: {
+          start_param: "tab=trades"
+        }
+      }
+    };
+    const params = parseStartParam();
+    expect(params.tab).toBe("trades");
+  });
+});

--- a/miniapp/src/components/DataTable.tsx
+++ b/miniapp/src/components/DataTable.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+export interface Column<Row> {
+  key: keyof Row | string;
+  label: string;
+  render?: (row: Row) => ReactNode;
+}
+
+interface DataTableProps<Row> {
+  columns: Column<Row>[];
+  rows: Row[];
+  emptyMessage?: string;
+}
+
+export function DataTable<Row>({ columns, rows, emptyMessage }: DataTableProps<Row>): JSX.Element {
+  if (rows.length === 0) {
+    return <div className="data-table__empty">{emptyMessage ?? "No data"}</div>;
+  }
+  return (
+    <table className="data-table">
+      <thead>
+        <tr>
+          {columns.map((column) => (
+            <th key={column.key as string}>{column.label}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <tr key={(row as unknown as { id?: string }).id ?? index}>
+            {columns.map((column) => (
+              <td key={column.key as string}>
+                {column.render ? column.render(row) : String((row as Record<string, unknown>)[column.key as string] ?? "")}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/miniapp/src/components/FileDrop.tsx
+++ b/miniapp/src/components/FileDrop.tsx
@@ -1,0 +1,85 @@
+import { useCallback, useState } from "react";
+import type { ChangeEvent, DragEvent } from "react";
+
+const MAX_SIZE_BYTES = 1024 * 1024; // 1 MiB
+
+interface FileDropProps {
+  onFileSelected: (file: File, preview: string[]) => void;
+  maxPreviewLines?: number;
+}
+
+export function FileDrop({ onFileSelected, maxPreviewLines = 5 }: FileDropProps): JSX.Element {
+  const [error, setError] = useState<string | null>(null);
+  const [filename, setFilename] = useState<string | null>(null);
+  const [previewLines, setPreviewLines] = useState<string[]>([]);
+
+  const processFile = useCallback(
+    (file: File) => {
+      if (file.type && file.type !== "text/csv") {
+        setError("Only CSV files are supported.");
+        return;
+      }
+      if (file.size > MAX_SIZE_BYTES) {
+        setError("File is too large. Limit is 1 MiB.");
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const text = typeof reader.result === "string" ? reader.result : "";
+        const lines = text.split(/\r?\n/).slice(0, maxPreviewLines);
+        setPreviewLines(lines);
+        setError(null);
+        setFilename(file.name);
+        onFileSelected(file, lines);
+      };
+      reader.onerror = () => {
+        setError("Failed to read file.");
+      };
+      reader.readAsText(file);
+    },
+    [onFileSelected, maxPreviewLines]
+  );
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        processFile(file);
+      }
+    },
+    [processFile]
+  );
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const file = event.dataTransfer.files?.[0];
+      if (file) {
+        processFile(file);
+      }
+    },
+    [processFile]
+  );
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  }, []);
+
+  return (
+    <div className="file-drop" onDrop={handleDrop} onDragOver={handleDragOver}>
+      <label className="file-drop__label">
+        <input type="file" accept=".csv,text/csv" onChange={handleInputChange} />
+        <span>{filename ? `Selected: ${filename}` : "Drop CSV here or click to upload"}</span>
+      </label>
+      {error && <div className="file-drop__error">{error}</div>}
+      {previewLines.length > 0 && (
+        <div className="file-drop__preview">
+          <p>Preview:</p>
+          <pre>
+            {previewLines.join("\n")}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/miniapp/src/components/TabBar.tsx
+++ b/miniapp/src/components/TabBar.tsx
@@ -1,0 +1,30 @@
+interface TabItem {
+  path: string;
+  label: string;
+}
+
+interface TabBarProps {
+  items: TabItem[];
+  activePath: string;
+  onNavigate: (path: string) => void;
+}
+
+export function TabBar({ items, activePath, onNavigate }: TabBarProps): JSX.Element {
+  return (
+    <nav className="tab-bar">
+      {items.map((item) => {
+        const isActive = activePath === item.path;
+        return (
+          <button
+            type="button"
+            key={item.path}
+            className={isActive ? "tab-bar__button tab-bar__button--active" : "tab-bar__button"}
+            onClick={() => onNavigate(item.path)}
+          >
+            {item.label}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/miniapp/src/components/TopBar.tsx
+++ b/miniapp/src/components/TopBar.tsx
@@ -1,0 +1,28 @@
+import { expand } from "../lib/telegram";
+import type { ThemeMode } from "../lib/session";
+
+interface TopBarProps {
+  title: string;
+  theme: ThemeMode;
+  onToggleTheme: () => void;
+}
+
+export function TopBar({ title, theme, onToggleTheme }: TopBarProps): JSX.Element {
+  const appName = import.meta.env.VITE_APP_NAME ?? "Mini App";
+  return (
+    <header className="top-bar">
+      <div>
+        <h1>{title || appName}</h1>
+        <span className="top-bar__subtitle">{appName}</span>
+      </div>
+      <div className="top-bar__actions">
+        <button type="button" onClick={() => expand()} className="top-bar__button">
+          Expand
+        </button>
+        <button type="button" onClick={onToggleTheme} className="top-bar__button">
+          {theme === "dark" ? "Light" : "Dark"}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/miniapp/src/lib/api.ts
+++ b/miniapp/src/lib/api.ts
@@ -1,0 +1,191 @@
+import { clearJwt, getJwt, setJwt } from "./session";
+
+const API_BASE = (import.meta.env.VITE_API_BASE ?? "").replace(/\/$/, "");
+const DEFAULT_TIMEOUT = 10000;
+
+export interface Position {
+  instrumentId: string;
+  qty: number;
+  avgPrice: number;
+  lastPrice: number;
+  upl: number;
+}
+
+export interface Trade {
+  id: string;
+  instrumentId: string;
+  qty: number;
+  price: number;
+  side: "buy" | "sell";
+  executedAt: string;
+}
+
+export interface TradesResponse {
+  items: Trade[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface ImportResult {
+  inserted: number;
+  skipped: number;
+  failed: Array<{ row: number; reason: string }>;
+}
+
+export interface ReportSummary {
+  totalValue: number;
+  realizedPnl: number;
+  unrealizedPnl: number;
+}
+
+export interface PortfolioReport {
+  summary: ReportSummary;
+  generatedAt: string;
+}
+
+export interface Quote {
+  instrumentId: string;
+  price: number;
+  changePct: number;
+  updatedAt: string;
+}
+
+function withBase(path: string): string {
+  if (!API_BASE) {
+    return path;
+  }
+  if (path.startsWith("http")) {
+    return path;
+  }
+  return `${API_BASE}${path}`;
+}
+
+function createUrl(path: string): URL {
+  const base = API_BASE || (typeof window !== "undefined" ? window.location.origin : "http://localhost");
+  return new URL(path, base);
+}
+
+async function request<T>(path: string, init: RequestInit = {}, options?: { requireAuth?: boolean; timeoutMs?: number }): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options?.timeoutMs ?? DEFAULT_TIMEOUT);
+  const headers = new Headers(init.headers);
+  if ((options?.requireAuth ?? true) && !headers.has("Authorization")) {
+    const token = getJwt();
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+  }
+  if (!headers.has("Content-Type") && init.body && !(init.body instanceof FormData)) {
+    headers.set("Content-Type", "application/json");
+  }
+  try {
+    const response = await fetch(withBase(path), {
+      ...init,
+      headers,
+      signal: controller.signal
+    });
+    if (response.status === 401) {
+      clearJwt();
+      throw new Error("Unauthorized");
+    }
+    if (!response.ok) {
+      const message = await safeReadError(response);
+      throw new Error(message);
+    }
+    const text = await response.text();
+    if (!text) {
+      return undefined as T;
+    }
+    return JSON.parse(text) as T;
+  } catch (error) {
+    if ((error as Error).name === "AbortError") {
+      throw new Error("Request timed out");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function safeReadError(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    if (!text) {
+      return response.statusText || "Request failed";
+    }
+    try {
+      const data = JSON.parse(text) as { message?: string };
+      return data.message ?? text;
+    } catch (error) {
+      return text;
+    }
+  } catch (error) {
+    return response.statusText || "Request failed";
+  }
+}
+
+export async function authWebApp(initData: string): Promise<string> {
+  if (!initData) {
+    throw new Error("Missing init data");
+  }
+  const tokenResponse = await request<{ token: string }>("/api/auth/telegram/verify", {
+    method: "POST",
+    body: JSON.stringify({ initData })
+  }, { requireAuth: false });
+  if (!tokenResponse.token) {
+    throw new Error("Invalid auth response");
+  }
+  setJwt(tokenResponse.token);
+  return tokenResponse.token;
+}
+
+export async function getPositions(): Promise<Position[]> {
+  return request<Position[]>("/api/positions", { method: "GET" });
+}
+
+export async function getTrades(params: { limit?: number; offset?: number; side?: "buy" | "sell" | "all" } = {}): Promise<TradesResponse> {
+  const url = createUrl("/api/trades");
+  if (params.limit) {
+    url.searchParams.set("limit", params.limit.toString());
+  }
+  if (typeof params.offset === "number") {
+    url.searchParams.set("offset", params.offset.toString());
+  }
+  if (params.side && params.side !== "all") {
+    url.searchParams.set("side", params.side);
+  }
+  return request<TradesResponse>(url.toString(), { method: "GET" });
+}
+
+export async function postImportCsv(file: File): Promise<ImportResult> {
+  const form = new FormData();
+  form.append("file", file);
+  return request<ImportResult>("/api/import/csv", {
+    method: "POST",
+    body: form
+  });
+}
+
+export async function postRevalue(): Promise<{ status: string }> {
+  return request<{ status: string }>("/api/portfolio/revalue", { method: "POST" });
+}
+
+export async function getReport(params: { from?: string; to?: string } = {}): Promise<PortfolioReport> {
+  const url = createUrl("/api/reports/portfolio");
+  if (params.from) {
+    url.searchParams.set("from", params.from);
+  }
+  if (params.to) {
+    url.searchParams.set("to", params.to);
+  }
+  return request<PortfolioReport>(url.toString(), { method: "GET" });
+}
+
+export async function getQuotes(instruments?: string[]): Promise<Quote[]> {
+  const url = createUrl("/api/quotes");
+  if (instruments && instruments.length > 0) {
+    url.searchParams.set("instruments", instruments.join(","));
+  }
+  return request<Quote[]>(url.toString(), { method: "GET" });
+}

--- a/miniapp/src/lib/format.ts
+++ b/miniapp/src/lib/format.ts
@@ -1,0 +1,28 @@
+export function formatMoney(amount: number | string, currency: string = "USD"): string {
+  const value = typeof amount === "string" ? Number(amount) : amount;
+  if (Number.isNaN(value)) {
+    return "-";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }).format(value);
+}
+
+export function formatDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    return isoDate;
+  }
+  return date.toLocaleString();
+}
+
+export function formatPct(value: number | string): string {
+  const numeric = typeof value === "string" ? Number(value) : value;
+  if (Number.isNaN(numeric)) {
+    return "-";
+  }
+  return `${numeric >= 0 ? "+" : ""}${numeric.toFixed(2)}%`;
+}

--- a/miniapp/src/lib/guards.ts
+++ b/miniapp/src/lib/guards.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { authWebApp } from "./api";
+import { clearJwt, getJwt } from "./session";
+
+export type AuthStatus = "pending" | "authorized" | "unauthorized";
+
+export interface AuthState {
+  status: AuthStatus;
+  error?: string;
+}
+
+export function useAuthGuard(initData: string | null, enabled: boolean): AuthState {
+  const [state, setState] = useState<AuthState>(() => {
+    if (getJwt()) {
+      return { status: "authorized" };
+    }
+    return { status: "pending" };
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const token = getJwt();
+    if (token) {
+      setState({ status: "authorized" });
+      return;
+    }
+    if (!enabled) {
+      setState({ status: "pending" });
+      return;
+    }
+    if (!initData) {
+      setState({ status: "unauthorized", error: "Mini App must be opened from Telegram." });
+      return;
+    }
+    setState({ status: "pending" });
+    authWebApp(initData)
+      .then(() => {
+        if (!cancelled) {
+          setState({ status: "authorized" });
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          clearJwt();
+          setState({ status: "unauthorized", error: (error as Error).message });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [initData, enabled]);
+
+  return state;
+}
+
+export function AuthRequired({ error }: { error?: string }): JSX.Element {
+  return (
+    <div className="auth-required">
+      <h1>Authorization required</h1>
+      <p>
+        {error ? error : "This mini app needs to be launched from Telegram to receive a secure session."}
+      </p>
+      <p>Open the bot in Telegram and tap the Mini App button.</p>
+    </div>
+  );
+}

--- a/miniapp/src/lib/session.ts
+++ b/miniapp/src/lib/session.ts
@@ -1,0 +1,102 @@
+export type ThemeMode = "light" | "dark";
+
+export interface UIPreferences {
+  theme: ThemeMode;
+  lastTab: string;
+}
+
+let jwt: string | null = null;
+
+const PREF_STORAGE_KEY = "portfolio-miniapp:prefs";
+const DEFAULT_PREFS: UIPreferences = {
+  theme: "light",
+  lastTab: "/"
+};
+
+let cachedPrefs: UIPreferences = { ...DEFAULT_PREFS };
+
+function readPrefsFromStorage(): UIPreferences {
+  if (typeof window === "undefined") {
+    return cachedPrefs;
+  }
+  try {
+    const raw = window.localStorage.getItem(PREF_STORAGE_KEY);
+    if (!raw) {
+      return cachedPrefs;
+    }
+    const parsed = JSON.parse(raw) as Partial<UIPreferences>;
+    return {
+      theme: parsed.theme === "dark" ? "dark" : "light",
+      lastTab: typeof parsed.lastTab === "string" ? parsed.lastTab : DEFAULT_PREFS.lastTab
+    };
+  } catch (error) {
+    console.warn("Failed to parse UI preferences", error);
+    return cachedPrefs;
+  }
+}
+
+function persistPrefs(next: UIPreferences): void {
+  cachedPrefs = next;
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(PREF_STORAGE_KEY, JSON.stringify(next));
+  } catch (error) {
+    console.warn("Failed to persist UI preferences", error);
+  }
+}
+
+export function loadUIPreferences(): UIPreferences {
+  const prefs = readPrefsFromStorage();
+  cachedPrefs = prefs;
+  return prefs;
+}
+
+export function saveUIPreferences(next: UIPreferences): void {
+  persistPrefs(next);
+}
+
+export function getUIPreferences(): UIPreferences {
+  return cachedPrefs;
+}
+
+export function setThemePreference(theme: ThemeMode): void {
+  const next: UIPreferences = {
+    ...cachedPrefs,
+    theme
+  };
+  persistPrefs(next);
+}
+
+export function setLastTabPreference(path: string): void {
+  const next: UIPreferences = {
+    ...cachedPrefs,
+    lastTab: path
+  };
+  persistPrefs(next);
+}
+
+export function clearUIPreferences(): void {
+  cachedPrefs = { ...DEFAULT_PREFS };
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.removeItem(PREF_STORAGE_KEY);
+  } catch (error) {
+    console.warn("Failed to clear UI preferences", error);
+  }
+}
+
+export function setJwt(value: string): void {
+  jwt = value;
+}
+
+export function getJwt(): string | null {
+  return jwt;
+}
+
+export function clearJwt(): void {
+  jwt = null;
+}

--- a/miniapp/src/lib/telegram.ts
+++ b/miniapp/src/lib/telegram.ts
@@ -1,0 +1,74 @@
+export type Tg = typeof window.Telegram & { WebApp: any };
+
+declare global {
+  interface Window {
+    Telegram?: Tg;
+  }
+}
+
+export interface StartParam {
+  tab?: string;
+  [key: string]: string | undefined;
+}
+
+export type InitDataUnsafe = Record<string, unknown> & {
+  user?: {
+    id?: number;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
+  };
+  start_param?: string;
+  startParam?: string;
+};
+
+export function getWebApp(): Tg["WebApp"] | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.Telegram?.WebApp ?? null;
+}
+
+export function ready(): void {
+  const app = getWebApp();
+  if (app?.ready) {
+    app.ready();
+  }
+}
+
+export function expand(): void {
+  const app = getWebApp();
+  if (app?.expand) {
+    app.expand();
+  }
+}
+
+export function getInitData(): string {
+  return getWebApp()?.initData ?? "";
+}
+
+export function getInitDataUnsafe<T = InitDataUnsafe>(): T | null {
+  return (getWebApp()?.initDataUnsafe as T | undefined) ?? null;
+}
+
+export function getStartParamRaw(): string {
+  const unsafe = getInitDataUnsafe();
+  if (!unsafe) {
+    return "";
+  }
+  const candidate = (unsafe as InitDataUnsafe).start_param ?? (unsafe as InitDataUnsafe).startParam;
+  return typeof candidate === "string" ? candidate : "";
+}
+
+export function parseStartParam(raw?: string): StartParam {
+  const source = raw ?? getStartParamRaw();
+  if (!source) {
+    return {};
+  }
+  const params = new URLSearchParams(source);
+  const result: StartParam = {};
+  params.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}

--- a/miniapp/src/main.tsx
+++ b/miniapp/src/main.tsx
@@ -1,0 +1,66 @@
+import { StrictMode, useEffect, useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { App } from "./App";
+import "./styles.css";
+import { getWebApp, ready, expand, getInitData, getInitDataUnsafe } from "./lib/telegram";
+import type { InitDataUnsafe } from "./lib/telegram";
+import { AuthRequired, useAuthGuard } from "./lib/guards";
+import { loadUIPreferences } from "./lib/session";
+import type { ThemeMode } from "./lib/session";
+
+function Root(): JSX.Element {
+  const [theme, setTheme] = useState<ThemeMode>(() => loadUIPreferences().theme);
+  const [initData, setInitData] = useState<string | null>(null);
+  const [initDataUnsafe, setInitDataUnsafe] = useState<InitDataUnsafe | null>(null);
+  const [initReady, setInitReady] = useState(false);
+
+  useEffect(() => {
+    const webApp = getWebApp();
+    if (webApp) {
+      ready();
+      expand();
+      const data = getInitData();
+      setInitData(data || null);
+      setInitDataUnsafe(getInitDataUnsafe());
+    } else {
+      setInitData(null);
+      setInitDataUnsafe(null);
+    }
+    setInitReady(true);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
+
+  const authState = useAuthGuard(initData, initReady);
+
+  const content = useMemo(() => {
+    if (authState.status === "pending") {
+      return <div className="loading-screen">Authorizing session...</div>;
+    }
+    if (authState.status === "unauthorized") {
+      return <AuthRequired error={authState.error} />;
+    }
+    return (
+      <BrowserRouter>
+        <App theme={theme} onThemeChange={setTheme} initDataUnsafe={initDataUnsafe} />
+      </BrowserRouter>
+    );
+  }, [authState, theme, initDataUnsafe]);
+
+  return content;
+}
+
+const container = document.getElementById("root");
+if (!container) {
+  throw new Error("Root container not found");
+}
+
+const root = createRoot(container);
+root.render(
+  <StrictMode>
+    <Root />
+  </StrictMode>
+);

--- a/miniapp/src/pages/Calendar.tsx
+++ b/miniapp/src/pages/Calendar.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { getQuotes } from "../lib/api";
+import type { Quote } from "../lib/api";
+import { formatDate } from "../lib/format";
+
+export function Calendar(): JSX.Element {
+  const [events, setEvents] = useState<Quote[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getQuotes()
+      .then((data) => {
+        if (!cancelled) {
+          setEvents(data);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="page">
+      <section className="card">
+        <h2>Income calendar</h2>
+        {error && <div className="error">{error}</div>}
+        {events.length === 0 ? (
+          <p>No upcoming events.</p>
+        ) : (
+          <ul className="calendar-list">
+            {events.map((event) => (
+              <li key={event.instrumentId}>
+                <div className="calendar-list__instrument">{event.instrumentId}</div>
+                <div className="calendar-list__date">{formatDate(event.updatedAt)}</div>
+                <div className="calendar-list__note">Next payout estimate</div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/miniapp/src/pages/Dashboard.tsx
+++ b/miniapp/src/pages/Dashboard.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getQuotes, getReport } from "../lib/api";
+import type { PortfolioReport, Quote } from "../lib/api";
+import { formatMoney, formatPct } from "../lib/format";
+
+export function Dashboard(): JSX.Element {
+  const navigate = useNavigate();
+  const [report, setReport] = useState<PortfolioReport | null>(null);
+  const [quotes, setQuotes] = useState<Quote[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getReport()
+      .then((result) => {
+        if (!cancelled) {
+          setReport(result);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      });
+    getQuotes()
+      .then((result) => {
+        if (!cancelled) {
+          setQuotes(result.slice(0, 3));
+        }
+      })
+      .catch(() => {
+        // ignore quote errors to avoid blocking dashboard
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="page">
+      <section className="card">
+        <h2>Portfolio overview</h2>
+        {report ? (
+          <div className="metrics">
+            <div>
+              <span className="metrics__label">Total value</span>
+              <span className="metrics__value">{formatMoney(report.summary.totalValue)}</span>
+            </div>
+            <div>
+              <span className="metrics__label">Realized PnL</span>
+              <span className="metrics__value">{formatMoney(report.summary.realizedPnl)}</span>
+            </div>
+            <div>
+              <span className="metrics__label">Unrealized PnL</span>
+              <span className="metrics__value">{formatMoney(report.summary.unrealizedPnl)}</span>
+            </div>
+          </div>
+        ) : (
+          <p>{error ? error : "Loading summary..."}</p>
+        )}
+        <div className="actions">
+          <button type="button" onClick={() => navigate("/positions")}>View positions</button>
+          <button type="button" onClick={() => navigate("/reports")}>Go to reports</button>
+        </div>
+      </section>
+      <section className="card">
+        <h2>Market snapshot</h2>
+        {quotes.length === 0 ? (
+          <p>No recent quotes available.</p>
+        ) : (
+          <ul className="quote-list">
+            {quotes.map((quote) => (
+              <li key={quote.instrumentId}>
+                <span>{quote.instrumentId}</span>
+                <span>{formatMoney(quote.price)}</span>
+                <span>{formatPct(quote.changePct)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/miniapp/src/pages/Import.tsx
+++ b/miniapp/src/pages/Import.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+import { FileDrop } from "../components/FileDrop";
+import { postImportCsv, postRevalue } from "../lib/api";
+import type { ImportResult } from "../lib/api";
+
+export function Import(): JSX.Element {
+  const [file, setFile] = useState<File | null>(null);
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [revalueMessage, setRevalueMessage] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!file) {
+      setError("Please select a CSV file first.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const response = await postImportCsv(file);
+      setResult(response);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const triggerRevalue = async () => {
+    setRevalueMessage(null);
+    try {
+      const response = await postRevalue();
+      setRevalueMessage(response.status);
+    } catch (err) {
+      setRevalueMessage((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="page">
+      <section className="card">
+        <h2>Import transactions</h2>
+        <form onSubmit={handleSubmit} className="import-form">
+          <FileDrop
+            onFileSelected={(nextFile) => {
+              setFile(nextFile);
+              setResult(null);
+              setError(null);
+            }}
+          />
+          {error && <div className="error">{error}</div>}
+          <button type="submit" disabled={loading}>
+            {loading ? "Uploading..." : "Upload"}
+          </button>
+        </form>
+        {result && (
+          <div className="import-result">
+            <h3>Import result</h3>
+            <ul>
+              <li>Inserted: {result.inserted}</li>
+              <li>Skipped: {result.skipped}</li>
+              <li>
+                Failed rows:
+                {result.failed.length === 0 ? (
+                  <span> none</span>
+                ) : (
+                  <ul>
+                    {result.failed.map((item) => (
+                      <li key={item.row}>
+                        Row {item.row}: {item.reason}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            </ul>
+          </div>
+        )}
+        <div className="import-revalue">
+          <button type="button" onClick={triggerRevalue}>
+            Trigger portfolio revaluation
+          </button>
+          {revalueMessage && <p>{revalueMessage}</p>}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/miniapp/src/pages/Positions.tsx
+++ b/miniapp/src/pages/Positions.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react";
+import { DataTable } from "../components/DataTable";
+import { getPositions } from "../lib/api";
+import type { Position } from "../lib/api";
+import { formatMoney } from "../lib/format";
+
+export function Positions(): JSX.Element {
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    getPositions()
+      .then((data) => {
+        setPositions(data);
+      })
+      .catch((err) => {
+        setError((err as Error).message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div className="page">
+      <section className="card">
+        <div className="card__header">
+          <h2>Positions</h2>
+          <button type="button" onClick={load} disabled={loading}>
+            {loading ? "Refreshing..." : "Refresh"}
+          </button>
+        </div>
+        {error && <div className="error">{error}</div>}
+        <DataTable
+          columns={[
+            { key: "instrumentId", label: "Instrument" },
+            { key: "qty", label: "Quantity" },
+            { key: "avgPrice", label: "Avg. Price", render: (row) => formatMoney(row.avgPrice) },
+            { key: "lastPrice", label: "Last Price", render: (row) => formatMoney(row.lastPrice) },
+            { key: "upl", label: "Unrealized PnL", render: (row) => formatMoney(row.upl) }
+          ]}
+          rows={positions}
+          emptyMessage={loading ? "Loading positions..." : "No positions"}
+        />
+      </section>
+    </div>
+  );
+}

--- a/miniapp/src/pages/Reports.tsx
+++ b/miniapp/src/pages/Reports.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+import { getReport } from "../lib/api";
+import type { PortfolioReport } from "../lib/api";
+import { formatDate, formatMoney } from "../lib/format";
+
+export function Reports(): JSX.Element {
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [report, setReport] = useState<PortfolioReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getReport({ from: from || undefined, to: to || undefined });
+      setReport(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="page">
+      <section className="card">
+        <h2>Reports</h2>
+        <form className="report-form" onSubmit={handleSubmit}>
+          <label>
+            From
+            <input type="date" value={from} onChange={(event) => setFrom(event.target.value)} />
+          </label>
+          <label>
+            To
+            <input type="date" value={to} onChange={(event) => setTo(event.target.value)} />
+          </label>
+          <button type="submit" disabled={loading}>
+            {loading ? "Loading..." : "Generate"}
+          </button>
+        </form>
+        {error && <div className="error">{error}</div>}
+        {report && (
+          <div className="report-summary">
+            <h3>Summary</h3>
+            <p>Generated at: {formatDate(report.generatedAt)}</p>
+            <ul>
+              <li>Total value: {formatMoney(report.summary.totalValue)}</li>
+              <li>Realized PnL: {formatMoney(report.summary.realizedPnl)}</li>
+              <li>Unrealized PnL: {formatMoney(report.summary.unrealizedPnl)}</li>
+            </ul>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/miniapp/src/pages/Settings.tsx
+++ b/miniapp/src/pages/Settings.tsx
@@ -1,0 +1,52 @@
+import type { InitDataUnsafe } from "../lib/telegram";
+import type { ThemeMode } from "../lib/session";
+import { clearJwt, clearUIPreferences, setThemePreference } from "../lib/session";
+
+interface SettingsProps {
+  theme: ThemeMode;
+  onThemeChange: (theme: ThemeMode) => void;
+  initDataUnsafe: InitDataUnsafe | null;
+}
+
+export function Settings({ theme, onThemeChange, initDataUnsafe }: SettingsProps): JSX.Element {
+  const username = initDataUnsafe?.user?.username ?? "Unknown";
+
+  const handleThemeChange = (nextTheme: ThemeMode) => {
+    setThemePreference(nextTheme);
+    onThemeChange(nextTheme);
+  };
+
+  const handleClearSession = () => {
+    clearJwt();
+    clearUIPreferences();
+    window.location.reload();
+  };
+
+  return (
+    <div className="page">
+      <section className="card">
+        <h2>Settings</h2>
+        <div className="settings-item">
+          <label htmlFor="theme-select">Theme</label>
+          <select
+            id="theme-select"
+            value={theme}
+            onChange={(event) => handleThemeChange(event.target.value as ThemeMode)}
+          >
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </div>
+        <div className="settings-item">
+          <button type="button" onClick={handleClearSession}>
+            Clear session
+          </button>
+        </div>
+        <div className="settings-item">
+          <span>Telegram user</span>
+          <strong>{username}</strong>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/miniapp/src/pages/Trades.tsx
+++ b/miniapp/src/pages/Trades.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from "react";
+import { DataTable } from "../components/DataTable";
+import { getTrades } from "../lib/api";
+import type { Trade, TradesResponse } from "../lib/api";
+import { formatDate, formatMoney } from "../lib/format";
+
+const PAGE_SIZE = 20;
+
+type TradeSide = "buy" | "sell" | "all";
+
+export function Trades(): JSX.Element {
+  const [state, setState] = useState<TradesResponse | null>(null);
+  const [side, setSide] = useState<TradeSide>("all");
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    getTrades({ limit: PAGE_SIZE, offset: page * PAGE_SIZE, side })
+      .then((data) => {
+        setState(data);
+      })
+      .catch((err) => {
+        setError((err as Error).message);
+      })
+      .finally(() => setLoading(false));
+  }, [page, side]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const totalPages = state ? Math.ceil(state.total / state.limit) : 0;
+
+  return (
+    <div className="page">
+      <section className="card">
+        <div className="card__header">
+          <h2>Trades</h2>
+          <div className="filters">
+            <label>
+              Side:
+              <select
+                value={side}
+                onChange={(event) => {
+                  setPage(0);
+                  setSide(event.target.value as TradeSide);
+                }}
+              >
+                <option value="all">All</option>
+                <option value="buy">Buy</option>
+                <option value="sell">Sell</option>
+              </select>
+            </label>
+          </div>
+        </div>
+        {error && <div className="error">{error}</div>}
+        <DataTable<Trade>
+          columns={[
+            { key: "instrumentId", label: "Instrument" },
+            { key: "side", label: "Side" },
+            { key: "qty", label: "Quantity" },
+            { key: "price", label: "Price", render: (row) => formatMoney(row.price) },
+            { key: "executedAt", label: "Executed", render: (row) => formatDate(row.executedAt) }
+          ]}
+          rows={state?.items ?? []}
+          emptyMessage={loading ? "Loading trades..." : "No trades"}
+        />
+        <div className="pagination">
+          <button type="button" disabled={page === 0 || loading} onClick={() => setPage((p) => Math.max(0, p - 1))}>
+            Previous
+          </button>
+          <span>
+            Page {totalPages === 0 ? 0 : page + 1} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={loading || totalPages === 0 || page + 1 >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/miniapp/src/router.tsx
+++ b/miniapp/src/router.tsx
@@ -1,0 +1,34 @@
+import { Routes, Route } from "react-router-dom";
+import { Dashboard } from "./pages/Dashboard";
+import { Positions } from "./pages/Positions";
+import { Trades } from "./pages/Trades";
+import { Import } from "./pages/Import";
+import { Calendar } from "./pages/Calendar";
+import { Reports } from "./pages/Reports";
+import { Settings } from "./pages/Settings";
+import type { ThemeMode } from "./lib/session";
+import type { InitDataUnsafe } from "./lib/telegram";
+
+interface SettingsProps {
+  theme: ThemeMode;
+  onThemeChange: (theme: ThemeMode) => void;
+  initDataUnsafe: InitDataUnsafe | null;
+}
+
+interface AppRoutesProps {
+  settingsProps: SettingsProps;
+}
+
+export function AppRoutes({ settingsProps }: AppRoutesProps): JSX.Element {
+  return (
+    <Routes>
+      <Route path="/" element={<Dashboard />} />
+      <Route path="/positions" element={<Positions />} />
+      <Route path="/trades" element={<Trades />} />
+      <Route path="/import" element={<Import />} />
+      <Route path="/calendar" element={<Calendar />} />
+      <Route path="/reports" element={<Reports />} />
+      <Route path="/settings" element={<Settings {...settingsProps} />} />
+    </Routes>
+  );
+}

--- a/miniapp/src/styles.css
+++ b/miniapp/src/styles.css
@@ -1,0 +1,308 @@
+:root {
+  color-scheme: light dark;
+  --bg-color: #f8f9fa;
+  --card-bg: #ffffff;
+  --text-color: #1d1f23;
+  --accent-color: #2f80ed;
+  --border-color: #dbe0e8;
+}
+
+:root[data-theme="dark"] {
+  --bg-color: #101418;
+  --card-bg: #1a1f24;
+  --text-color: #f2f5f9;
+  --accent-color: #64b5f6;
+  --border-color: #2b343d;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+button,
+select,
+input {
+  font-family: inherit;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: var(--card-bg);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.top-bar h1 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.top-bar__subtitle {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--accent-color);
+}
+
+.top-bar__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.top-bar__button {
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+}
+
+.top-bar__button:hover {
+  opacity: 0.9;
+}
+
+.app-content {
+  flex: 1;
+  padding: 1rem;
+}
+
+.tab-bar {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.25rem;
+  padding: 0.5rem;
+  background: var(--card-bg);
+  border-top: 1px solid var(--border-color);
+}
+
+.tab-bar__button {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.5rem;
+  cursor: pointer;
+  color: var(--text-color);
+}
+
+.tab-bar__button--active {
+  border-color: var(--accent-color);
+  background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.metrics__label {
+  font-size: 0.8rem;
+  color: var(--accent-color);
+}
+
+.metrics__value {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.actions button,
+.report-form button,
+.import-form button,
+.import-revalue button {
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.quote-list,
+.calendar-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.quote-list li,
+.calendar-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+
+.calendar-list__instrument {
+  font-weight: 600;
+}
+
+.calendar-list__note {
+  font-size: 0.75rem;
+  color: var(--accent-color);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--border-color);
+  text-align: left;
+}
+
+.data-table__empty {
+  padding: 1rem;
+  text-align: center;
+}
+
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1rem;
+}
+
+.pagination button {
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.3rem 0.8rem;
+  cursor: pointer;
+}
+
+.error {
+  margin: 0.5rem 0;
+  color: #d32f2f;
+}
+
+.file-drop {
+  border: 2px dashed var(--border-color);
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+  background: color-mix(in srgb, var(--accent-color) 10%, transparent);
+}
+
+.file-drop__label {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+
+.file-drop__label input {
+  display: none;
+}
+
+.file-drop__error {
+  color: #d32f2f;
+  margin-top: 0.5rem;
+}
+
+.file-drop__preview {
+  margin-top: 0.75rem;
+  text-align: left;
+}
+
+.file-drop__preview pre {
+  background: rgba(0, 0, 0, 0.05);
+  padding: 0.5rem;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.import-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.import-revalue {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.settings-item {
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.report-form {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.report-summary ul {
+  padding-left: 1.2rem;
+}
+
+.auth-required {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.loading-screen {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.1rem;
+}

--- a/miniapp/src/types/telegram-web-app.d.ts
+++ b/miniapp/src/types/telegram-web-app.d.ts
@@ -1,0 +1,48 @@
+interface TelegramWebAppThemeParams {
+  bg_color?: string;
+  text_color?: string;
+  hint_color?: string;
+  link_color?: string;
+  button_color?: string;
+  button_text_color?: string;
+}
+
+interface TelegramBackButton {
+  isVisible: boolean;
+  onClick(callback: () => void): void;
+  show(): void;
+  hide(): void;
+}
+
+interface TelegramMainButton {
+  text: string;
+  isVisible: boolean;
+  setText(text: string): TelegramMainButton;
+  onClick(callback: () => void): void;
+  show(): void;
+  hide(): void;
+}
+
+interface TelegramWebApp {
+  initData: string;
+  initDataUnsafe: unknown;
+  themeParams: TelegramWebAppThemeParams;
+  colorScheme: "light" | "dark";
+  ready(): void;
+  expand(): void;
+  close(): void;
+  MainButton: TelegramMainButton;
+  BackButton: TelegramBackButton;
+}
+
+interface Telegram {
+  WebApp: TelegramWebApp;
+}
+
+declare global {
+  interface Window {
+    Telegram?: Telegram;
+  }
+}
+
+export {};

--- a/miniapp/tsconfig.json
+++ b/miniapp/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/miniapp/tsconfig.node.json
+++ b/miniapp/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/miniapp/vite.config.ts
+++ b/miniapp/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, loadEnv } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173
+    },
+    preview: {
+      port: 5173
+    },
+    define: {
+      "import.meta.env.VITE_API_BASE": JSON.stringify(env.VITE_API_BASE),
+      "import.meta.env.VITE_APP_NAME": JSON.stringify(env.VITE_APP_NAME)
+    }
+  };
+});

--- a/miniapp/vitest.config.ts
+++ b/miniapp/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: [],
+    globals: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript mini app with Telegram Web App bootstrapping
- implement dashboard, positions, trades, import, calendar, reports, and settings pages with tab navigation and theming
- add API client with JWT handshake, Telegram helpers, reusable UI components, and vitest coverage for auth and start param parsing

## Testing
- not run (pnpm not available in CI)

------
https://chatgpt.com/codex/tasks/task_e_68d5553728608321ac1d86842eb06c59