### PR TITLE
Add local review runner and pre-push automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Use Java 21. To list projects:
 ./gradlew -q projects
 ```
 
+## Local Review / Pre-push
+
+Install git hooks and run local revision before pushing:
+
+```bash
+./gradlew installGitHooks
+bash tools/audit/run_all.sh
+bash tools/audit/run_all.sh --skip-build
+bash tools/audit/run_all.sh --only-audit
+```
+
+`run_all.sh` orchestrates Kotlin lint/tests/build, grep-based audit checks, and optional miniapp verification. The script refuses to run when `APP_PROFILE=prod`. The pre-push hook executes `run_all.sh --skip-build` automatically and blocks the push on failures.
+
 ## Environment
 
 Copy `.env.example` to `.env` and provide the required values.

--- a/tools/audit/run_all.sh
+++ b/tools/audit/run_all.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+blue()   { printf '\033[34m%s\033[0m\n' "$*"; }
+
+usage() {
+  cat <<'USAGE'
+Usage: tools/audit/run_all.sh [--skip-build] [--skip-miniapp] [--only-audit]
+  --skip-build     Skip Gradle clean build step
+  --skip-miniapp   Skip miniapp npm/pnpm checks
+  --only-audit     Only run grep-based audit checks
+  -h, --help       Show this message
+USAGE
+}
+
+skip_build=0
+skip_miniapp=0
+only_audit=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-build)   skip_build=1; shift ;;
+    --skip-miniapp) skip_miniapp=1; shift ;;
+    --only-audit)   only_audit=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) red "[FAIL] unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+trap 'code=$?; if (( code == 0 )); then green "[OK] all checks passed"; else red "[FAIL] run_all.sh failed (exit ${code})"; fi' EXIT
+
+if [[ "${APP_PROFILE:-}" == "prod" ]]; then
+  red "[FAIL] refusing to run with APP_PROFILE=prod"
+  exit 2
+fi
+
+if [[ ! -f ./gradlew ]]; then
+  red "[FAIL] ./gradlew not found in repository root"
+  exit 3
+fi
+
+blue "== Local revision (lint + tests + audit + miniapp) =="
+
+java_version=$(java -version 2>&1 | head -n 1 | tr -d '\r')
+if [[ -n "${java_version}" ]]; then
+  yellow "[INFO] ${java_version}"
+fi
+
+gradle_version=$(./gradlew -v | awk '/^Gradle / {print; exit}')
+if [[ -n "${gradle_version}" ]]; then
+  yellow "[INFO] ${gradle_version}"
+fi
+
+summary=()
+
+if (( ! only_audit )); then
+  yellow "[INFO] Running ktlintCheck and detekt"
+  ./gradlew --no-daemon --stacktrace ktlintCheck detekt
+  summary+=("ktlint+detekt")
+
+  yellow "[INFO] Running JVM module tests"
+  ./gradlew --no-daemon --stacktrace :core:test :storage:test :app:test --console=plain
+  summary+=("tests")
+
+  if (( skip_build )); then
+    yellow "[WARN] --skip-build enabled, skipping clean build"
+  else
+    yellow "[INFO] Running clean build"
+    ./gradlew --no-daemon --stacktrace clean build --console=plain
+    summary+=("build")
+  fi
+fi
+
+yellow "[INFO] Running audit grep checks"
+if [[ ! -x tools/audit/grep_checks.sh ]]; then
+  red "[FAIL] tools/audit/grep_checks.sh is missing or not executable"
+  exit 4
+fi
+
+if ! tools/audit/grep_checks.sh; then
+  status=$?
+  red "[FAIL] audit grep checks failed"
+  exit "$status"
+fi
+summary+=("audit-grep")
+
+if (( ! only_audit )) && (( ! skip_miniapp )); then
+  if [[ -f miniapp/package.json ]]; then
+    yellow "[INFO] Running miniapp checks"
+    if command -v corepack >/dev/null 2>&1; then
+      corepack enable
+      corepack prepare pnpm@latest --activate
+    else
+      yellow "[WARN] corepack not found; attempting pnpm directly"
+    fi
+    pushd miniapp >/dev/null
+    if command -v pnpm >/dev/null 2>&1; then
+      pnpm install --frozen-lockfile
+      pnpm build
+      pnpm test -- --run
+    else
+      red "[FAIL] pnpm not available"
+      popd >/dev/null
+      exit 5
+    fi
+    popd >/dev/null
+    summary+=("miniapp")
+  else
+    yellow "[INFO] miniapp/package.json not found, skipping miniapp checks"
+  fi
+elif (( skip_miniapp )); then
+  yellow "[WARN] --skip-miniapp enabled, skipping miniapp checks"
+fi
+
+if (( ${#summary[@]} > 0 )); then
+  summary_line="${summary[0]}"
+  for entry in "${summary[@]:1}"; do
+    summary_line+="; ${entry}"
+  done
+  green "[OK] summary: ${summary_line}"
+fi
+
+exit 0

--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+if git grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- . >/dev/null 2>&1; then
+  red "[FAIL] merge-conflict markers detected; resolve conflicts before pushing"
+  exit 1
+fi
+
+run_all="$repo_root/tools/audit/run_all.sh"
+if [[ ! -x "$run_all" ]]; then
+  yellow "[WARN] tools/audit/run_all.sh missing; reinstall hooks with ./gradlew installGitHooks"
+  exit 0
+fi
+
+yellow "[INFO] Running pre-push audit (skip build)"
+if ! "$run_all" --skip-build; then
+  status=$?
+  red "[FAIL] pre-push checks failed"
+  yellow "[INFO] To reproduce: bash tools/audit/run_all.sh --skip-build"
+  exit "$status"
+fi
+
+green "[OK] pre-push checks passed"
+exit 0


### PR DESCRIPTION
## Summary
- add a consolidated `tools/audit/run_all.sh` script to orchestrate lint, tests, audits, and optional miniapp checks
- install both `pre-commit` and `pre-push` hooks via `installGitHooks`, wiring the new pre-push hook to the audit runner
- document the local review workflow and commands in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d87635528083219582cb1cce6add3b