### PR TITLE
Implement channel publishing with CTA deep links

### DIFF
--- a/news/src/main/kotlin/news/config/NewsConfig.kt
+++ b/news/src/main/kotlin/news/config/NewsConfig.kt
@@ -10,7 +10,8 @@ data class NewsConfig(
     val httpTimeoutMs: Long,
     val sourceWeights: List<SourceWeight>,
     val channelId: Long,
-    val botDeepLinkBase: String
+    val botDeepLinkBase: String,
+    val maxPayloadBytes: Int = 64
 )
 
 object NewsDefaults {
@@ -29,7 +30,8 @@ object NewsDefaults {
         httpTimeoutMs = 30_000,
         sourceWeights = defaultWeights,
         channelId = 0L,
-        botDeepLinkBase = "https://t.me/example_bot"
+        botDeepLinkBase = "https://t.me/example_bot",
+        maxPayloadBytes = 64
     )
 
     fun weightFor(domain: String, weights: List<SourceWeight> = defaultWeights): Int {

--- a/news/src/main/kotlin/news/cta/CtaBuilder.kt
+++ b/news/src/main/kotlin/news/cta/CtaBuilder.kt
@@ -1,0 +1,79 @@
+package news.cta
+
+import com.pengrad.telegrambot.model.request.InlineKeyboardButton
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+object CtaBuilder {
+    /** base: https://t.me/<bot_username>, payload ≤ maxBytes */
+    fun deepLink(base: String, payload: String, maxBytes: Int): String {
+        require(maxBytes > 0) { "maxBytes must be positive" }
+        val sanitizedBase = base.trim().trimEnd { it == '/' || it == '?' }
+        val trimmedPayload = trimToBytes(payload, maxBytes)
+        val encodedPayload = URLEncoder.encode(trimmedPayload, StandardCharsets.UTF_8)
+        return "$sanitizedBase?start=$encodedPayload"
+    }
+
+    fun watchTicker(base: String, ticker: String, maxBytes: Int): InlineKeyboardButton {
+        val normalizedTicker = normalizeTicker(ticker)
+        val payload = "TICKER_${normalizedTicker.ifEmpty { "MARKET" }}"
+        val link = deepLink(base, payload, maxBytes)
+        return InlineKeyboardButton("Следить за ${displayTicker(ticker)}").url(link)
+    }
+
+    fun btcFast(base: String, maxBytes: Int): InlineKeyboardButton {
+        val link = deepLink(base, "TICKER_BTC_2PCT", maxBytes)
+        return InlineKeyboardButton("BTC: +2% за час?").url(link)
+    }
+
+    fun weeklyReminders(base: String, maxBytes: Int): InlineKeyboardButton {
+        val link = deepLink(base, "TOPIC_WEEKLY", maxBytes)
+        return InlineKeyboardButton("Еженед. напоминания").url(link)
+    }
+
+    fun myPortfolio(base: String, maxBytes: Int): InlineKeyboardButton {
+        val link = deepLink(base, "PORTFOLIO_HOME", maxBytes)
+        return InlineKeyboardButton("Мой портфель").url(link)
+    }
+
+    /** Стандартная раскладка 2×2 */
+    fun defaultMarkup(base: String, maxBytes: Int, primaryTicker: String?): InlineKeyboardMarkup {
+        val firstRowFirst = primaryTicker?.takeIf { it.isNotBlank() }
+            ?.let { watchTicker(base, it, maxBytes) }
+            ?: InlineKeyboardButton("Рынок сейчас").url(deepLink(base, "TOPIC_MARKET", maxBytes))
+        val firstRowSecond = btcFast(base, maxBytes)
+        val secondRowFirst = weeklyReminders(base, maxBytes)
+        val secondRowSecond = myPortfolio(base, maxBytes)
+        return InlineKeyboardMarkup(
+            arrayOf(firstRowFirst, firstRowSecond),
+            arrayOf(secondRowFirst, secondRowSecond)
+        )
+    }
+
+    private fun trimToBytes(value: String, maxBytes: Int): String {
+        var currentBytes = 0
+        val builder = StringBuilder()
+        for (char in value) {
+            val charBytes = char.toString().toByteArray(StandardCharsets.UTF_8).size
+            if (currentBytes + charBytes > maxBytes) {
+                break
+            }
+            builder.append(char)
+            currentBytes += charBytes
+        }
+        return builder.toString()
+    }
+
+    private fun normalizeTicker(ticker: String): String {
+        val upper = ticker.trim().uppercase(Locale.US)
+        val filtered = upper.filter { it.isLetterOrDigit() || it == '_' }
+        return trimToBytes(filtered.ifEmpty { "MARKET" }, 48)
+    }
+
+    private fun displayTicker(ticker: String): String {
+        val trimmed = ticker.trim()
+        return if (trimmed.isEmpty()) "рынком" else trimmed.uppercase(Locale.getDefault())
+    }
+}

--- a/news/src/main/kotlin/news/pipeline/PublishBreaking.kt
+++ b/news/src/main/kotlin/news/pipeline/PublishBreaking.kt
@@ -1,0 +1,33 @@
+package news.pipeline
+
+import java.security.MessageDigest
+import java.util.Base64
+import kotlin.text.Charsets
+import news.config.NewsConfig
+import news.cta.CtaBuilder
+import news.model.Cluster
+import news.publisher.ChannelPublisher
+import news.render.PostTemplates
+
+class PublishBreaking(
+    private val cfg: NewsConfig,
+    private val publisher: ChannelPublisher
+) {
+    suspend fun publish(cluster: Cluster, primaryTicker: String?): Boolean {
+        val deepLink = deepLink(cluster.clusterKey)
+        val text = PostTemplates.renderBreaking(cluster, deepLink)
+        val markup = CtaBuilder.defaultMarkup(cfg.botDeepLinkBase, cfg.maxPayloadBytes, primaryTicker)
+        return publisher.publish(cluster.clusterKey, text, markup)
+    }
+
+    private fun deepLink(clusterKey: String): String {
+        val payload = payload(clusterKey)
+        return CtaBuilder.deepLink(cfg.botDeepLinkBase, payload, cfg.maxPayloadBytes)
+    }
+
+    private fun payload(clusterKey: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashed = digest.digest(clusterKey.toByteArray(Charsets.UTF_8)).copyOf(16)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashed)
+    }
+}

--- a/news/src/main/kotlin/news/publisher/ChannelPublisher.kt
+++ b/news/src/main/kotlin/news/publisher/ChannelPublisher.kt
@@ -1,0 +1,43 @@
+package news.publisher
+
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+import com.pengrad.telegrambot.model.request.ParseMode
+import com.pengrad.telegrambot.request.SendMessage
+import news.config.NewsConfig
+import news.publisher.store.IdempotencyStore
+import org.slf4j.LoggerFactory
+
+open class ChannelPublisher(
+    private val bot: TelegramBot,
+    private val cfg: NewsConfig,
+    private val store: IdempotencyStore
+) {
+    private val logger = LoggerFactory.getLogger(ChannelPublisher::class.java)
+
+    /** Идемпотентная публикация: вернёт false, если кластер уже публиковался */
+    open suspend fun publish(clusterKey: String, text: String, markup: InlineKeyboardMarkup?): Boolean {
+        if (store.seen(clusterKey)) {
+            logger.info("cluster {} already published", clusterKey)
+            return false
+        }
+        return try {
+            val request = SendMessage(cfg.channelId, text)
+                .parseMode(ParseMode.MarkdownV2)
+            if (markup != null) {
+                request.replyMarkup(markup)
+            }
+            val response = bot.execute(request)
+            if (response.isOk) {
+                store.mark(clusterKey)
+                true
+            } else {
+                logger.warn("telegram send failed for {}", clusterKey)
+                false
+            }
+        } catch (ex: Exception) {
+            logger.error("telegram send threw for {}", clusterKey, ex)
+            false
+        }
+    }
+}

--- a/news/src/main/kotlin/news/publisher/IdempotencyStore.kt
+++ b/news/src/main/kotlin/news/publisher/IdempotencyStore.kt
@@ -1,43 +1,4 @@
 package news.publisher
 
-import java.time.Clock
-import java.time.Duration
-import java.time.Instant
-
-interface IdempotencyStore {
-    fun seen(clusterKey: String): Boolean
-    fun mark(clusterKey: String)
-}
-
-class InMemoryIdempotencyStore(
-    private val ttl: Duration = Duration.ofHours(6),
-    private val clock: Clock = Clock.systemUTC()
-) : IdempotencyStore {
-    private val entries = mutableMapOf<String, Instant>()
-
-    override fun seen(clusterKey: String): Boolean {
-        purgeExpired()
-        val expiresAt = entries[clusterKey] ?: return false
-        if (expiresAt.isBefore(clock.instant())) {
-            entries.remove(clusterKey)
-            return false
-        }
-        return true
-    }
-
-    override fun mark(clusterKey: String) {
-        purgeExpired()
-        entries[clusterKey] = clock.instant().plus(ttl)
-    }
-
-    private fun purgeExpired() {
-        val now = clock.instant()
-        val iterator = entries.entries.iterator()
-        while (iterator.hasNext()) {
-            val entry = iterator.next()
-            if (entry.value.isBefore(now)) {
-                iterator.remove()
-            }
-        }
-    }
-}
+typealias IdempotencyStore = news.publisher.store.IdempotencyStore
+typealias InMemoryIdempotencyStore = news.publisher.store.InMemoryIdempotencyStore

--- a/news/src/main/kotlin/news/publisher/store/IdempotencyStore.kt
+++ b/news/src/main/kotlin/news/publisher/store/IdempotencyStore.kt
@@ -1,0 +1,44 @@
+package news.publisher.store
+
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+interface IdempotencyStore {
+    fun seen(key: String): Boolean
+    fun mark(key: String)
+}
+
+class InMemoryIdempotencyStore(
+    private val ttlMinutes: Long = 1_440,
+    private val clock: Clock = Clock.systemUTC()
+) : IdempotencyStore {
+    private val entries = ConcurrentHashMap<String, Instant>()
+
+    override fun seen(key: String): Boolean {
+        purgeExpired()
+        val expiresAt = entries[key] ?: return false
+        if (expiresAt.isBefore(clock.instant())) {
+            entries.remove(key)
+            return false
+        }
+        return true
+    }
+
+    override fun mark(key: String) {
+        purgeExpired()
+        val expiry = clock.instant().plusSeconds(ttlMinutes * 60)
+        entries[key] = expiry
+    }
+
+    private fun purgeExpired() {
+        val now = clock.instant()
+        val iterator = entries.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.value.isBefore(now)) {
+                iterator.remove()
+            }
+        }
+    }
+}

--- a/news/src/main/kotlin/news/render/PostTemplates.kt
+++ b/news/src/main/kotlin/news/render/PostTemplates.kt
@@ -7,14 +7,16 @@ object PostTemplates {
         val canonical = cluster.canonical
         val builder = StringBuilder()
         builder.append("*Breaking:* ")
-        builder.append(escapeMarkdown(canonical.title))
+        builder.append(escapeMarkdownV2(canonical.title))
         canonical.summary?.let {
-            builder.append("\n\n")
-            builder.append(escapeMarkdown(it))
+            if (it.isNotBlank()) {
+                builder.append("\n\n")
+                builder.append(escapeMarkdownV2(it))
+            }
         }
         builder.append("\n\n")
         builder.append("Источник: ")
-        builder.append(escapeMarkdown(canonical.domain))
+        builder.append(escapeMarkdownV2(canonical.domain))
         builder.append("\n")
         builder.append(renderCta(deepLink))
         return builder.toString()
@@ -26,10 +28,10 @@ object PostTemplates {
         clusters.take(3).forEachIndexed { index, cluster ->
             builder.append("\n")
             builder.append("${index + 1}. ")
-            builder.append(escapeMarkdown(cluster.canonical.title))
+            builder.append(escapeMarkdownV2(cluster.canonical.title))
             cluster.topics.takeIf { it.isNotEmpty() }?.let {
                 builder.append(" — ")
-                builder.append(escapeMarkdown(it.joinToString(", ")))
+                builder.append(escapeMarkdownV2(it.joinToString(", ")))
             }
             builder.append("\n")
             builder.append(renderCta(deepLinkBuilder(cluster)))
@@ -43,36 +45,45 @@ object PostTemplates {
         builder.append("*Weekly Preview*\n")
         clusters.forEach { cluster ->
             builder.append("\n• ")
-            builder.append(escapeMarkdown(cluster.canonical.title))
+            builder.append(escapeMarkdownV2(cluster.canonical.title))
             if (cluster.topics.isNotEmpty()) {
                 builder.append(" (")
-                builder.append(escapeMarkdown(cluster.topics.joinToString(", ")))
+                builder.append(escapeMarkdownV2(cluster.topics.joinToString(", ")))
                 builder.append(")")
             }
         }
-        builder.append("\n\n")
-        builder.append("Подробнее: ")
-        builder.append(renderCta(deepLinkBuilder(clusters.firstOrNull() ?: return builder.toString().trim())))
+        if (clusters.isNotEmpty()) {
+            builder.append("\n\n")
+            builder.append("Подробнее: ")
+            builder.append(renderCta(deepLinkBuilder(clusters.first())))
+        }
         return builder.toString().trim()
     }
 
-    private fun renderCta(deepLink: String): String {
-        val sanitized = deepLink.take(64)
-        return "👉 [Открыть в боте](${escapeMarkdownLink(sanitized)})"
-    }
-
-    private fun escapeMarkdown(text: String): String {
-        return buildString(text.length) {
+    fun escapeMarkdownV2(text: String): String {
+        return buildString(text.length * 2) {
             text.forEach { char ->
                 when (char) {
-                    '\\', '*', '_', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' -> append('\\')
+                    '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' -> append('\\')
                 }
                 append(char)
             }
         }
     }
 
-    private fun escapeMarkdownLink(text: String): String {
-        return text.replace("(", "%28").replace(")", "%29").replace(" ", "%20")
+    private fun renderCta(deepLink: String): String {
+        val url = escapeMarkdownV2Url(deepLink)
+        return "👉 [Открыть в боте]($url)"
+    }
+
+    private fun escapeMarkdownV2Url(url: String): String {
+        return buildString(url.length * 2) {
+            url.forEach { char ->
+                when (char) {
+                    '(', ')', '\\' -> append('\\')
+                }
+                append(char)
+            }
+        }
     }
 }

--- a/news/src/test/kotlin/news/cta/CtaBuilderTest.kt
+++ b/news/src/test/kotlin/news/cta/CtaBuilderTest.kt
@@ -1,0 +1,54 @@
+package news.cta
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CtaBuilderTest {
+    private val base = "https://t.me/test_bot"
+
+    @Test
+    fun `deep link trims payload to limit`() {
+        val payload = "A".repeat(128)
+        val link = CtaBuilder.deepLink(base, payload, 64)
+        val encoded = link.substringAfter("start=")
+        val decoded = URLDecoder.decode(encoded, StandardCharsets.UTF_8)
+        assertEquals(64, decoded.length)
+    }
+
+    @Test
+    fun `deep link has no spaces`() {
+        val link = CtaBuilder.deepLink(base, "TICKER Test", 64)
+        assertTrue(!link.contains(' '))
+    }
+
+    @Test
+    fun `default markup contains expected buttons`() {
+        val markup = CtaBuilder.defaultMarkup(base, 64, "SBER")
+        val rows = markup.inlineKeyboard()
+        assertEquals(2, rows.size)
+        assertTrue(rows.all { it.size == 2 })
+        val watchTicker = rows[0][0]
+        assertEquals("Следить за SBER", watchTicker.text)
+        assertTrue(watchTicker.url!!.contains("TICKER_SBER"))
+        val btc = rows[0][1]
+        assertEquals("BTC: +2% за час?", btc.text)
+        assertTrue(btc.url!!.contains("TICKER_BTC_2PCT"))
+        val weekly = rows[1][0]
+        assertEquals("Еженед. напоминания", weekly.text)
+        assertTrue(weekly.url!!.contains("TOPIC_WEEKLY"))
+        val portfolio = rows[1][1]
+        assertEquals("Мой портфель", portfolio.text)
+        assertTrue(portfolio.url!!.contains("PORTFOLIO_HOME"))
+    }
+
+    @Test
+    fun `default markup falls back without ticker`() {
+        val markup = CtaBuilder.defaultMarkup(base, 64, null)
+        val rows = markup.inlineKeyboard()
+        assertEquals("Рынок сейчас", rows[0][0].text)
+        assertTrue(rows[0][0].url!!.contains("TOPIC_MARKET"))
+    }
+}

--- a/news/src/test/kotlin/news/pipeline/PublishBreakingTest.kt
+++ b/news/src/test/kotlin/news/pipeline/PublishBreakingTest.kt
@@ -1,0 +1,85 @@
+package news.pipeline
+
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+import com.pengrad.telegrambot.request.BaseRequest
+import com.pengrad.telegrambot.response.BaseResponse
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import news.config.NewsConfig
+import news.config.NewsDefaults
+import news.model.Article
+import news.model.Cluster
+import news.publisher.ChannelPublisher
+import news.publisher.store.InMemoryIdempotencyStore
+
+class PublishBreakingTest {
+    private val config = NewsDefaults.defaultConfig.copy(
+        channelId = -1001234567890L,
+        botDeepLinkBase = "https://t.me/test_bot",
+        maxPayloadBytes = 64
+    )
+
+    @Test
+    fun `publish composes markdown and markup`() = runTest {
+        val publisher = RecordingPublisher(config)
+        val useCase = PublishBreaking(config, publisher)
+        val article = Article(
+            id = "id-1",
+            url = "https://example.com/news",
+            domain = "example.com",
+            title = "Сбербанк (MOEX:SBER)!",
+            summary = "Рост +2% #финансы",
+            publishedAt = Instant.parse("2024-06-01T10:15:30Z"),
+            language = "ru",
+            tickers = setOf("SBER"),
+            entities = setOf("Sberbank")
+        )
+        val cluster = Cluster(
+            clusterKey = "cluster-key-1",
+            canonical = article,
+            articles = listOf(article),
+            topics = setOf("Finance"),
+            createdAt = article.publishedAt
+        )
+
+        val result = useCase.publish(cluster, "SBER")
+
+        assertTrue(result)
+        assertEquals(listOf(cluster.clusterKey), publisher.publishedKeys)
+        val text = publisher.lastText
+        assertNotNull(text)
+        assertTrue(text.contains("\\(MOEX:SBER\\)"))
+        assertTrue(text.contains("Рост \\+2%"))
+        assertTrue(text.contains("[Открыть в боте]"))
+        val markup = publisher.lastMarkup
+        assertNotNull(markup)
+        val rows = markup.inlineKeyboard()
+        assertEquals(2, rows.size)
+        assertTrue(rows.all { it.size == 2 })
+        assertTrue(rows.flatten().all { it.url!!.startsWith("https://t.me/test_bot?start=") })
+    }
+
+    private class RecordingPublisher(config: NewsConfig) : ChannelPublisher(NoopTelegramBot(), config, InMemoryIdempotencyStore()) {
+        val publishedKeys = mutableListOf<String>()
+        var lastText: String? = null
+        var lastMarkup: InlineKeyboardMarkup? = null
+
+        override suspend fun publish(clusterKey: String, text: String, markup: InlineKeyboardMarkup?): Boolean {
+            publishedKeys += clusterKey
+            lastText = text
+            lastMarkup = markup
+            return true
+        }
+    }
+
+    private class NoopTelegramBot : TelegramBot("test-token") {
+        override fun <T : BaseRequest<T, R>, R : BaseResponse> execute(request: BaseRequest<T, R>): R {
+            throw UnsupportedOperationException("not used in tests")
+        }
+    }
+}

--- a/news/src/test/kotlin/news/publisher/ChannelPublisherTest.kt
+++ b/news/src/test/kotlin/news/publisher/ChannelPublisherTest.kt
@@ -1,0 +1,102 @@
+package news.publisher
+
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+import com.pengrad.telegrambot.request.BaseRequest
+import com.pengrad.telegrambot.request.SendMessage
+import com.pengrad.telegrambot.response.BaseResponse
+import com.pengrad.telegrambot.response.SendResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import news.config.NewsDefaults
+import news.publisher.store.InMemoryIdempotencyStore
+
+class ChannelPublisherTest {
+    private val config = NewsDefaults.defaultConfig.copy(
+        channelId = -1001234567890L,
+        botDeepLinkBase = "https://t.me/test_bot",
+        maxPayloadBytes = 64
+    )
+
+    @Test
+    fun `publish once respects idempotency`() = runTest {
+        val bot = RecordingTelegramBot()
+        bot.nextResponse = sendResponse(ok = true)
+        val publisher = ChannelPublisher(bot, config, InMemoryIdempotencyStore())
+
+        val first = publisher.publish("cluster-key", "text", InlineKeyboardMarkup())
+        val second = publisher.publish("cluster-key", "text", InlineKeyboardMarkup())
+
+        assertTrue(first)
+        assertFalse(second)
+        assertEquals(1, bot.executed.size)
+        val request = bot.executed.first() as SendMessage
+        assertEquals(config.channelId, request.getParameters()["chat_id"])
+    }
+
+    @Test
+    fun `failure response does not mark idempotency`() = runTest {
+        val bot = RecordingTelegramBot()
+        bot.nextResponse = sendResponse(ok = false, description = "rate limit")
+        val publisher = ChannelPublisher(bot, config, InMemoryIdempotencyStore())
+
+        val first = publisher.publish("cluster-key", "text", null)
+        assertFalse(first)
+
+        bot.nextResponse = sendResponse(ok = true)
+        val second = publisher.publish("cluster-key", "text", null)
+        assertTrue(second)
+        assertEquals(2, bot.executed.size)
+    }
+
+    @Test
+    fun `exceptions are captured and reported as failure`() = runTest {
+        val bot = RecordingTelegramBot()
+        bot.throwOnExecute = true
+        val publisher = ChannelPublisher(bot, config, InMemoryIdempotencyStore())
+
+        val result = publisher.publish("cluster-key", "text", null)
+        assertFalse(result)
+        assertEquals(0, bot.executed.size)
+    }
+
+    private class RecordingTelegramBot : TelegramBot("test-token") {
+        val executed = mutableListOf<BaseRequest<*, *>>()
+        var nextResponse: BaseResponse = sendResponse(ok = true)
+        var throwOnExecute: Boolean = false
+
+        override fun <T : BaseRequest<T, R>, R : BaseResponse> execute(request: BaseRequest<T, R>): R {
+            if (throwOnExecute) {
+                throw IllegalStateException("forced failure")
+            }
+            executed += request
+            @Suppress("UNCHECKED_CAST")
+            return nextResponse as R
+        }
+    }
+
+}
+
+private fun sendResponse(ok: Boolean, description: String? = null): SendResponse {
+    val ctor = SendResponse::class.java.getDeclaredConstructor()
+    ctor.isAccessible = true
+    val response = ctor.newInstance()
+    setField(response, "ok", ok)
+    if (description != null) {
+        setField(response, "description", description)
+    }
+    return response
+}
+
+private fun setField(response: BaseResponse, name: String, value: Any) {
+    val field = BaseResponse::class.java.getDeclaredField(name)
+    field.isAccessible = true
+    if (value is Boolean) {
+        field.setBoolean(response, value)
+    } else {
+        field.set(response, value)
+    }
+}


### PR DESCRIPTION
## Summary
- add channel publisher built on the Pengrad Telegram Bot API with idempotent delivery
- generate deep-link CTA buttons and wire them into the breaking-news pipeline
- cover publisher, CTA builder, and pipeline logic with unit tests

## Testing
- ./gradlew :news:compileKotlin :news:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d7569fad8c832189a3b16835f378ce