### PR TITLE
Add monitoring stack with Prometheus Grafana and alerts

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,0 +1,43 @@
+name: Monitoring Validation
+
+on:
+  push:
+    paths:
+      - 'deploy/monitoring/**'
+      - '.github/workflows/monitoring.yml'
+  pull_request:
+    paths:
+      - 'deploy/monitoring/**'
+      - '.github/workflows/monitoring.yml'
+
+jobs:
+  promlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate monitoring files exist
+        run: |
+          for file in \
+            deploy/monitoring/docker-compose.monitoring.yml \
+            deploy/monitoring/prometheus/prometheus.yml \
+            deploy/monitoring/prometheus/alerts.rules.yml \
+            deploy/monitoring/alertmanager/alertmanager.yml; do
+            if [ ! -s "$file" ]; then
+              echo "Missing required file: $file" >&2
+              exit 1
+            fi
+          done
+
+      - name: Basic YAML validation
+        run: |
+          sudo apt-get update && sudo apt-get install -y yamllint
+          yamllint -d '{extends: default, rules: {line-length: disable}}' \
+            deploy/monitoring/docker-compose.monitoring.yml \
+            deploy/monitoring/prometheus/prometheus.yml \
+            deploy/monitoring/prometheus/alerts.rules.yml \
+            deploy/monitoring/alertmanager/alertmanager.yml \
+            deploy/monitoring/grafana/provisioning/datasources/datasource.yml \
+            deploy/monitoring/grafana/provisioning/dashboards/dashboards.yml \
+            .github/workflows/monitoring.yml

--- a/README.md
+++ b/README.md
@@ -360,5 +360,39 @@ curl -s -H "Authorization: Bearer $JWT" \
 ## DoD (Definition of Done)
 - `docker build` успешен; `docker compose up -d` поднимает `db/app/nginx` (`healthy`).
 - `/healthz` и `/metrics` доступны через `nginx`.
-- `setWebhook` срабатывает; Ktor получает запросы по HTTPS (TLS терминация в Nginx).  
+- `setWebhook` срабатывает; Ktor получает запросы по HTTPS (TLS терминация в Nginx).
 - Файлы сгенерированы строго в формате для автосоздания PR.
+
+## P21 — Monitoring (Prometheus + Grafana + Alertmanager)
+
+### 1) Поднять app/db/nginx (P14)
+
+```bash
+docker compose -f deploy/compose/docker-compose.yml up -d
+```
+
+### 2) Поднять monitoring (в той же сети compose_default)
+
+```bash
+cd deploy/monitoring
+cp .env.example .env
+docker compose -f docker-compose.monitoring.yml up -d
+```
+
+### 3) Открыть Grafana
+
+Откройте http://localhost:3000 и авторизуйтесь с `admin / $GF_SECURITY_ADMIN_PASSWORD`.
+
+### 4) Dashboard
+
+Дашборд "NewsBot / Observability" импортируется автоматически.
+
+### 5) Alerts
+
+Проверьте состояние алёртов в Prometheus: http://localhost:9090/alerts.
+
+### Примечания
+
+- Сеть `compose_default` должна существовать (поднимайте app-compose перед monitoring).
+- В бою меняйте пароли и webhook-URL через переменные окружения или секрет-менеджер.
+- Метрики webhook/duplicates требуют инкремента соответствующих счётчиков в коде (если ещё не сделано).

--- a/deploy/monitoring/.env.example
+++ b/deploy/monitoring/.env.example
@@ -1,0 +1,3 @@
+GF_SECURITY_ADMIN_PASSWORD=replace_me
+ALERT_WEBHOOK_URL=http://example.com/hook
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/XXXXX

--- a/deploy/monitoring/alertmanager/alertmanager.yml
+++ b/deploy/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,26 @@
+route:
+  receiver: null-receiver
+  group_by: ['alertname']
+  group_wait: 10s
+  group_interval: 5m
+  repeat_interval: 2h
+  routes:
+    - matchers:
+        - severity="critical"
+      receiver: slack
+      continue: false
+    - receiver: webhook
+
+receivers:
+  - name: null-receiver
+  - name: webhook
+    webhook_configs:
+      - url: ${ALERT_WEBHOOK_URL:-http://example.com/hook}
+  - name: slack
+    slack_configs:
+      - api_url: ${SLACK_WEBHOOK_URL:-https://hooks.slack.com/services/T000/B000/XXXXX}
+        send_resolved: true
+        title: '{{ template "slack.default.title" . }}'
+        text: '{{ template "slack.default.text" . }}'
+
+templates: []

--- a/deploy/monitoring/docker-compose.monitoring.yml
+++ b/deploy/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,64 @@
+version: "3.9"
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.0
+    restart: unless-stopped
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=15d"
+      - "--storage.tsdb.wal-compression"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts.rules.yml:/etc/prometheus/alerts.rules.yml:ro
+    ports:
+      - "9090:9090"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+    networks:
+      - compose_default
+
+  alertmanager:
+    image: prom/alertmanager:v0.26.0
+    restart: unless-stopped
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    ports:
+      - "9093:9093"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+    networks:
+      - compose_default
+
+  grafana:
+    image: grafana/grafana:10.4.3
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    networks:
+      - compose_default
+
+networks:
+  compose_default:
+    external: true

--- a/deploy/monitoring/grafana/dashboards/newsbot-observability.json
+++ b/deploy/monitoring/grafana/dashboards/newsbot-observability.json
@@ -1,0 +1,557 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\", uri!~\"/metrics\"}[$__rate_interval])))",
+          "interval": "",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\", uri!~\"/metrics\"}[$__rate_interval])))",
+          "interval": "",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\", uri!~\"/metrics\"}[$__rate_interval])))",
+          "interval": "",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "API Latency (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\", uri=~\"$uri\"}[$__rate_interval])))",
+          "interval": "",
+          "legendFormat": "p95 {{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook Latency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "lineWidth": 2
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=~\"$job\", status=~\"2..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])), 1e-9)",
+          "format": "time_series",
+          "legendFormat": "2xx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=~\"$job\", status=~\"4..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])), 1e-9)",
+          "format": "time_series",
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=~\"$job\", status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])), 1e-9)",
+          "format": "time_series",
+          "legendFormat": "5xx",
+          "refId": "C"
+        }
+      ],
+      "title": "HTTP Status Code Rate (%)",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "lineWidth": 2
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "increase(webhook_stars_success_total{job=~\"$job\"}[$__rate_interval])",
+          "legendFormat": "Success",
+          "refId": "A"
+        },
+        {
+          "expr": "increase(webhook_stars_duplicate_total{job=~\"$job\"}[$__rate_interval])",
+          "legendFormat": "Duplicates",
+          "refId": "B"
+        }
+      ],
+      "title": "Stars Success vs Duplicates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(domain_observability_alerts_push_total{job=~\"$job\"}[$__rate_interval]))",
+          "legendFormat": "Alerts pushed",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(domain_observability_budget_reject_total{job=~\"$job\"}[$__rate_interval]))",
+          "legendFormat": "Budget rejects",
+          "refId": "B"
+        }
+      ],
+      "title": "Alerts Push / Budget Rejects",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{job=~\"$job\", area=\"heap\"})",
+          "legendFormat": "Heap Used",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(jvm_memory_max_bytes{job=~\"$job\", area=\"heap\"})",
+          "legendFormat": "Heap Max",
+          "refId": "B"
+        }
+      ],
+      "title": "JVM Heap Usage",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "If JVM thread metrics are unavailable, enable Micrometer JVM metrics in the application.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(jvm_threads_live_threads{job=~\"$job\"})",
+          "legendFormat": "Live",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(jvm_threads_peak_threads{job=~\"$job\"})",
+          "legendFormat": "Peak",
+          "refId": "B"
+        }
+      ],
+      "title": "JVM Threads",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "newsbot"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_requests_seconds_count, job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": "label_values(http_server_requests_seconds_count, job)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "/telegram/webhook",
+          "value": "/telegram/webhook"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_requests_seconds_bucket{job=~\"$job\", uri!~\"/metrics\"}, uri)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "URI",
+        "multi": false,
+        "name": "uri",
+        "options": [],
+        "query": "label_values(http_server_requests_seconds_bucket{job=~\"$job\", uri!~\"/metrics\"}, uri)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "15s",
+        "current": {
+          "selected": false,
+          "text": "auto",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Interval",
+        "name": "__interval",
+        "options": [
+          {
+            "selected": true,
+            "text": "auto",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "1h",
+      "6h"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "NewsBot / Observability",
+  "uid": "newsbot-observability",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources: []
+
+dashboardProviders:
+  - name: newsbot-dashboards
+    orgId: 1
+    folder: NewsBot
+    type: file
+    disableDeletion: false
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/deploy/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/deploy/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/monitoring/prometheus/alerts.rules.yml
+++ b/deploy/monitoring/prometheus/alerts.rules.yml
@@ -1,0 +1,91 @@
+groups:
+  - name: newsbot.rules
+    rules:
+      - alert: WebhookP95High
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(http_server_requests_seconds_bucket{job="app", uri="/telegram/webhook"}[5m])
+            )
+          ) > 1.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Webhook /telegram/webhook latency p95 is high"
+          description: |
+            The 95th percentile latency for /telegram/webhook is above 1.5s for more than 5 minutes.
+      - alert: WebhookP95High
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(http_server_requests_seconds_bucket{job="app", uri="/telegram/webhook"}[5m])
+            )
+          ) > 3
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Webhook /telegram/webhook latency p95 is critically high"
+          description: |
+            The 95th percentile latency for /telegram/webhook is above 3s for more than 5 minutes.
+
+      - alert: Http5xxRateHigh
+        expr: |
+          (
+            sum(rate(http_server_requests_seconds_count{job="app", status=~"5.."}[5m]))
+            /
+            clamp_min(sum(rate(http_server_requests_seconds_count{job="app"}[5m])), 1e-9)
+          ) > 0.02
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "HTTP 5xx error rate is elevated"
+          description: |
+            More than 2% of HTTP responses over the last 5 minutes are 5xx errors.
+      - alert: Http5xxRateHigh
+        expr: |
+          (
+            sum(rate(http_server_requests_seconds_count{job="app", status=~"5.."}[5m]))
+            /
+            clamp_min(sum(rate(http_server_requests_seconds_count{job="app"}[5m])), 1e-9)
+          ) > 0.04
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "HTTP 5xx error rate is critically high"
+          description: |
+            More than 4% of HTTP responses over the last 5 minutes are 5xx errors.
+
+      - alert: StarsDuplicateRateHigh
+        expr: |
+          (
+            increase(webhook_stars_duplicate_total{job="app"}[5m])
+            /
+            clamp_min(increase(webhook_stars_success_total{job="app"}[5m]), 1e-9)
+          ) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Duplicate star payments rate is elevated"
+          description: |
+            Duplicate webhook star payments exceed 1% of successful payments over the last 5 minutes.
+      - alert: StarsDuplicateRateHigh
+        expr: |
+          (
+            increase(webhook_stars_duplicate_total{job="app"}[5m])
+            /
+            clamp_min(increase(webhook_stars_success_total{job="app"}[5m]), 1e-9)
+          ) > 0.02
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Duplicate star payments rate is critically high"
+          description: |
+            Duplicate webhook star payments exceed 2% of successful payments over the last 5 minutes.

--- a/deploy/monitoring/prometheus/prometheus.yml
+++ b/deploy/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - alerts.rules.yml
+
+scrape_configs:
+  - job_name: app
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - newsbot-app:8080
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093


### PR DESCRIPTION
## Summary
- add docker compose stack for Prometheus, Grafana, and Alertmanager connected to the existing application network
- configure Prometheus scrapes, alerting rules, and Alertmanager routing for latency, error-rate, and duplicate-payment SLOs
- provision Grafana datasources/dashboards and document monitoring bootstrap steps including sample CI validation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d894486e608321baeeb3566cbf3f0d