### PR TITLE
Add Stars bot commands and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,13 @@ curl -s -X POST "$BASE/telegram/webhook" \
 PowerShell: замените export на $env:NAME="value".
 ```
 
+## P16 — Bot: Stars/Subscriptions
+
+- Команды бота: `/plans` (активные тарифы и цены в XTR), `/buy` (inline-кнопки PRO/PRO+/VIP), `/status` (текущая подписка).
+- UX: выберите план через `/buy`, получите `invoiceLink`, оплатите в Stars, webhook успешного платежа активирует/продлевает подписку, `/status` отражает актуальный уровень.
+- Безопасность: логи без токенов, сумм и PII; повторные доставки `update_id` от Telegram не создают дубликаты ответов (in-memory idempotency).
+- Smoke: используйте webhook-имитацию из P06-05 для успешного платежа и команду `/status` в чате бота для проверки активации.
+
 ## P10 — CSV/Sheets import
 
 ### Smoke-curl

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.java.time)
+    implementation(libs.pengrad.bot)
     testImplementation(libs.kotlin.test)
     testImplementation(kotlin("test-junit5"))
     testImplementation(libs.ktor.server.test.host)

--- a/app/src/main/kotlin/billing/bot/StarsBotCommands.kt
+++ b/app/src/main/kotlin/billing/bot/StarsBotCommands.kt
@@ -1,0 +1,186 @@
+package billing.bot
+
+import billing.model.BillingPlan
+import billing.model.Tier
+import billing.model.UserSubscription
+import billing.service.BillingService
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.Update
+import com.pengrad.telegrambot.model.request.InlineKeyboardButton
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+import com.pengrad.telegrambot.model.request.ParseMode
+import com.pengrad.telegrambot.request.AnswerCallbackQuery
+import com.pengrad.telegrambot.request.SendMessage
+import java.time.Instant
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+
+object StarsBotCommands {
+    private val logger = LoggerFactory.getLogger(StarsBotCommands::class.java)
+
+    private object UpdateGuard {
+        private const val TTL_MS: Long = 5 * 60 * 1000
+        private val processed = ConcurrentHashMap<Int, Long>()
+
+        fun tryAcquire(update: Update): Boolean {
+            val updateId = update.updateId()
+            val now = System.currentTimeMillis()
+            cleanup(now)
+            val existing = processed.putIfAbsent(updateId, now)
+            if (existing == null) {
+                return true
+            }
+            if (now - existing > TTL_MS) {
+                processed[updateId] = now
+                return true
+            }
+            logger.debug("duplicate_update id={}", updateId)
+            return false
+        }
+
+        private fun cleanup(now: Long) {
+            processed.entries.removeIf { now - it.value > TTL_MS }
+        }
+    }
+
+    suspend fun handlePlans(update: Update, bot: TelegramBot, svc: BillingService) {
+        if (!UpdateGuard.tryAcquire(update)) {
+            return
+        }
+        val message = update.message() ?: return
+        val chatId = message.chat()?.id() ?: return
+        val response = withContext(Dispatchers.IO) { svc.listPlans() }
+        val text = response.fold(
+            onSuccess = { plans -> formatPlans(plans) },
+            onFailure = { _ -> "Try later" }
+        )
+        bot.execute(
+            SendMessage(chatId, text)
+                .parseMode(ParseMode.Markdown)
+                .disableWebPagePreview(true)
+        )
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    suspend fun handleBuy(update: Update, bot: TelegramBot, svc: BillingService) {
+        if (!UpdateGuard.tryAcquire(update)) {
+            return
+        }
+        val message = update.message() ?: return
+        val chatId = message.chat()?.id() ?: return
+        val keyboard = InlineKeyboardMarkup(
+            arrayOf(
+                InlineKeyboardButton("Buy PRO").callbackData("buy:PRO"),
+                InlineKeyboardButton("Buy PRO+").callbackData("buy:PRO_PLUS"),
+                InlineKeyboardButton("Buy VIP").callbackData("buy:VIP")
+            )
+        )
+        bot.execute(
+            SendMessage(chatId, "Choose your plan:")
+                .replyMarkup(keyboard)
+        )
+    }
+
+    suspend fun handleStatus(update: Update, bot: TelegramBot, svc: BillingService) {
+        if (!UpdateGuard.tryAcquire(update)) {
+            return
+        }
+        val message = update.message() ?: return
+        val chatId = message.chat()?.id() ?: return
+        val userId = message.from()?.id() ?: return
+        val result = withContext(Dispatchers.IO) { svc.getMySubscription(userId) }
+        val text = result.fold(
+            onSuccess = { subscription -> formatStatus(subscription) },
+            onFailure = { _ -> "Try later" }
+        )
+        bot.execute(
+            SendMessage(chatId, text)
+                .parseMode(ParseMode.Markdown)
+                .disableWebPagePreview(true)
+        )
+    }
+
+    suspend fun handleCallback(update: Update, bot: TelegramBot, svc: BillingService) {
+        val callback = update.callbackQuery() ?: return
+        val queryId = callback.id()
+        val chatId = callback.message()?.chat()?.id()
+        val userId = callback.from()?.id()
+        val data = callback.data() ?: return
+        if (!data.startsWith("buy:", ignoreCase = true)) {
+            bot.execute(AnswerCallbackQuery(queryId))
+            return
+        }
+        if (!UpdateGuard.tryAcquire(update)) {
+            bot.execute(AnswerCallbackQuery(queryId))
+            return
+        }
+        val tier = parseTier(data.substringAfter(':'))
+        if (tier == null || chatId == null || userId == null) {
+            bot.execute(AnswerCallbackQuery(queryId))
+            return
+        }
+        val invoice = withContext(Dispatchers.IO) { svc.createInvoiceFor(userId, tier) }
+        if (invoice.isSuccess) {
+            bot.execute(
+                SendMessage(chatId, "Pay via Stars: ${invoice.getOrNull()}")
+            )
+            bot.execute(
+                AnswerCallbackQuery(queryId).text("Invoice sent")
+            )
+            return
+        }
+        val error = invoice.exceptionOrNull()
+        val message = when (error) {
+            is NoSuchElementException, is IllegalArgumentException -> "Plan not found"
+            else -> "Try later"
+        }
+        bot.execute(SendMessage(chatId, message))
+        bot.execute(AnswerCallbackQuery(queryId))
+    }
+
+    private fun formatPlans(plans: List<BillingPlan>): String {
+        val active = plans.filter { it.isActive }
+        if (active.isEmpty()) {
+            return "*Available plans*\nNo active plans"
+        }
+        val header = "*Available plans*"
+        val lines = active.map { plan ->
+            val tierLabel = humanTier(plan.tier)
+            "• *$tierLabel* — ${plan.title} — ${plan.priceXtr.value} XTR"
+        }
+        return buildString {
+            appendLine(header)
+            lines.forEachIndexed { index, line ->
+                if (index == lines.lastIndex) {
+                    append(line)
+                } else {
+                    appendLine(line)
+                }
+            }
+        }
+    }
+
+    private fun formatStatus(subscription: UserSubscription?): String {
+        if (subscription == null) {
+            return "*Tier:* FREE\n*Status:* EXPIRED\n*Expires:* —"
+        }
+        val expires = subscription.expiresAt?.let(Instant::toString) ?: "—"
+        val tier = humanTier(subscription.tier)
+        return "*Tier:* $tier\n*Status:* ${subscription.status.name}\n*Expires:* $expires"
+    }
+
+    private fun humanTier(tier: Tier): String = when (tier) {
+        Tier.FREE -> "FREE"
+        Tier.PRO -> "PRO"
+        Tier.PRO_PLUS -> "PRO+"
+        Tier.VIP -> "VIP"
+    }
+
+    private fun parseTier(raw: String): Tier? {
+        val normalized = raw.trim().uppercase(Locale.ROOT)
+        return runCatching { Tier.valueOf(normalized) }.getOrNull()
+    }
+}

--- a/app/src/main/kotlin/billing/bot/StarsBotRouter.kt
+++ b/app/src/main/kotlin/billing/bot/StarsBotRouter.kt
@@ -1,0 +1,35 @@
+package billing.bot
+
+import com.pengrad.telegrambot.model.Update
+import java.util.Locale
+
+object StarsBotRouter {
+    sealed class BotRoute {
+        data object Plans : BotRoute()
+        data object Buy : BotRoute()
+        data object Status : BotRoute()
+        data object Callback : BotRoute()
+        data object Unknown : BotRoute()
+    }
+
+    fun route(update: Update): BotRoute {
+        val callbackData = update.callbackQuery()?.data()
+        if (callbackData != null && callbackData.startsWith("buy:", ignoreCase = true)) {
+            return BotRoute.Callback
+        }
+
+        val message = update.message() ?: return BotRoute.Unknown
+        val rawText = message.text() ?: return BotRoute.Unknown
+        val command = rawText.trim().takeWhile { !it.isWhitespace() }
+        if (command.isEmpty()) {
+            return BotRoute.Unknown
+        }
+        val normalized = command.substringBefore('@').lowercase(Locale.ROOT)
+        return when (normalized) {
+            "/plans" -> BotRoute.Plans
+            "/buy" -> BotRoute.Buy
+            "/status" -> BotRoute.Status
+            else -> BotRoute.Unknown
+        }
+    }
+}

--- a/app/src/main/kotlin/di/TelegramBotModule.kt
+++ b/app/src/main/kotlin/di/TelegramBotModule.kt
@@ -1,0 +1,27 @@
+package di
+
+import com.pengrad.telegrambot.TelegramBot
+import io.ktor.server.application.Application
+import io.ktor.util.AttributeKey
+import org.slf4j.LoggerFactory
+
+private val TelegramBotKey: AttributeKey<TelegramBot> = AttributeKey("TelegramBot")
+
+private val logger = LoggerFactory.getLogger("TelegramBotModule")
+
+fun Application.ensureTelegramBot(): TelegramBot {
+    if (attributes.contains(TelegramBotKey)) {
+        return attributes[TelegramBotKey]
+    }
+
+    val token = environment.config.propertyOrNull("telegram.botToken")?.getString()?.trim()
+        ?: throw IllegalStateException("telegram.botToken is not configured")
+    require(token.isNotEmpty()) { "telegram.botToken must not be blank" }
+
+    val bot = TelegramBot(token)
+    attributes.put(TelegramBotKey, bot)
+    logger.info("telegram-bot initialized")
+    return bot
+}
+
+fun Application.telegramBot(): TelegramBot = ensureTelegramBot()

--- a/app/src/test/kotlin/billing/bot/StarsBotCommandsTest.kt
+++ b/app/src/test/kotlin/billing/bot/StarsBotCommandsTest.kt
@@ -1,0 +1,238 @@
+package billing.bot
+
+import billing.model.BillingPlan
+import billing.model.SubStatus
+import billing.model.Tier
+import billing.model.UserSubscription
+import billing.model.Xtr
+import billing.service.BillingService
+import com.pengrad.telegrambot.BotUtils
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.Update
+import com.pengrad.telegrambot.model.request.InlineKeyboardButton
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+import com.pengrad.telegrambot.request.AnswerCallbackQuery
+import com.pengrad.telegrambot.request.BaseRequest
+import com.pengrad.telegrambot.request.SendMessage
+import com.pengrad.telegrambot.response.BaseResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+class StarsBotCommandsTest {
+
+    @Test
+    fun `plans command renders markdown list`() = runBlocking {
+        val service = FakeBillingService().apply {
+            plansResult = Result.success(
+                listOf(
+                    BillingPlan(Tier.FREE, "Free", Xtr(0), isActive = true),
+                    BillingPlan(Tier.PRO, "Pro", Xtr(1500), isActive = true),
+                    BillingPlan(Tier.PRO_PLUS, "Pro Plus", Xtr(3000), isActive = false),
+                    BillingPlan(Tier.VIP, "Vip", Xtr(5000), isActive = true)
+                )
+            )
+        }
+        val bot = FakeTelegramBot()
+        val update = messageUpdate(100, 42L, "/plans")
+
+        StarsBotCommands.handlePlans(update, bot, service)
+
+        val request = bot.singleRequest<SendMessage>()
+        val params = request.parameters
+        val text = params["text"] as String
+        assertTrue(text.startsWith("*Available plans*"))
+        assertTrue(text.contains("• *FREE* — Free — 0 XTR"))
+        assertTrue(text.contains("• *PRO* — Pro — 1500 XTR"))
+        assertTrue(text.contains("• *VIP* — Vip — 5000 XTR"))
+        assertTrue(!text.contains("Pro Plus"))
+    }
+
+    @Test
+    fun `buy command emits inline keyboard`() = runBlocking {
+        val service = FakeBillingService()
+        val bot = FakeTelegramBot()
+        val update = messageUpdate(101, 55L, "/buy")
+
+        StarsBotCommands.handleBuy(update, bot, service)
+
+        val request = bot.singleRequest<SendMessage>()
+        val params = request.parameters
+        val markup = params["reply_markup"] as InlineKeyboardMarkup
+        val buttons: Array<Array<InlineKeyboardButton>> = markup.inlineKeyboard()
+        assertEquals(1, buttons.size)
+        val row = buttons[0]
+        assertEquals(listOf("buy:PRO", "buy:PRO_PLUS", "buy:VIP"), row.map { it.callbackData() })
+    }
+
+    @Test
+    fun `callback creates invoice once`() = runBlocking {
+        val service = FakeBillingService().apply {
+            invoiceResult = Result.success("https://invoice.test")
+        }
+        val bot = FakeTelegramBot()
+        val update = callbackUpdate(102, userId = 77L, chatId = 77L, data = "buy:PRO")
+
+        StarsBotCommands.handleCallback(update, bot, service)
+
+        assertEquals(listOf(77L to Tier.PRO), service.invoiceRequests)
+        val requests = bot.requests
+        assertEquals(2, requests.size)
+        val send = assertIs<SendMessage>(requests[0])
+        val sendParams = send.parameters
+        val text = sendParams["text"] as String
+        assertTrue(text.contains("https://invoice.test"))
+        val ack = assertIs<AnswerCallbackQuery>(requests[1])
+        val ackParams = ack.parameters
+        assertEquals("Invoice sent", ackParams["text"])
+    }
+
+    @Test
+    fun `status reports active subscription`() = runBlocking {
+        val expiresAt = java.time.Instant.parse("2025-01-01T00:00:00Z")
+        val service = FakeBillingService().apply {
+            subscriptionResult = Result.success(
+                UserSubscription(88L, Tier.PRO_PLUS, SubStatus.ACTIVE, expiresAt.minusSeconds(3600), expiresAt)
+            )
+        }
+        val bot = FakeTelegramBot()
+        val update = messageUpdate(103, 88L, "/status")
+
+        StarsBotCommands.handleStatus(update, bot, service)
+
+        val request = bot.singleRequest<SendMessage>()
+        val params = request.parameters
+        val text = params["text"] as String
+        assertTrue(text.contains("*Tier:* PRO+"))
+        assertTrue(text.contains("*Status:* ACTIVE"))
+        assertTrue(text.contains("*Expires:* 2025-01-01T00:00:00Z"))
+    }
+
+    @Test
+    fun `status without subscription reports free`() = runBlocking {
+        val service = FakeBillingService().apply {
+            subscriptionResult = Result.success(null)
+        }
+        val bot = FakeTelegramBot()
+        val update = messageUpdate(104, 91L, "/status")
+
+        StarsBotCommands.handleStatus(update, bot, service)
+
+        val request = bot.singleRequest<SendMessage>()
+        val params = request.parameters
+        val text = params["text"] as String
+        assertTrue(text.contains("*Tier:* FREE"))
+        assertTrue(text.contains("*Status:* EXPIRED"))
+    }
+
+    @Test
+    fun `duplicate update is ignored`() = runBlocking {
+        val service = FakeBillingService().apply {
+            plansResult = Result.success(
+                listOf(BillingPlan(Tier.PRO, "Pro", Xtr(1000), isActive = true))
+            )
+        }
+        val bot = FakeTelegramBot()
+        val update = messageUpdate(105, 123L, "/plans")
+
+        StarsBotCommands.handlePlans(update, bot, service)
+        StarsBotCommands.handlePlans(update, bot, service)
+
+        assertEquals(1, bot.requests.size)
+    }
+
+    @Test
+    fun `service errors map to user friendly message`() = runBlocking {
+        val service = FakeBillingService().apply {
+            invoiceResult = Result.failure(NoSuchElementException("missing"))
+        }
+        val bot = FakeTelegramBot()
+        val update = callbackUpdate(106, userId = 66L, chatId = 66L, data = "buy:VIP")
+
+        StarsBotCommands.handleCallback(update, bot, service)
+
+        val request = assertIs<SendMessage>(bot.requests[0])
+        val params = request.parameters
+        val text = params["text"] as String
+        assertEquals("Plan not found", text)
+    }
+
+    private fun messageUpdate(updateId: Int, userId: Long, text: String): Update {
+        val json = """
+            {
+              "update_id": $updateId,
+              "message": {
+                "message_id": 1,
+                "from": {"id": $userId, "is_bot": false, "first_name": "User"},
+                "chat": {"id": $userId, "type": "private"},
+                "date": 0,
+                "text": "$text"
+              }
+            }
+        """
+        return BotUtils.parseUpdate(json)
+    }
+
+    private fun callbackUpdate(updateId: Int, userId: Long, chatId: Long, data: String): Update {
+        val json = """
+            {
+              "update_id": $updateId,
+              "callback_query": {
+                "id": "${'$'}{updateId}cb",
+                "from": {"id": $userId, "is_bot": false, "first_name": "User"},
+                "message": {
+                  "message_id": 9,
+                  "chat": {"id": $chatId, "type": "private"}
+                },
+                "data": "$data"
+              }
+            }
+        """
+        return BotUtils.parseUpdate(json)
+    }
+
+    private class FakeBillingService : BillingService {
+        var plansResult: Result<List<BillingPlan>> = Result.success(emptyList())
+        var invoiceResult: Result<String> = Result.success("https://noop")
+        var subscriptionResult: Result<UserSubscription?> = Result.success(null)
+        val invoiceRequests = mutableListOf<Pair<Long, Tier>>()
+
+        override suspend fun listPlans(): Result<List<BillingPlan>> = plansResult
+
+        override suspend fun createInvoiceFor(userId: Long, tier: Tier): Result<String> {
+            invoiceRequests += userId to tier
+            return invoiceResult
+        }
+
+        override suspend fun applySuccessfulPayment(
+            userId: Long,
+            tier: Tier,
+            amountXtr: Long,
+            providerPaymentId: String?,
+            payload: String?
+        ): Result<Unit> = Result.success(Unit)
+
+        override suspend fun getMySubscription(userId: Long): Result<UserSubscription?> = subscriptionResult
+    }
+
+    private class FakeTelegramBot : TelegramBot("test-token") {
+        val requests = mutableListOf<BaseRequest<*, *>>()
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : BaseRequest<T, R>, R : BaseResponse> execute(request: BaseRequest<T, R>): R {
+            requests += request
+            val ctor = BaseResponse::class.java.getDeclaredConstructor()
+            ctor.isAccessible = true
+            return ctor.newInstance() as R
+        }
+
+        inline fun <reified T : BaseRequest<*, *>> singleRequest(): T {
+            assertEquals(1, requests.size)
+            val request = requests.first()
+            assertIs<T>(request)
+            return request
+        }
+    }
+}

--- a/app/src/test/kotlin/routes/AlertsSettingsRoutesTest.kt
+++ b/app/src/test/kotlin/routes/AlertsSettingsRoutesTest.kt
@@ -17,6 +17,9 @@ import billing.model.SubStatus
 import billing.model.Tier
 import billing.model.UserSubscription
 import billing.service.BillingService
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.request.BaseRequest
+import com.pengrad.telegrambot.response.BaseResponse
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.patch
@@ -130,7 +133,7 @@ class AlertsSettingsRoutesTest {
 
             application {
                 installSecurity()
-                attributes.put(Services.Key, Services(billingService))
+                attributes.put(Services.Key, Services(billingService, NoopTelegramBot()))
                 attributes.put(AlertsSettingsDepsKey, AlertsSettingsRouteDeps(billingService, service))
                 routing {
                     authenticate("auth-jwt") {
@@ -190,4 +193,13 @@ class AlertsSettingsRoutesTest {
             )
         )
     )
+}
+
+private class NoopTelegramBot : TelegramBot("test-token") {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : BaseRequest<T, R>, R : BaseResponse> execute(request: BaseRequest<T, R>): R {
+        val ctor = BaseResponse::class.java.getDeclaredConstructor()
+        ctor.isAccessible = true
+        return ctor.newInstance() as R
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ testcontainers = "1.20.2"
 logback = "1.5.12"
 ktlintGradle = "12.1.0"
 detekt = "1.23.6"
+pengrad = "6.9.1"
 
 
 [libraries]
@@ -58,6 +59,7 @@ testcontainers-core = { module = "org.testcontainers:testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:postgresql" }
 testcontainers-junit = { module = "org.testcontainers:junit-jupiter" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+pengrad-bot = { module = "com.github.pengrad:java-telegram-bot-api", version.ref = "pengrad" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- add the Pengrad Telegram Bot dependency and wire a TelegramBot via a new DI module
- route /telegram/webhook updates to Stars bot commands and implement plan, buy, status, and callback handling with idempotency
- cover the bot command flow with unit tests and document the P16 Stars bot commands in the README

## Testing
- ./gradlew :app:compileKotlin :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d74b8f0d28832187fe269568079f3e