### PR TITLE
Configure Kotlin linting and detekt quality tooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,26 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 4
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+indent_style = space
+indent_size = 4
+max_line_length = 120
 trim_trailing_whitespace = true
+
+[*.kt]
+ij_kotlin_packages_to_use_import_on_demand = _
+ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^ 
+ktlint_standard_filename = enabled
+ktlint_standard_final-newline = enabled
+ktlint_standard_no-wildcard-imports = enabled
+ktlint_standard_max-line-length = enabled
+ktlint_function_naming_ignore_when_annotated = true
+
+[*.kts]
+max_line_length = 120
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["**"]
   pull_request:
 
 jobs:
@@ -14,18 +14,21 @@ jobs:
         with:
           lfs: true
 
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
-          cache: gradle
-
       - name: Fail on merge conflict markers
         run: |
-          if git grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- . ; then
-            echo "Merge conflict markers found. Please resolve conflicts." && exit 1
+          if git grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- . ':!**/.github/**' ; then
+            echo "Merge conflict markers found. Please resolve."; exit 1;
           fi
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Lint (ktlint + detekt)
+        run: ./gradlew --no-daemon --stacktrace ktlintCheck detekt
 
       - name: Build
         uses: gradle/gradle-build-action@v3
@@ -38,12 +41,13 @@ jobs:
       - name: App tests
         run: ./gradlew :app:test --console=plain
 
-      - name: Upload test reports
+      - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: quality-reports
           path: |
-            **/build/test-results/**/*.xml
+            **/build/reports/ktlint/**/*
+            **/build/reports/detekt/**/*
             **/build/reports/tests/**/*
           if-no-files-found: ignore

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,14 @@
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ktor) apply false
+    alias(libs.plugins.ktlint.gradle) apply false
+    alias(libs.plugins.detekt.gradle) apply false
 }
 
 subprojects {
@@ -9,10 +16,14 @@ subprojects {
         mavenCentral()
     }
 
-    apply(plugin = "org.jetbrains.kotlin.jvm")
-    apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+    if (!plugins.hasPlugin("org.jetbrains.kotlin.jvm")) {
+        apply(plugin = "org.jetbrains.kotlin.jvm")
+    }
+    if (!plugins.hasPlugin("org.jetbrains.kotlin.plugin.serialization")) {
+        apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+    }
 
-    extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension> {
+    extensions.configure(KotlinJvmProjectExtension::class.java) {
         jvmToolchain(21)
     }
 
@@ -20,21 +31,84 @@ subprojects {
         "testImplementation"(kotlin("test"))
     }
 
-    tasks.withType<org.gradle.api.tasks.testing.Test> {
+    tasks.withType(org.gradle.api.tasks.testing.Test::class.java).configureEach {
         useJUnitPlatform()
+    }
+
+    afterEvaluate {
+        val hasKotlin = plugins.hasPlugin("org.jetbrains.kotlin.jvm") ||
+            plugins.hasPlugin("org.jetbrains.kotlin.android") ||
+            plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
+        if (hasKotlin) {
+            apply(plugin = "org.jlleitschuh.gradle.ktlint")
+            apply(plugin = "io.gitlab.arturbosch.detekt")
+
+            dependencies.add(
+                "detektPlugins",
+                "io.gitlab.arturbosch.detekt:detekt-formatting:${libs.versions.detekt.get()}"
+            )
+
+            extensions.configure(KtlintExtension::class.java) {
+                android.set(false)
+                ignoreFailures.set(false)
+                reporters {
+                    reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN)
+                    reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
+                }
+                filter {
+                    exclude("**/build/**")
+                    exclude("**/generated/**")
+                }
+            }
+
+            extensions.configure(DetektExtension::class.java) {
+                buildUponDefaultConfig = true
+                allRules = false
+                autoCorrect = false
+                config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
+                source.setFrom(files(projectDir))
+                parallel = true
+                basePath = rootDir.path
+                reports {
+                    xml.required.set(true)
+                    html.required.set(true)
+                    txt.required.set(false)
+                    sarif.required.set(false)
+                    md.required.set(false)
+                }
+            }
+
+            tasks.register("lint") {
+                group = "verification"
+                description = "Run ktlintCheck and detekt"
+                dependsOn("ktlintCheck", "detekt")
+            }
+            tasks.register("format") {
+                group = "formatting"
+                description = "Run ktlintFormat"
+                dependsOn("ktlintFormat")
+            }
+
+            tasks.withType(org.gradle.api.tasks.testing.Test::class.java).configureEach {
+                testLogging {
+                    events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+                }
+            }
+        }
     }
 }
 
+// Hook installer: переустановит pre-commit
 tasks.register("installGitHooks") {
-    description = "Install pre-commit hook to block merge conflict markers."
     group = "git"
+    description = "Install pre-commit hook for lint/conflict markers"
     doLast {
-        val hookSrc = file("tools/git-hooks/pre-commit")
-        val hookDst = file(".git/hooks/pre-commit")
-        if (!hookSrc.exists()) error("Missing tools/git-hooks/pre-commit")
-        hookDst.parentFile.mkdirs()
-        hookSrc.copyTo(hookDst, overwrite = true)
-        hookDst.setExecutable(true)
+        val src = file("tools/git-hooks/pre-commit")
+        val dst = file(".git/hooks/pre-commit")
+        if (!src.exists()) error("Missing tools/git-hooks/pre-commit")
+        dst.parentFile.mkdirs()
+        src.copyTo(dst, overwrite = true)
+        dst.setExecutable(true)
         println("Installed .git/hooks/pre-commit")
     }
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,111 @@
+build:
+  maxIssues: 0
+  excludes: ""
+
+config:
+  validation: true
+
+processors:
+  active: true
+
+console-reports:
+  active: true
+  exclude:
+    - 'ProjectStatisticsReport'
+    - 'ComplexityReport'
+
+comments:
+  active: true
+  AbsentOrWrongFileLicense:
+    active: false
+
+style:
+  MagicNumber:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/generated/**']
+    ignoreNumbers: ['-1','0','1','2','2.0','1.5','5.0','22','50','60','0.7','1.3','7']
+  WildcardImport:
+    active: true
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+  ReturnCount:
+    active: false
+  UnusedPrivateMember:
+    active: true
+  ForbiddenComment:
+    active: true
+    comments:
+      - reason: 'Forbidden TODO marker in production code.'
+        value: 'TODO:'
+      - reason: 'Forbidden FIXME marker in production code.'
+        value: 'FIXME:'
+      - reason: 'Forbidden HACK marker in production code.'
+        value: 'HACK:'
+    allowedPatterns: ''
+  ForbiddenMethodCall:
+    active: true
+    methods:
+      - reason: 'print does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.print'
+      - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.println'
+
+formatting:
+  active: true
+  android: false
+  FinalNewline:
+    active: true
+  NoWildcardImports:
+    active: true
+  ImportOrdering:
+    active: false
+  Indentation:
+    active: true
+    indentSize: 4
+  MaximumLineLength:
+    active: true
+    maxLineLength: 120
+
+naming:
+  active: true
+  FunctionNaming:
+    active: true
+    ignoreAnnotated: ['Composable']
+  TopLevelPropertyNaming:
+    active: true
+
+performance:
+  active: true
+  ForEachOnRange:
+    active: true
+
+potential-bugs:
+  active: true
+  UnsafeCallOnNullableType:
+    active: true
+  LateinitUsage:
+    active: true
+    excludes: ['**/test/**']
+
+exceptions:
+  active: true
+  PrintStackTrace:
+    active: true
+  TooGenericExceptionCaught:
+    active: false
+  SwallowedException:
+    active: false
+
+complexity:
+  active: true
+  LongParameterList:
+    active: true
+    constructorThreshold: 9
+    functionThreshold: 8
+    ignoreDefaultParameters: true
+
+empty-blocks:
+  active: true
+  EmptyFunctionBlock:
+    active: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ kotest = "5.9.1"
 junit = "5.11.3"
 testcontainers = "1.20.2"
 logback = "1.5.12"
+ktlintGradle = "12.1.0"
+detekt = "1.23.6"
 
 
 [libraries]
@@ -61,3 +63,5 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
+ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }
+detekt-gradle = { id = "io.gitlab.arturbosch.detekt",   version.ref = "detekt" }

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Найти конфликтные маркеры в индексированных файлах
-FILES=$(git diff --cached --name-only)
-if [ -z "$FILES" ]; then
-  exit 0
-fi
-
+# 1) Блокируем конфликтные маркеры
 if git diff --cached --name-only \
  | xargs -I{} sh -c "grep -Hn -E '^(<<<<<<<|=======|>>>>>>>)' '{}' || true" \
  | grep -E '^(<<<<<<<|=======|>>>>>>>)' >/dev/null 2>&1; then
-  echo "ERROR: merge conflict markers detected. Resolve conflicts before commit."
+  echo "ERROR: merge conflict markers detected. Resolve before commit."
   exit 1
+fi
+
+# 2) Быстрый линт перед коммитом
+if [ -x "./gradlew" ]; then
+  ./gradlew -q ktlintCheck detekt || {
+    echo "ERROR: ktlint/detekt violations. Fix or run: ./gradlew format"
+    exit 1
+  }
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- add ktlint and detekt plugins via version catalog and root build logic with aggregated lint/format tasks
- define repository-wide editorconfig, detekt ruleset, and a pre-commit hook that blocks conflict markers and runs ktlint/detekt
- extend CI to run linting before the build and upload quality reports artifacts

## Testing
- ./gradlew clean build detekt ktlintCheck --console=plain *(fails: existing detekt issues in legacy modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d744990e0483218f0d9920d830aa14