### PR TITLE
Add alerts settings overrides support

### DIFF
--- a/app/src/main/kotlin/routes/AlertsSettingsRoutes.kt
+++ b/app/src/main/kotlin/routes/AlertsSettingsRoutes.kt
@@ -1,0 +1,181 @@
+package routes
+
+import app.Services
+import alerts.settings.AlertsConfig
+import alerts.settings.AlertsOverridePatch
+import alerts.settings.AlertsSettingsService
+import alerts.settings.AlertsSettingsServiceImpl
+import alerts.settings.Budget
+import alerts.settings.DynamicScale
+import alerts.settings.Hysteresis
+import alerts.settings.MatrixV11
+import alerts.settings.Percent
+import alerts.settings.QuietHours
+import alerts.settings.Thresholds
+import alerts.settings.validate
+import billing.model.Tier
+import billing.service.BillingService
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import io.ktor.util.AttributeKey
+import kotlinx.coroutines.CoroutineScope
+import repo.AlertsSettingsRepositoryImpl
+import security.requireTierAtLeast
+import security.userIdOrNull
+
+private const val ALERTS_CONFIG_PATH = "alerts"
+
+fun Route.alertsSettingsRoutes() {
+    route("/api/alerts/settings") {
+        get {
+            val deps = call.alertsSettingsDependencies()
+            val subject = call.userIdOrNull?.toLongOrNull()
+            if (subject == null) {
+                call.respondUnauthorized()
+                return@get
+            }
+            val result = runCatching { deps.settingsService.effectiveFor(subject) }
+                .onFailure { throwable ->
+                    call.application.environment.log.error("alerts.settings.fetch_failed", throwable)
+                }
+                .getOrElse { throwable ->
+                    call.handleDomainError(throwable)
+                    return@get
+                }
+            call.respond(result)
+        }
+
+        put {
+            call.handleOverrideUpdate(isPatch = false)
+        }
+
+        patch {
+            call.handleOverrideUpdate(isPatch = true)
+        }
+    }
+}
+
+private suspend fun ApplicationCall.handleOverrideUpdate(isPatch: Boolean) {
+    val deps = alertsSettingsDependencies()
+    val subject = userIdOrNull?.toLongOrNull()
+    if (subject == null) {
+        respondUnauthorized()
+        return
+    }
+
+    val patch = try {
+        receive<AlertsOverridePatch>()
+    } catch (exception: Throwable) {
+        application.environment.log.warn("alerts.settings.invalid_payload", exception)
+        respondBadRequest(listOf("Invalid JSON payload"))
+        return
+    }
+
+    val validationErrors = patch.validate()
+    if (validationErrors.isNotEmpty()) {
+        respondBadRequest(validationErrors)
+        return
+    }
+
+    if (!requireTierAtLeast(Tier.PRO, deps.billingService)) {
+        return
+    }
+
+    val updateSucceeded = runCatching { deps.settingsService.upsert(subject, patch) }
+        .onFailure { throwable ->
+            application.environment.log.error("alerts.settings.update_failed", throwable)
+        }
+        .isSuccess
+
+    if (!updateSucceeded) {
+        return
+    }
+
+    if (!isPatch) {
+        application.environment.log.info("alerts.settings.override_replaced", mapOf("userId" to subject))
+    }
+    respond(HttpStatusCode.NoContent)
+}
+
+internal data class AlertsSettingsRouteDeps(
+    val billingService: BillingService,
+    val settingsService: AlertsSettingsService
+)
+
+internal val AlertsSettingsDepsKey = AttributeKey<AlertsSettingsRouteDeps>("AlertsSettingsDeps")
+
+private fun ApplicationCall.alertsSettingsDependencies(): AlertsSettingsRouteDeps {
+    val attributes = application.attributes
+    if (attributes.contains(AlertsSettingsDepsKey)) {
+        return attributes[AlertsSettingsDepsKey]
+    }
+    val deps = application.buildDefaultAlertsSettingsDeps()
+    attributes.put(AlertsSettingsDepsKey, deps)
+    return deps
+}
+
+private fun Application.buildDefaultAlertsSettingsDeps(): AlertsSettingsRouteDeps {
+    val services = attributes[Services.Key]
+    val defaults = loadAlertsDefaults()
+    val repository = AlertsSettingsRepositoryImpl()
+    val service = AlertsSettingsServiceImpl(defaults, repository, this as CoroutineScope)
+    return AlertsSettingsRouteDeps(services.billingService, service)
+}
+
+private fun Application.loadAlertsDefaults(): AlertsConfig {
+    val rootConfig = ConfigFactory.load()
+    val alertsCfg = rootConfig.getConfig(ALERTS_CONFIG_PATH)
+    val quietCfg = alertsCfg.getConfig("quiet")
+    val budgetCfg = alertsCfg.getConfig("budget")
+    val hysteresisCfg = alertsCfg.getConfig("hysteresis")
+    val dynamicCfg = alertsCfg.getConfig("dynamic")
+    val matrixCfg = alertsCfg.getConfig("matrix")
+
+    val perClassCfg = matrixCfg.getConfig("perClass")
+    val perClass = perClassCfg.root().entries.associate { entry ->
+        val key = entry.key
+        val cfg = perClassCfg.getConfig(key)
+        key to cfg.toThresholds()
+    }
+
+    return AlertsConfig(
+        quiet = QuietHours(
+            start = quietCfg.getString("start"),
+            end = quietCfg.getString("end")
+        ),
+        budget = Budget(maxPushesPerDay = budgetCfg.getInt("maxPushesPerDay")),
+        hysteresis = Hysteresis(
+            enterPct = Percent(hysteresisCfg.getDouble("enterPct")),
+            exitPct = Percent(hysteresisCfg.getDouble("exitPct"))
+        ),
+        cooldownMinutes = alertsCfg.getInt("cooldownMinutes"),
+        dynamic = DynamicScale(
+            enabled = dynamicCfg.getBoolean("enabled"),
+            min = dynamicCfg.getDouble("min"),
+            max = dynamicCfg.getDouble("max")
+        ),
+        matrix = MatrixV11(
+            portfolioDayPct = Percent(matrixCfg.getDouble("portfolioDayPct")),
+            portfolioDrawdown = Percent(matrixCfg.getDouble("portfolioDrawdown")),
+            perClass = perClass
+        )
+    )
+}
+
+private fun Config.toThresholds(): Thresholds {
+    val pctFast = Percent(getDouble("pctFast"))
+    val pctDay = Percent(getDouble("pctDay"))
+    val volMult = if (hasPath("volMultFast")) getDouble("volMultFast") else null
+    return Thresholds(pctFast = pctFast, pctDay = pctDay, volMultFast = volMult)
+}

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -72,3 +72,37 @@ upload {
   csvMaxBytes = 1048576
   allowedCsvContentTypes = ["text/csv","application/octet-stream","application/vnd.ms-excel"]
 }
+
+alerts {
+  quiet {
+    start = "23:00"
+    end   = "07:00"
+  }
+  budget {
+    maxPushesPerDay = 6
+  }
+  hysteresis {
+    enterPct = 2.0
+    exitPct  = 1.5
+  }
+  cooldownMinutes = 60
+  dynamic {
+    enabled = false
+    min = 0.7
+    max = 1.3
+  }
+  matrix {
+    portfolioDayPct   = 2.0
+    portfolioDrawdown = 5.0
+    perClass = {
+      MOEX_BLUE     = { pctFast = 2.0, pctDay = 4.0, volMultFast = 1.8 }
+      MOEX_SECOND   = { pctFast = 3.0, pctDay = 6.0, volMultFast = 2.2 }
+      OFZ           = { pctFast = 0.3, pctDay = 0.6 }
+      INDEX         = { pctFast = 0.7, pctDay = 1.5 }
+      FX            = { pctFast = 1.0, pctDay = 2.0 }
+      CRYPTO_MAJOR  = { pctFast = 2.0, pctDay = 4.0, volMultFast = 2.0 }
+      CRYPTO_MID    = { pctFast = 4.0, pctDay = 8.0, volMultFast = 2.5 }
+      STABLECOIN    = { pctFast = 0.5, pctDay = 0.8 }
+    }
+  }
+}

--- a/app/src/test/kotlin/routes/AlertsSettingsRoutesTest.kt
+++ b/app/src/test/kotlin/routes/AlertsSettingsRoutesTest.kt
@@ -1,0 +1,193 @@
+package routes
+
+import alerts.settings.AlertsConfig
+import alerts.settings.AlertsOverridePatch
+import alerts.settings.AlertsSettingsService
+import alerts.settings.AlertsSettingsServiceImpl
+import alerts.settings.Budget
+import alerts.settings.DynamicScale
+import alerts.settings.Hysteresis
+import alerts.settings.MatrixV11
+import alerts.settings.Percent
+import alerts.settings.QuietHours
+import alerts.settings.Thresholds
+import app.Services
+import billing.model.BillingPlan
+import billing.model.SubStatus
+import billing.model.Tier
+import billing.model.UserSubscription
+import billing.service.BillingService
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.patch
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.auth.authenticate
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import repo.AlertsSettingsRepository
+import security.JwtConfig
+import security.JwtSupport
+import security.installSecurity
+import java.time.Instant
+
+class AlertsSettingsRoutesTest {
+    private val jwtConfig = JwtConfig(
+        issuer = "newsbot",
+        audience = "newsbot-clients",
+        realm = "newsbot-api",
+        secret = "test-secret",
+        accessTtlMinutes = 60
+    )
+
+    @Test
+    fun `GET without JWT returns 401`() = testRoute { service, _ ->
+        val response = client.get("/api/alerts/settings")
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `PATCH without Pro plan returns 403`() = testRoute(billingTier = Tier.FREE) { _, config ->
+        val token = JwtSupport.issueToken(config, subject = "123")
+        val response = client.patch("/api/alerts/settings") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            setBody("""{"cooldownMinutes":60}""")
+        }
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    @Test
+    fun `PATCH with invalid payload returns 400`() = testRoute { _, config ->
+        val token = JwtSupport.issueToken(config, subject = "321")
+        val response = client.patch("/api/alerts/settings") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            setBody("""{"budgetPerDay":0,"hysteresis":{"enterPct":1.0,"exitPct":1.2}}""")
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("budgetPerDay"))
+    }
+
+    @Test
+    fun `GET returns merged effective config`() = testRoute { service, config ->
+        runBlocking { service.upsert(555L, AlertsOverridePatch(cooldownMinutes = 45)) }
+        val token = JwtSupport.issueToken(config, subject = "555")
+        val response = client.get("/api/alerts/settings") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val payload = Json.decodeFromString(AlertsConfig.serializer(), response.bodyAsText())
+        assertEquals(45, payload.cooldownMinutes)
+        assertEquals(defaultConfig().budget.maxPushesPerDay, payload.budget.maxPushesPerDay)
+    }
+
+    @Test
+    fun `PATCH updates overrides immediately`() = testRoute { service, config ->
+        val token = JwtSupport.issueToken(config, subject = "777")
+        val response = client.patch("/api/alerts/settings") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            setBody("""{"quietHours":{"start":"01:15"}}""")
+        }
+        assertEquals(HttpStatusCode.NoContent, response.status)
+        val effective = runBlocking { service.effectiveFor(777L) }
+        assertEquals("01:15", effective.quiet.start)
+    }
+
+    private fun testRoute(
+        billingTier: Tier = Tier.PRO,
+        block: suspend ApplicationTestBuilder.(AlertsSettingsService, JwtConfig) -> Unit
+    ) {
+        testApplication {
+            environment {
+                config = MapApplicationConfig().apply {
+                    put("security.jwtSecret", jwtConfig.secret)
+                    put("security.issuer", jwtConfig.issuer)
+                    put("security.audience", jwtConfig.audience)
+                    put("security.realm", jwtConfig.realm)
+                    put("security.accessTtlMinutes", jwtConfig.accessTtlMinutes.toString())
+                }
+            }
+
+            val repository = InMemoryAlertsRepository()
+            val service = AlertsSettingsServiceImpl(defaultConfig(), repository, CoroutineScope(Dispatchers.Unconfined))
+            val billingService = FakeBillingService(billingTier)
+
+            application {
+                installSecurity()
+                attributes.put(Services.Key, Services(billingService))
+                attributes.put(AlertsSettingsDepsKey, AlertsSettingsRouteDeps(billingService, service))
+                routing {
+                    authenticate("auth-jwt") {
+                        alertsSettingsRoutes()
+                    }
+                }
+            }
+
+            block(this, service, jwtConfig)
+        }
+    }
+
+    private class InMemoryAlertsRepository : AlertsSettingsRepository {
+        private val store = mutableMapOf<Long, String>()
+
+        override suspend fun upsert(userId: Long, json: String) {
+            store[userId] = json
+        }
+
+        override suspend fun find(userId: Long): String? = store[userId]
+    }
+
+    private class FakeBillingService(private val tier: Tier) : BillingService {
+        override suspend fun listPlans(): Result<List<BillingPlan>> = Result.success(emptyList())
+        override suspend fun createInvoiceFor(userId: Long, tier: Tier): Result<String> =
+            Result.failure(UnsupportedOperationException("not supported"))
+        override suspend fun applySuccessfulPayment(
+            userId: Long,
+            tier: Tier,
+            amountXtr: Long,
+            providerPaymentId: String?,
+            payload: String?
+        ): Result<Unit> = Result.failure(UnsupportedOperationException("not supported"))
+
+        override suspend fun getMySubscription(userId: Long): Result<UserSubscription?> = Result.success(
+            UserSubscription(
+                userId = userId,
+                tier = tier,
+                status = SubStatus.ACTIVE,
+                startedAt = Instant.EPOCH,
+                expiresAt = Instant.EPOCH
+            )
+        )
+    }
+
+    private fun defaultConfig(): AlertsConfig = AlertsConfig(
+        quiet = QuietHours(start = "23:00", end = "07:00"),
+        budget = Budget(maxPushesPerDay = 6),
+        hysteresis = Hysteresis(enterPct = Percent(2.0), exitPct = Percent(1.5)),
+        cooldownMinutes = 60,
+        dynamic = DynamicScale(enabled = false, min = 0.7, max = 1.3),
+        matrix = MatrixV11(
+            portfolioDayPct = Percent(2.0),
+            portfolioDrawdown = Percent(5.0),
+            perClass = mapOf(
+                "MOEX_BLUE" to Thresholds(Percent(2.0), Percent(4.0), volMultFast = 1.8)
+            )
+        )
+    )
+}

--- a/core/src/main/kotlin/alerts/settings/AlertsSettingsModels.kt
+++ b/core/src/main/kotlin/alerts/settings/AlertsSettingsModels.kt
@@ -1,0 +1,259 @@
+package alerts.settings
+
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import kotlinx.serialization.Serializable
+
+@JvmInline
+@Serializable
+value class Percent(val value: Double) {
+    init {
+        require(value.isFinite()) { "Percent value must be finite" }
+    }
+}
+
+@Serializable
+data class QuietHours(
+    val start: String,
+    val end: String
+)
+
+@Serializable
+data class Budget(
+    val maxPushesPerDay: Int
+)
+
+@Serializable
+data class Hysteresis(
+    val enterPct: Percent,
+    val exitPct: Percent
+)
+
+@Serializable
+data class Thresholds(
+    val pctFast: Percent,
+    val pctDay: Percent,
+    val volMultFast: Double? = null
+)
+
+@Serializable
+data class MatrixV11(
+    val portfolioDayPct: Percent,
+    val portfolioDrawdown: Percent,
+    val perClass: Map<String, Thresholds>
+)
+
+@Serializable
+data class DynamicScale(
+    val enabled: Boolean,
+    val min: Double,
+    val max: Double
+)
+
+@Serializable
+data class AlertsConfig(
+    val quiet: QuietHours,
+    val budget: Budget,
+    val hysteresis: Hysteresis,
+    val cooldownMinutes: Int,
+    val dynamic: DynamicScale,
+    val matrix: MatrixV11
+)
+
+@Serializable
+data class QuietHoursPatch(
+    val start: String? = null,
+    val end: String? = null
+)
+
+@Serializable
+data class HysteresisPatch(
+    val enterPct: Double? = null,
+    val exitPct: Double? = null
+)
+
+@Serializable
+data class DynamicPatch(
+    val enabled: Boolean? = null,
+    val min: Double? = null,
+    val max: Double? = null
+)
+
+@Serializable
+data class ThresholdsPatch(
+    val pctFast: Double? = null,
+    val pctDay: Double? = null,
+    val volMultFast: Double? = null
+)
+
+@Serializable
+data class AlertsOverridePatch(
+    val cooldownMinutes: Int? = null,
+    val budgetPerDay: Int? = null,
+    val quietHours: QuietHoursPatch? = null,
+    val hysteresis: HysteresisPatch? = null,
+    val dynamic: DynamicPatch? = null,
+    val thresholds: Map<String, ThresholdsPatch>? = null
+)
+
+fun AlertsConfig.merge(patch: AlertsOverridePatch): AlertsConfig {
+    val mergedQuiet = patch.quietHours?.let { overrides ->
+        QuietHours(
+            start = overrides.start ?: quiet.start,
+            end = overrides.end ?: quiet.end
+        )
+    } ?: quiet
+
+    val mergedBudget = patch.budgetPerDay?.let { value ->
+        Budget(maxPushesPerDay = value)
+    } ?: budget
+
+    val mergedHysteresis = patch.hysteresis?.let { overrides ->
+        Hysteresis(
+            enterPct = overrides.enterPct?.let(::Percent) ?: hysteresis.enterPct,
+            exitPct = overrides.exitPct?.let(::Percent) ?: hysteresis.exitPct
+        )
+    } ?: hysteresis
+
+    val mergedDynamic = patch.dynamic?.let { overrides ->
+        DynamicScale(
+            enabled = overrides.enabled ?: dynamic.enabled,
+            min = overrides.min ?: dynamic.min,
+            max = overrides.max ?: dynamic.max
+        )
+    } ?: dynamic
+
+    val mergedThresholds = mergeThresholds(matrix.perClass, patch.thresholds)
+
+    val mergedCooldown = patch.cooldownMinutes ?: cooldownMinutes
+
+    return AlertsConfig(
+        quiet = mergedQuiet,
+        budget = mergedBudget,
+        hysteresis = mergedHysteresis,
+        cooldownMinutes = mergedCooldown,
+        dynamic = mergedDynamic,
+        matrix = MatrixV11(
+            portfolioDayPct = matrix.portfolioDayPct,
+            portfolioDrawdown = matrix.portfolioDrawdown,
+            perClass = mergedThresholds
+        )
+    )
+}
+
+fun AlertsOverridePatch.validate(): List<String> {
+    val errors = mutableListOf<String>()
+    cooldownMinutes?.let { value ->
+        if (value < 5 || value > 720) {
+            errors += "cooldownMinutes must be between 5 and 720"
+        }
+    }
+    budgetPerDay?.let { value ->
+        if (value < 1 || value > 100) {
+            errors += "budgetPerDay must be between 1 and 100"
+        }
+    }
+
+    quietHours?.let { patch ->
+        patch.start?.let { start ->
+            if (!start.isValidTime()) {
+                errors += "quietHours.start must be in HH:mm format"
+            }
+        }
+        patch.end?.let { end ->
+            if (!end.isValidTime()) {
+                errors += "quietHours.end must be in HH:mm format"
+            }
+        }
+    }
+
+    hysteresis?.let { patch ->
+        val enter = patch.enterPct
+        val exit = patch.exitPct
+        if (enter != null && enter <= 0.0) {
+            errors += "hysteresis.enterPct must be positive"
+        }
+        if (exit != null && exit <= 0.0) {
+            errors += "hysteresis.exitPct must be positive"
+        }
+        if (enter != null && exit != null && enter <= exit) {
+            errors += "hysteresis.enterPct must be greater than hysteresis.exitPct"
+        }
+    }
+
+    dynamic?.let { patch ->
+        val min = patch.min
+        val max = patch.max
+        if (min != null && (min < 0.5 || min > 2.0)) {
+            errors += "dynamic.min must be between 0.5 and 2.0"
+        }
+        if (max != null && (max < 0.5 || max > 2.0)) {
+            errors += "dynamic.max must be between 0.5 and 2.0"
+        }
+        if (min != null && max != null && min > max) {
+            errors += "dynamic.min must be less than or equal to dynamic.max"
+        }
+        if (min != null && min > 1.0) {
+            errors += "dynamic.min must not exceed 1.0"
+        }
+        if (max != null && max < 1.0) {
+            errors += "dynamic.max must be at least 1.0"
+        }
+    }
+
+    thresholds?.forEach { (key, patch) ->
+        patch.pctFast?.let { value ->
+            if (value <= 0.0) {
+                errors += "thresholds[$key].pctFast must be positive"
+            }
+        }
+        patch.pctDay?.let { value ->
+            if (value <= 0.0) {
+                errors += "thresholds[$key].pctDay must be positive"
+            }
+        }
+        patch.volMultFast?.let { value ->
+            if (value <= 0.0) {
+                errors += "thresholds[$key].volMultFast must be positive"
+            }
+        }
+    }
+
+    return errors
+}
+
+private fun mergeThresholds(
+    defaults: Map<String, Thresholds>,
+    overrides: Map<String, ThresholdsPatch>?
+): Map<String, Thresholds> {
+    if (overrides.isNullOrEmpty()) {
+        return defaults
+    }
+    val result = defaults.toMutableMap()
+    overrides.forEach { (key, patch) ->
+        val base = result[key]
+        val pctFast = patch.pctFast?.let(::Percent) ?: base?.pctFast
+        val pctDay = patch.pctDay?.let(::Percent) ?: base?.pctDay
+        val volMult = patch.volMultFast ?: base?.volMultFast
+        if (pctFast != null && pctDay != null) {
+            result[key] = Thresholds(
+                pctFast = pctFast,
+                pctDay = pctDay,
+                volMultFast = volMult
+            )
+        }
+    }
+    return result
+}
+
+private fun String.isValidTime(): Boolean {
+    return try {
+        LocalTime.parse(this, TIME_FORMATTER)
+        true
+    } catch (_: DateTimeParseException) {
+        false
+    }
+}
+
+private val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")

--- a/core/src/main/kotlin/alerts/settings/AlertsSettingsService.kt
+++ b/core/src/main/kotlin/alerts/settings/AlertsSettingsService.kt
@@ -1,0 +1,197 @@
+package alerts.settings
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+interface AlertsSettingsRepository {
+    suspend fun upsert(userId: Long, json: String)
+    suspend fun find(userId: Long): String?
+}
+
+interface AlertsSettingsService {
+    val updatesFlow: StateFlow<Long>
+    suspend fun defaults(): AlertsConfig
+    suspend fun effectiveFor(userId: Long): AlertsConfig
+    suspend fun upsert(userId: Long, patch: AlertsOverridePatch)
+}
+
+class AlertsSettingsServiceImpl(
+    private val defaults: AlertsConfig,
+    private val repository: AlertsSettingsRepository,
+    scope: CoroutineScope,
+    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = false }
+) : AlertsSettingsService {
+    @Suppress("unused")
+    private val applicationScope: CoroutineScope = scope
+
+    private val cache = ConcurrentHashMap<Long, AlertsOverridePatch>()
+    private val _updatesFlow = MutableStateFlow(0L)
+
+    override val updatesFlow: StateFlow<Long> = _updatesFlow.asStateFlow()
+
+    override suspend fun defaults(): AlertsConfig = defaults
+
+    override suspend fun effectiveFor(userId: Long): AlertsConfig {
+        val patch = loadPatch(userId)
+        return patch?.let { defaults.merge(it) } ?: defaults
+    }
+
+    override suspend fun upsert(userId: Long, patch: AlertsOverridePatch) {
+        val current = loadPatch(userId)
+        val merged = mergePatches(current, patch).normalized()
+        val serialized = json.encodeToString(merged)
+        repository.upsert(userId, serialized)
+        if (merged.isEmpty()) {
+            cache.remove(userId)
+        } else {
+            cache[userId] = merged
+        }
+        _updatesFlow.update { value -> value + 1 }
+    }
+
+    private suspend fun loadPatch(userId: Long): AlertsOverridePatch? {
+        cache[userId]?.let { return it }
+        val stored = repository.find(userId) ?: return null
+        val decoded = try {
+            json.decodeFromString<AlertsOverridePatch>(stored)
+        } catch (exception: SerializationException) {
+            throw IllegalStateException("Failed to decode alerts override for user $userId", exception)
+        }
+        val normalized = decoded.normalized()
+        if (!normalized.isEmpty()) {
+            cache[userId] = normalized
+        }
+        return normalized
+    }
+
+    private fun mergePatches(
+        existing: AlertsOverridePatch?,
+        incoming: AlertsOverridePatch
+    ): AlertsOverridePatch {
+        if (existing == null) {
+            return incoming
+        }
+        return AlertsOverridePatch(
+            cooldownMinutes = incoming.cooldownMinutes ?: existing.cooldownMinutes,
+            budgetPerDay = incoming.budgetPerDay ?: existing.budgetPerDay,
+            quietHours = mergeQuiet(existing.quietHours, incoming.quietHours),
+            hysteresis = mergeHysteresis(existing.hysteresis, incoming.hysteresis),
+            dynamic = mergeDynamic(existing.dynamic, incoming.dynamic),
+            thresholds = mergeThresholds(existing.thresholds, incoming.thresholds)
+        )
+    }
+
+    private fun mergeQuiet(
+        base: QuietHoursPatch?,
+        incoming: QuietHoursPatch?
+    ): QuietHoursPatch? {
+        if (base == null && incoming == null) {
+            return null
+        }
+        val start = incoming?.start ?: base?.start
+        val end = incoming?.end ?: base?.end
+        return if (start == null && end == null) null else QuietHoursPatch(start, end)
+    }
+
+    private fun mergeHysteresis(
+        base: HysteresisPatch?,
+        incoming: HysteresisPatch?
+    ): HysteresisPatch? {
+        if (base == null && incoming == null) {
+            return null
+        }
+        val enter = incoming?.enterPct ?: base?.enterPct
+        val exit = incoming?.exitPct ?: base?.exitPct
+        return if (enter == null && exit == null) null else HysteresisPatch(enterPct = enter, exitPct = exit)
+    }
+
+    private fun mergeDynamic(
+        base: DynamicPatch?,
+        incoming: DynamicPatch?
+    ): DynamicPatch? {
+        if (base == null && incoming == null) {
+            return null
+        }
+        val enabled = incoming?.enabled ?: base?.enabled
+        val min = incoming?.min ?: base?.min
+        val max = incoming?.max ?: base?.max
+        return if (enabled == null && min == null && max == null) {
+            null
+        } else {
+            DynamicPatch(enabled = enabled, min = min, max = max)
+        }
+    }
+
+    private fun mergeThresholds(
+        base: Map<String, ThresholdsPatch>?,
+        incoming: Map<String, ThresholdsPatch>?
+    ): Map<String, ThresholdsPatch>? {
+        if ((base == null || base.isEmpty()) && (incoming == null || incoming.isEmpty())) {
+            return null
+        }
+        val result = mutableMapOf<String, ThresholdsPatch>()
+        base?.forEach { (key, patch) ->
+            result[key] = patch
+        }
+        incoming?.forEach { (key, patch) ->
+            val existing = result[key]
+            val merged = ThresholdsPatch(
+                pctFast = patch.pctFast ?: existing?.pctFast,
+                pctDay = patch.pctDay ?: existing?.pctDay,
+                volMultFast = patch.volMultFast ?: existing?.volMultFast
+            )
+            if (merged.pctFast == null && merged.pctDay == null && merged.volMultFast == null) {
+                result.remove(key)
+            } else {
+                result[key] = merged
+            }
+        }
+        return if (result.isEmpty()) null else result.toMap()
+    }
+
+    private fun AlertsOverridePatch.normalized(): AlertsOverridePatch {
+        val quiet = quietHours?.takeIf { it.start != null || it.end != null }
+        val hyst = hysteresis?.takeIf { it.enterPct != null || it.exitPct != null }
+        val dyn = dynamic?.takeIf { it.enabled != null || it.min != null || it.max != null }
+        val thresholdsNormalized = thresholds
+            ?.mapNotNull { (key, patch) ->
+                val normalized = ThresholdsPatch(
+                    pctFast = patch.pctFast,
+                    pctDay = patch.pctDay,
+                    volMultFast = patch.volMultFast
+                )
+                if (normalized.pctFast == null && normalized.pctDay == null && normalized.volMultFast == null) {
+                    null
+                } else {
+                    key to normalized
+                }
+            }
+            ?.toMap()
+
+        return AlertsOverridePatch(
+            cooldownMinutes = cooldownMinutes,
+            budgetPerDay = budgetPerDay,
+            quietHours = quiet,
+            hysteresis = hyst,
+            dynamic = dyn,
+            thresholds = thresholdsNormalized
+        )
+    }
+
+    private fun AlertsOverridePatch.isEmpty(): Boolean {
+        return cooldownMinutes == null &&
+            budgetPerDay == null &&
+            quietHours == null &&
+            hysteresis == null &&
+            dynamic == null &&
+            thresholds.isNullOrEmpty()
+    }
+}

--- a/core/src/test/kotlin/alerts/settings/AlertsSettingsServiceTest.kt
+++ b/core/src/test/kotlin/alerts/settings/AlertsSettingsServiceTest.kt
@@ -1,0 +1,102 @@
+package alerts.settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class AlertsSettingsServiceTest {
+    private val defaults = AlertsConfig(
+        quiet = QuietHours(start = "22:00", end = "07:00"),
+        budget = Budget(maxPushesPerDay = 6),
+        hysteresis = Hysteresis(enterPct = Percent(2.0), exitPct = Percent(1.5)),
+        cooldownMinutes = 60,
+        dynamic = DynamicScale(enabled = false, min = 0.7, max = 1.3),
+        matrix = MatrixV11(
+            portfolioDayPct = Percent(2.0),
+            portfolioDrawdown = Percent(5.0),
+            perClass = mapOf(
+                "MOEX_BLUE" to Thresholds(Percent(2.0), Percent(4.0), volMultFast = 1.8),
+                "MOEX_SECOND" to Thresholds(Percent(3.0), Percent(6.0), volMultFast = 2.2)
+            )
+        )
+    )
+
+    @Test
+    fun `merge applies overrides to config`() {
+        val patch = AlertsOverridePatch(
+            cooldownMinutes = 120,
+            budgetPerDay = 8,
+            quietHours = QuietHoursPatch(start = "23:30"),
+            hysteresis = HysteresisPatch(exitPct = 1.2),
+            dynamic = DynamicPatch(enabled = true, min = 0.8),
+            thresholds = mapOf(
+                "MOEX_BLUE" to ThresholdsPatch(pctFast = 2.5),
+                "MOEX_SECOND" to ThresholdsPatch(volMultFast = 3.0)
+            )
+        )
+
+        val merged = defaults.merge(patch)
+
+        assertEquals(120, merged.cooldownMinutes)
+        assertEquals(8, merged.budget.maxPushesPerDay)
+        assertEquals("23:30", merged.quiet.start)
+        assertEquals(1.2, merged.hysteresis.exitPct.value)
+        assertTrue(merged.dynamic.enabled)
+        assertEquals(0.8, merged.dynamic.min)
+        assertEquals(2.5, merged.matrix.perClass.getValue("MOEX_BLUE").pctFast.value)
+        assertEquals(3.0, merged.matrix.perClass.getValue("MOEX_SECOND").volMultFast)
+    }
+
+    @Test
+    fun `validate detects invalid values`() {
+        val patch = AlertsOverridePatch(
+            cooldownMinutes = 4,
+            budgetPerDay = 0,
+            quietHours = QuietHoursPatch(start = "25:61"),
+            hysteresis = HysteresisPatch(enterPct = 1.0, exitPct = 1.2),
+            dynamic = DynamicPatch(min = 1.5, max = 0.8),
+            thresholds = mapOf("MOEX_BLUE" to ThresholdsPatch(pctFast = -1.0, pctDay = 0.0, volMultFast = -0.5))
+        )
+
+        val errors = patch.validate()
+
+        assertTrue(errors.any { it.contains("cooldownMinutes") })
+        assertTrue(errors.any { it.contains("budgetPerDay") })
+        assertTrue(errors.any { it.contains("quietHours.start") })
+        assertTrue(errors.any { it.contains("enterPct") })
+        assertTrue(errors.any { it.contains("dynamic.min") })
+        assertTrue(errors.any { it.contains("dynamic.max") })
+        assertTrue(errors.any { it.contains("thresholds[MOEX_BLUE].pctFast") })
+    }
+
+    @Test
+    fun `updatesFlow increments and effective config reflects overrides`() = runTest {
+        val repository = InMemoryAlertsRepository()
+        val service = AlertsSettingsServiceImpl(defaults, repository, this)
+        val userId = 42L
+
+        assertEquals(0L, service.updatesFlow.value)
+
+        service.upsert(userId, AlertsOverridePatch(cooldownMinutes = 90))
+        assertEquals(1L, service.updatesFlow.value)
+        assertEquals(90, service.effectiveFor(userId).cooldownMinutes)
+
+        service.upsert(userId, AlertsOverridePatch(quietHours = QuietHoursPatch(start = "01:00")))
+        assertEquals(2L, service.updatesFlow.value)
+        val effective = service.effectiveFor(userId)
+        assertEquals("01:00", effective.quiet.start)
+        assertEquals(90, effective.cooldownMinutes)
+        assertTrue(repository.store.containsKey(userId))
+    }
+
+    private class InMemoryAlertsRepository : AlertsSettingsRepository {
+        val store = mutableMapOf<Long, String>()
+
+        override suspend fun upsert(userId: Long, json: String) {
+            store[userId] = json
+        }
+
+        override suspend fun find(userId: Long): String? = store[userId]
+    }
+}

--- a/storage/src/main/kotlin/repo/AlertsSettingsRepository.kt
+++ b/storage/src/main/kotlin/repo/AlertsSettingsRepository.kt
@@ -1,0 +1,52 @@
+package repo
+
+import alerts.settings.AlertsSettingsRepository as CoreAlertsSettingsRepository
+import db.DatabaseFactory.dbQuery
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+
+interface AlertsSettingsRepository : CoreAlertsSettingsRepository
+
+class AlertsSettingsRepositoryImpl(
+    private val json: Json = Json { ignoreUnknownKeys = true }
+) : AlertsSettingsRepository {
+    override suspend fun upsert(userId: Long, json: String) {
+        val element = parsePayload(json)
+        val now = Instant.now().atOffset(ZoneOffset.UTC)
+        dbQuery {
+            val updated = UserAlertOverridesTable.update({ UserAlertOverridesTable.userId eq userId }) {
+                it[UserAlertOverridesTable.payload] = element
+                it[UserAlertOverridesTable.updatedAt] = now
+            }
+            if (updated == 0) {
+                UserAlertOverridesTable.insert {
+                    it[UserAlertOverridesTable.userId] = userId
+                    it[UserAlertOverridesTable.payload] = element
+                    it[UserAlertOverridesTable.updatedAt] = now
+                }
+            }
+        }
+    }
+
+    override suspend fun find(userId: Long): String? = dbQuery {
+        UserAlertOverridesTable
+            .select { UserAlertOverridesTable.userId eq userId }
+            .firstOrNull()
+            ?.get(UserAlertOverridesTable.payload)
+            ?.let { payload -> json.encodeToString(JsonElement.serializer(), payload) }
+    }
+
+    private fun parsePayload(raw: String): JsonElement {
+        val element = json.parseToJsonElement(raw)
+        require(element is JsonObject) { "payload must be a JSON object" }
+        return element
+    }
+}

--- a/storage/src/main/kotlin/repo/AlertsSettingsTables.kt
+++ b/storage/src/main/kotlin/repo/AlertsSettingsTables.kt
@@ -1,0 +1,15 @@
+package repo
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+import org.jetbrains.exposed.sql.json.jsonb
+
+object UserAlertOverridesTable : Table("user_alert_overrides") {
+    val userId = long("user_id")
+    val payload = jsonb("payload", Json, JsonElement.serializer())
+    val updatedAt = timestampWithTimeZone("updated_at")
+
+    override val primaryKey = PrimaryKey(userId)
+}

--- a/storage/src/main/resources/db/migration/V3__alerts_overrides.sql
+++ b/storage/src/main/resources/db/migration/V3__alerts_overrides.sql
@@ -1,0 +1,7 @@
+-- Хранилище персональных оверрайдов настроек алертов (по tg_user_id)
+CREATE TABLE user_alert_overrides (
+  user_id     BIGINT PRIMARY KEY,
+  payload     JSONB NOT NULL,                  -- частичный объект (patch), валидируется приложением
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_user_alert_overrides_updated ON user_alert_overrides (updated_at DESC);


### PR DESCRIPTION
## Summary
- add default alerts configuration and core models/service for merging user overrides
- persist per-user alerts override payloads via Flyway migration and Exposed repository
- expose /api/alerts/settings endpoints with validation, plan guard, and comprehensive tests

## Testing
- ./gradlew :core:compileKotlin :core:test :app:compileKotlin :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d73871fe548321930911b8261f44a7