### PR TITLE
Add Playwright E2E suite for miniapp

### DIFF
--- a/.github/workflows/miniapp-e2e.yml
+++ b/.github/workflows/miniapp-e2e.yml
@@ -1,0 +1,54 @@
+name: Mini App E2E
+
+on:
+  push:
+    paths:
+      - "miniapp/**"
+      - ".github/workflows/miniapp-e2e.yml"
+  pull_request:
+    paths:
+      - "miniapp/**"
+      - ".github/workflows/miniapp-e2e.yml"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('miniapp/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install dependencies
+        working-directory: miniapp
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        working-directory: miniapp
+        run: pnpm playwright:install
+
+      - name: Run e2e tests
+        working-directory: miniapp
+        run: pnpm test:e2e -- --reporter=html
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: miniapp-playwright-report
+          path: miniapp/playwright-report
+          if-no-files-found: warn

--- a/miniapp/.env.e2e.example
+++ b/miniapp/.env.e2e.example
@@ -1,0 +1,2 @@
+VITE_API_BASE=http://localhost:9999
+VITE_APP_NAME=portfolio-miniapp-e2e

--- a/miniapp/README.md
+++ b/miniapp/README.md
@@ -30,6 +30,34 @@ pnpm typecheck
 pnpm test
 ```
 
+## P20 — e2e
+
+End-to-end coverage for the Mini App is implemented with Playwright and can be executed locally or in CI. The suite launches the
+production preview via `vite preview` and relies entirely on mocked network interactions, so no external backend is required.
+
+### Install Playwright browsers
+
+```bash
+pnpm playwright:install
+```
+
+### Run the tests
+
+```bash
+pnpm test:e2e
+```
+
+### Explore with the Playwright UI
+
+```bash
+pnpm test:e2e:ui
+```
+
+During each run the Telegram Mini Apps JavaScript API is stubbed through an init script so that the app can boot with synthetic
+`initData`. API calls to `/api/*` endpoints are intercepted through Playwright routing helpers that return deterministic JSON
+responses and assert the `Authorization` headers carry the in-memory JWT. The Playwright `webServer` configuration starts the
+application using `pnpm preview` on port 5173, mirroring the production build pipeline.
+
 ## Telegram auth flow
 
 When opened inside Telegram, the Mini App reads `initData` supplied by the client. The frontend sends this data to the backend endpoint `/api/auth/telegram/verify` which performs validation and responds with a JWT. The token is stored only in memory for the current session. UI preferences such as the theme and last opened tab are persisted to `localStorage`.

--- a/miniapp/package.json
+++ b/miniapp/package.json
@@ -6,9 +6,13 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --port 5173 --strictPort",
     "typecheck": "tsc --noEmit",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "playwright:install": "playwright install --with-deps"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -22,8 +26,10 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
+    "@types/node": "^20.12.7",
     "@types/telegram-web-app": "file:src/types/telegram-web-app",
     "@vitejs/plugin-react": "^5.0.3",
+    "@playwright/test": "^1.44.1",
     "jsdom": "^24.0.0",
     "typescript": "^5.4.5",
     "vite": "^5.2.10",

--- a/miniapp/playwright.config.ts
+++ b/miniapp/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "tests-e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 3_000
+  },
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "retain-on-failure",
+    video: "off"
+  },
+  reporter: [["list"], ["html", { open: "never" }]],
+  webServer: {
+    command: "pnpm preview",
+    port: 5173,
+    reuseExistingServer: process.env.CI ? false : true
+  }
+});

--- a/miniapp/pnpm-lock.yaml
+++ b/miniapp/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.44.1
+        version: 1.55.1
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.8.0
@@ -30,6 +33,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@9.3.4)
+      '@types/node':
+        specifier: ^20.12.7
+        version: 20.19.17
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.24
@@ -335,6 +341,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@playwright/test@1.55.1':
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@remix-run/router@1.23.0':
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
@@ -745,6 +756,11 @@ packages:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1045,6 +1061,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.55.1:
+    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.1:
+    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -1632,6 +1658,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@playwright/test@1.55.1':
+    dependencies:
+      playwright: 1.55.1
+
   '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.35': {}
@@ -1766,7 +1796,6 @@ snapshots:
   '@types/node@20.19.17':
     dependencies:
       undici-types: 6.21.0
-    optional: true
 
   '@types/prop-types@15.7.15': {}
 
@@ -2083,6 +2112,9 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2381,6 +2413,14 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  playwright-core@1.55.1: {}
+
+  playwright@1.55.1:
+    dependencies:
+      playwright-core: 1.55.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.6:
@@ -2607,8 +2647,7 @@ snapshots:
 
   ufo@1.6.1: {}
 
-  undici-types@6.21.0:
-    optional: true
+  undici-types@6.21.0: {}
 
   universalify@0.2.0: {}
 

--- a/miniapp/tests-e2e/auth.spec.ts
+++ b/miniapp/tests-e2e/auth.spec.ts
@@ -1,0 +1,99 @@
+import { mockApi, expect, test, type MockApiHandlers } from "./fixtures";
+import { mockAuthOk, mockPositions } from "./mocks";
+
+function createDashboardHandlers(): MockApiHandlers {
+  return {
+    "GET /api/reports/portfolio*": (request) => {
+      expect(request.headers()["authorization"]).toMatch(/^Bearer\s+/);
+      return {
+        body: {
+          summary: {
+            totalValue: 12500,
+            realizedPnl: 320,
+            unrealizedPnl: 180
+          },
+          generatedAt: "2024-04-01T10:00:00Z"
+        }
+      };
+    },
+    "GET /api/quotes*": (request) => {
+      expect(request.headers()["authorization"]).toMatch(/^Bearer\s+/);
+      return {
+        body: [
+          { instrumentId: "AAPL", price: 165, changePct: 0.012, updatedAt: "2024-04-01T09:50:00Z" },
+          { instrumentId: "TSLA", price: 220, changePct: -0.024, updatedAt: "2024-04-01T09:48:00Z" }
+        ]
+      };
+    }
+  };
+}
+
+test.describe("auth", () => {
+  test("authenticates with Telegram init data and keeps JWT in memory", async ({ page }) => {
+    const handlers = {
+      ...mockAuthOk(),
+      ...mockPositions(),
+      ...createDashboardHandlers()
+    };
+
+    await mockApi(page, handlers);
+
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "Portfolio overview" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Dashboard" })).toBeVisible();
+
+    const storedValues = await page.evaluate(() => {
+      const result: Record<string, string> = {};
+      for (let index = 0; index < window.localStorage.length; index += 1) {
+        const key = window.localStorage.key(index);
+        if (key) {
+          const value = window.localStorage.getItem(key);
+          if (value) {
+            result[key] = value;
+          }
+        }
+      }
+      return result;
+    });
+
+    expect(Object.values(storedValues).some((value) => value.includes("TEST_JWT"))).toBeFalsy();
+  });
+
+  test("re-authenticates on 401 responses", async ({ page }) => {
+    let authCalls = 0;
+    const handlers = {
+      ...mockAuthOk({
+        tokens: ["TEST_JWT", "TEST_JWT_REFRESHED"],
+        onRequest: (_, __, call) => {
+          authCalls = call;
+        }
+      }),
+      ...mockPositions({
+        expectedToken: (call) => (call === 1 ? "TEST_JWT" : "TEST_JWT_REFRESHED"),
+        onCall: (_request, call) => {
+          if (call === 1) {
+            return { status: 401, body: { message: "Unauthorized" } };
+          }
+          return undefined;
+        }
+      }),
+      ...createDashboardHandlers()
+    };
+
+    await mockApi(page, handlers);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Positions", exact: true }).click();
+
+    await expect(page.getByText("Unauthorized. Please restart the Mini App.")).toBeVisible();
+
+    await page.reload();
+    await expect.poll(() => authCalls).toBeGreaterThanOrEqual(2);
+    await expect(page.getByText("Authorizing session...")).toBeHidden();
+
+    await page.getByRole("button", { name: "Positions", exact: true }).click();
+
+    await expect(page.getByRole("cell", { name: "AAPL" })).toBeVisible();
+  });
+});

--- a/miniapp/tests-e2e/fixtures.ts
+++ b/miniapp/tests-e2e/fixtures.ts
@@ -1,0 +1,105 @@
+import { createRequire } from "module";
+import { test as base, expect, type Page, type Request } from "@playwright/test";
+
+const require = createRequire(import.meta.url);
+const telegramStubPath = require.resolve("./helpers/telegram-stub.js");
+
+export const test = base;
+export { expect };
+
+export interface MockApiResponse {
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+export type MockApiHandler = MockApiResponse | ((request: Request) => Promise<MockApiResponse> | MockApiResponse);
+
+export type MockApiHandlers = Record<string, MockApiHandler>;
+
+function patternToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const withWildcards = escaped.replace(/\\\*/g, ".*");
+  return new RegExp(`^${withWildcards}$`);
+}
+
+interface ParsedPattern {
+  method?: string;
+  regex: RegExp;
+}
+
+function parsePattern(pattern: string): ParsedPattern {
+  const trimmed = pattern.trim();
+  const parts = trimmed.split(/\s+/);
+  if (parts.length > 1 && /^[A-Z]+$/.test(parts[0])) {
+    const [method, ...rest] = parts;
+    return { method, regex: patternToRegex(rest.join(" ")) };
+  }
+  return { regex: patternToRegex(trimmed) };
+}
+
+function normalizeUrl(url: string): string {
+  const parsed = new URL(url);
+  return `${parsed.pathname}${parsed.search}`;
+}
+
+export async function mockApi(page: Page, handlers: MockApiHandlers): Promise<void> {
+  await page.route("**/api/**", async (route, request) => {
+    const target = normalizeUrl(request.url());
+    const method = request.method();
+    const entry = Object.entries(handlers).find(([pattern]) => {
+      const { method: expectedMethod, regex } = parsePattern(pattern);
+      if (expectedMethod && expectedMethod.toUpperCase() !== method.toUpperCase()) {
+        return false;
+      }
+      return regex.test(target);
+    });
+    if (!entry) {
+      await route.fulfill({
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: `Unhandled API request: ${method} ${target}` })
+      });
+      return;
+    }
+    const [, handler] = entry;
+    const response = typeof handler === "function" ? await handler(request) : handler;
+    const status = response.status ?? 200;
+    const headers = {
+      ...(response.body !== undefined ? { "Content-Type": "application/json" } : {}),
+      ...(response.headers ?? {})
+    };
+    const bodyValue = response.body;
+    await route.fulfill({
+      status,
+      headers,
+      body: bodyValue === undefined ? undefined : typeof bodyValue === "string" ? bodyValue : JSON.stringify(bodyValue)
+    });
+  });
+}
+
+export async function setStartParam(page: Page, value: string): Promise<void> {
+  await page.addInitScript((startParam) => {
+    const global = window as typeof window & {
+      Telegram?: { WebApp?: { initData?: string; initDataUnsafe?: Record<string, unknown> } };
+    };
+    const namespace = (global.Telegram = global.Telegram || {});
+    namespace.WebApp = namespace.WebApp || { initData: "", initDataUnsafe: {} };
+    const webApp = namespace.WebApp;
+    const params = new URLSearchParams(webApp.initData || "");
+    if (startParam) {
+      params.set("start_param", startParam);
+    } else {
+      params.delete("start_param");
+    }
+    webApp.initData = params.toString();
+    webApp.initDataUnsafe = {
+      ...(webApp.initDataUnsafe || {}),
+      start_param: startParam
+    };
+  }, value);
+}
+
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript({ path: telegramStubPath });
+});

--- a/miniapp/tests-e2e/helpers/telegram-stub.js
+++ b/miniapp/tests-e2e/helpers/telegram-stub.js
@@ -1,0 +1,12 @@
+(() => {
+  window.Telegram = window.Telegram || {};
+  window.Telegram.WebApp = {
+    initData: "user=%7B%22id%22%3A7446417641%2C%22username%22%3A%22test%22%7D&auth_date=1700000000&hash=stub",
+    initDataUnsafe: { user: { id: 7446417641, username: "test" }, start_param: "" },
+    ready: () => {},
+    expand: () => {},
+    themeParams: {},
+    MainButton: { show: () => {}, hide: () => {}, text: "" },
+    BackButton: { show: () => {}, hide: () => {} }
+  };
+})();

--- a/miniapp/tests-e2e/import.spec.ts
+++ b/miniapp/tests-e2e/import.spec.ts
@@ -1,0 +1,91 @@
+import { mockApi, expect, test, type MockApiHandlers } from "./fixtures";
+import { mockAuthOk, mockImportByUrl, mockImportCsv } from "./mocks";
+
+function createBaseHandlers(): MockApiHandlers {
+  return {
+    ...mockAuthOk(),
+    "GET /api/reports/portfolio*": (request) => {
+      expect(request.headers()["authorization"]).toMatch(/^Bearer\s+/);
+      return {
+        body: {
+          summary: {
+            totalValue: 15000,
+            realizedPnl: 250,
+            unrealizedPnl: 125
+          },
+          generatedAt: "2024-04-03T08:00:00Z"
+        }
+      };
+    },
+    "GET /api/quotes*": (request) => {
+      expect(request.headers()["authorization"]).toMatch(/^Bearer\s+/);
+      return {
+        body: [
+          { instrumentId: "AAPL", price: 172, changePct: 0.02, updatedAt: "2024-04-03T07:58:00Z" }
+        ]
+      };
+    }
+  };
+}
+
+test.describe("import", () => {
+  const portfolioId = "123e4567-e89b-12d3-a456-426614174000";
+
+  test("imports CSV file end-to-end", async ({ page }) => {
+    const handlers = {
+      ...createBaseHandlers(),
+      ...mockImportCsv()
+    };
+
+    await mockApi(page, handlers);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Import", exact: true }).click();
+
+    await page.fill("#import-portfolio-id", portfolioId);
+
+    const csvContent = [
+      "datetime,ticker,exchange,side,quantity,price,currency",
+      "2024-01-01T10:00:00Z,AAPL,NASDAQ,buy,10,150,USD"
+    ].join("\n");
+
+    await page.setInputFiles("input[type=\"file\"]", {
+      name: "trades.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csvContent, "utf-8")
+    });
+
+    await expect(page.getByText("Preview:")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Map CSV columns" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Save mapping" }).click();
+    await page.getByRole("button", { name: "Upload CSV" }).click();
+
+    await expect(page.getByRole("heading", { name: "Import report" })).toBeVisible();
+    await expect(page.getByText(/Inserted: 2/)).toBeVisible();
+    await expect(page.getByText(/Skipped duplicates: 0/)).toBeVisible();
+  });
+
+  test("imports trades by URL", async ({ page }) => {
+    const handlers = {
+      ...createBaseHandlers(),
+      ...mockImportByUrl()
+    };
+
+    await mockApi(page, handlers);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Import", exact: true }).click();
+
+    await page.fill("#import-portfolio-id", portfolioId);
+
+    await page.getByRole("button", { name: "By URL" }).click();
+
+    const csvUrl = "https://example.com/export.csv";
+    await page.fill("#import-url", csvUrl);
+    await page.getByRole("button", { name: "Import from URL" }).click();
+
+    await expect(page.getByRole("heading", { name: "Import report" })).toBeVisible();
+    await expect(page.getByText(/Inserted: 2/)).toBeVisible();
+  });
+});

--- a/miniapp/tests-e2e/mocks.ts
+++ b/miniapp/tests-e2e/mocks.ts
@@ -1,0 +1,189 @@
+import type { Request } from "@playwright/test";
+import { expect } from "./fixtures";
+import type { MockApiHandlers, MockApiResponse } from "./fixtures";
+
+interface Position {
+  instrumentId: string;
+  qty: number;
+  avgPrice: number;
+  lastPrice: number;
+  upl: number;
+}
+
+interface Trade {
+  id: string;
+  instrumentId: string;
+  qty: number;
+  price: number;
+  side: "buy" | "sell";
+  executedAt: string;
+}
+
+interface TradesResponse {
+  total: number;
+  limit: number;
+  offset: number;
+  items: Trade[];
+}
+
+interface ImportReport {
+  inserted: number;
+  skippedDuplicates: number;
+  failed: Array<{ line: number; error: string }>;
+}
+
+export interface MockAuthOptions {
+  tokens?: string[];
+  onRequest?: (request: Request, issuedToken: string, call: number) => void;
+}
+
+export function mockAuthOk(options: MockAuthOptions = {}): MockApiHandlers {
+  const tokens = options.tokens && options.tokens.length > 0 ? options.tokens : ["TEST_JWT"];
+  let call = 0;
+  return {
+    "POST /api/auth/telegram/verify": (request) => {
+      const index = Math.min(call, tokens.length - 1);
+      const token = tokens[index];
+      call += 1;
+      options.onRequest?.(request, token, call);
+      return {
+        body: {
+          token,
+          expiresAt: "2099-01-01T00:00:00Z",
+          user: { id: 7446417641 }
+        }
+      };
+    }
+  };
+}
+
+interface PositionsMockOptions {
+  positions?: Position[];
+  expectedToken?: string | ((call: number) => string | null);
+  onCall?: (request: Request, call: number) => MockApiResponse | void;
+}
+
+const defaultPositions: Position[] = [
+  { instrumentId: "AAPL", qty: 10, avgPrice: 150, lastPrice: 155, upl: 50 },
+  { instrumentId: "TSLA", qty: 4, avgPrice: 210, lastPrice: 215, upl: 20 }
+];
+
+export function mockPositions(options: PositionsMockOptions = {}): MockApiHandlers {
+  let call = 0;
+  return {
+    "GET /api/positions": (request) => {
+      call += 1;
+      const expected = options.expectedToken
+        ? typeof options.expectedToken === "function"
+          ? options.expectedToken(call)
+          : options.expectedToken
+        : undefined;
+      const header = request.headers()["authorization"];
+      if (expected === null) {
+        expect(header, "Authorization header should be absent").toBeFalsy();
+      } else if (expected) {
+        expect(header, "Authorization header must match expected token").toBe(`Bearer ${expected}`);
+      } else {
+        expect(header, "Authorization header must be set").toMatch(/^Bearer\s+/);
+      }
+      const override = options.onCall?.(request, call);
+      if (override) {
+        return override;
+      }
+      return { body: options.positions ?? defaultPositions };
+    }
+  };
+}
+
+interface TradesMockOptions {
+  response?: TradesResponse;
+  expectedToken?: string;
+}
+
+const defaultTrades: TradesResponse = {
+  total: 1,
+  limit: 20,
+  offset: 0,
+  items: [
+    {
+      id: "trade-1",
+      instrumentId: "AAPL",
+      qty: 10,
+      price: 152,
+      side: "buy",
+      executedAt: "2024-01-01T10:00:00Z"
+    }
+  ]
+};
+
+export function mockTrades(options: TradesMockOptions = {}): MockApiHandlers {
+  return {
+    "GET /api/trades*": (request) => {
+      const header = request.headers()["authorization"];
+      if (options.expectedToken) {
+        expect(header, "Authorization header must match expected token").toBe(`Bearer ${options.expectedToken}`);
+      } else {
+        expect(header, "Authorization header must be set").toMatch(/^Bearer\s+/);
+      }
+      return { body: options.response ?? defaultTrades };
+    }
+  };
+}
+
+interface ImportMockOptions {
+  expectedToken?: string;
+  report?: ImportReport;
+}
+
+const defaultImportReport: ImportReport = {
+  inserted: 2,
+  skippedDuplicates: 0,
+  failed: []
+};
+
+export function mockImportCsv(options: ImportMockOptions = {}): MockApiHandlers {
+  return {
+    "POST /api/portfolio/*/trades/import/csv": (request) => {
+      const header = request.headers()["authorization"];
+      if (options.expectedToken) {
+        expect(header, "Authorization header must match expected token").toBe(`Bearer ${options.expectedToken}`);
+      } else {
+        expect(header, "Authorization header must be set").toMatch(/^Bearer\s+/);
+      }
+      const body = request.postDataBuffer();
+      expect(body, "CSV import must send multipart payload").toBeTruthy();
+      const contentType = request.headers()["content-type"];
+      expect(contentType, "CSV import must use multipart/form-data").toContain("multipart/form-data");
+      return { body: options.report ?? defaultImportReport };
+    }
+  };
+}
+
+export function mockImportByUrl(options: ImportMockOptions = {}): MockApiHandlers {
+  return {
+    "POST /api/portfolio/*/trades/import/by-url": (request) => {
+      const header = request.headers()["authorization"];
+      if (options.expectedToken) {
+        expect(header, "Authorization header must match expected token").toBe(`Bearer ${options.expectedToken}`);
+      } else {
+        expect(header, "Authorization header must be set").toMatch(/^Bearer\s+/);
+      }
+      const payload = request.postData();
+      expect(payload, "Import by URL payload must be JSON").toBeTruthy();
+      if (payload) {
+        const parsed = JSON.parse(payload) as { url?: string };
+        expect(parsed.url, "Import URL must be provided").toBeTruthy();
+      }
+      return { body: options.report ?? defaultImportReport };
+    }
+  };
+}
+
+export function mock401(pattern: string, message = "Unauthorized"): MockApiHandlers {
+  return {
+    [pattern]: {
+      status: 401,
+      body: { message }
+    }
+  };
+}

--- a/miniapp/tests-e2e/navigation.spec.ts
+++ b/miniapp/tests-e2e/navigation.spec.ts
@@ -1,0 +1,85 @@
+import { mockApi, expect, test, type MockApiHandlers } from "./fixtures";
+import { mockAuthOk, mockPositions, mockTrades } from "./mocks";
+
+function createSharedHandlers(): MockApiHandlers {
+  return {
+    ...mockAuthOk(),
+    ...mockPositions(),
+    ...mockTrades(),
+    "GET /api/reports/portfolio*": (request) => {
+      expect(request.headers()["authorization"]).toMatch(/^Bearer\s+/);
+      return {
+        body: {
+          summary: {
+            totalValue: 14250,
+            realizedPnl: 210,
+            unrealizedPnl: 95
+          },
+          generatedAt: "2024-04-02T11:00:00Z"
+        }
+      };
+    },
+    "GET /api/quotes*": (request) => {
+      expect(request.headers()["authorization"]).toMatch(/^Bearer\s+/);
+      return {
+        body: [
+          { instrumentId: "AAPL", price: 170, changePct: 0.01, updatedAt: "2024-04-02T10:55:00Z" },
+          { instrumentId: "TSLA", price: 215, changePct: -0.02, updatedAt: "2024-04-02T10:54:00Z" }
+        ]
+      };
+    }
+  };
+}
+
+test.describe("navigation", () => {
+  test("tab bar routes between primary views", async ({ page }) => {
+    await page.addInitScript(() => {
+      const global = window as typeof window & {
+        Telegram?: { WebApp?: { initData?: string; initDataUnsafe?: Record<string, unknown> } };
+      };
+      const namespace = (global.Telegram = global.Telegram || {});
+      if (!namespace.WebApp) {
+        namespace.WebApp = {
+          initData:
+            "user=%7B%22id%22%3A7446417641%2C%22username%22%3A%22test%22%7D&auth_date=1700000000&hash=stub",
+          initDataUnsafe: { user: { id: 7446417641, username: "test" }, start_param: "" },
+          ready: () => {},
+          expand: () => {},
+          themeParams: {},
+          MainButton: { show: () => {}, hide: () => {}, text: "" },
+          BackButton: { show: () => {}, hide: () => {} }
+        };
+      }
+    });
+
+    await mockApi(page, createSharedHandlers());
+
+    await page.goto("/");
+
+    await expect(page).toHaveURL(/\/?$/);
+    await page.locator("nav.tab-bar").waitFor({ state: "visible", timeout: 7000 });
+    await expect(page.getByRole("heading", { level: 2, name: "Portfolio overview" })).toBeVisible({ timeout: 7000 });
+
+    await page.getByRole("button", { name: "Positions", exact: true }).click();
+    await expect(page).toHaveURL(/\/positions$/);
+    await expect(page.getByRole("heading", { level: 2, name: "Positions" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "AAPL" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Trades", exact: true }).click();
+    await expect(page).toHaveURL(/\/trades$/);
+    await expect(page.getByRole("heading", { level: 2, name: "Trades" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "buy" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Import", exact: true }).click();
+    await expect(page).toHaveURL(/\/import$/);
+    await expect(page.getByRole("heading", { level: 2, name: "Import trades" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Reports", exact: true }).click();
+    await expect(page).toHaveURL(/\/reports$/);
+    await expect(page.getByRole("heading", { level: 2, name: "Reports" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Settings", exact: true }).click();
+    await expect(page).toHaveURL(/\/settings$/);
+    await expect(page.getByRole("heading", { level: 2, name: "Settings" })).toBeVisible();
+  });
+});

--- a/miniapp/tests-e2e/start-param.spec.ts
+++ b/miniapp/tests-e2e/start-param.spec.ts
@@ -1,0 +1,41 @@
+import { mockApi, expect, test, setStartParam, type MockApiHandlers } from "./fixtures";
+import { mockAuthOk } from "./mocks";
+
+function createHandlers(): MockApiHandlers {
+  return {
+    ...mockAuthOk(),
+    "GET /api/reports/portfolio*": (request) => {
+      expect(request.headers()["authorization"]).toMatch(/^Bearer\s+/);
+      return {
+        body: {
+          summary: {
+            totalValue: 16000,
+            realizedPnl: 400,
+            unrealizedPnl: 210
+          },
+          generatedAt: "2024-04-04T12:00:00Z"
+        }
+      };
+    },
+    "GET /api/quotes*": (request) => {
+      expect(request.headers()["authorization"]).toMatch(/^Bearer\s+/);
+      return {
+        body: [
+          { instrumentId: "AAPL", price: 174, changePct: 0.015, updatedAt: "2024-04-04T11:55:00Z" }
+        ]
+      };
+    }
+  };
+}
+
+test.describe("start_param", () => {
+  test("opens Import tab when start_param specifies tab=import", async ({ page }) => {
+    await setStartParam(page, "tab=import");
+    await mockApi(page, createHandlers());
+
+    await page.goto("/");
+
+    await page.waitForURL(/\/import$/);
+    await expect(page.getByRole("heading", { name: "Import trades" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright configuration, fixtures, mocks, and end-to-end specs covering auth, navigation, import, and start parameter flows
- update miniapp package scripts, environment example, and documentation for the new test suite
- configure CI workflow to run Playwright tests with cached pnpm dependencies and publish reports

## Testing
- pnpm build
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d885b583c4832197410a06aa5d7ab7