### PR TITLE
Add SLA/SLO policy and runbooks for reliability operations

### DIFF
--- a/.github/workflows/sre-docs.yml
+++ b/.github/workflows/sre-docs.yml
@@ -1,0 +1,58 @@
+name: SRE Docs Validation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Verify required files
+        shell: bash
+        run: |
+          set -euo pipefail
+          required=(
+            docs/SLA_SLO_POLICY.md
+            docs/INCIDENT_RESPONSE.md
+            docs/ONCALL_ROTATION.md
+            docs/RUNBOOKS/WEBHOOK_XTR.md
+            docs/RUNBOOKS/API_5XX.md
+            docs/RUNBOOKS/DUPLICATE_PAYMENTS.md
+            docs/RUNBOOKS/IMPORT_DOS.md
+            docs/RUNBOOKS/ALERTS_NOISE.md
+            docs/TEMPLATES/INCIDENT_TEMPLATE.md
+            docs/TEMPLATES/POSTMORTEM_TEMPLATE.md
+            tools/sre/sli_query.sh
+            tools/sre/incident_new.sh
+          )
+          missing=false
+          for path in "${required[@]}"; do
+            if [[ ! -f "$path" ]]; then
+              echo "::error::missing required file: $path"
+              missing=true
+            fi
+          done
+          if [[ "$missing" == true ]]; then
+            exit 1
+          fi
+
+      - name: Shell lint SRE scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash -n tools/sre/sli_query.sh
+          bash -n tools/sre/incident_new.sh
+
+      - name: Ensure docs do not contain TODO markers
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -R "TODO" docs; then
+            echo "::error::TODO marker found in docs"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -396,3 +396,24 @@ docker compose -f docker-compose.monitoring.yml up -d
 - Сеть `compose_default` должна существовать (поднимайте app-compose перед monitoring).
 - В бою меняйте пароли и webhook-URL через переменные окружения или секрет-менеджер.
 - Метрики webhook/duplicates требуют инкремента соответствующих счётчиков в коде (если ещё не сделано).
+
+## P22 — SLA/SLO & Runbooks
+
+### Ресурсы
+- `docs/SLA_SLO_POLICY.md` — политика SLA/SLO/SLI, error budget, связи с `deploy/monitoring/prometheus/alerts.rules.yml`.
+- `docs/INCIDENT_RESPONSE.md` — роли, матрица эскалации, шаблоны коммуникаций.
+- `docs/RUNBOOKS/` — операционные инструкции для webhook latency, HTTP 5xx, дубликатов платежей, DoS на импорт и шумных алертов.
+- `docs/TEMPLATES/` — шаблоны инцидентов и пост-мортемов.
+- `docs/ONCALL_ROTATION.md` — расписание on-call и handoff чек-лист.
+
+### Быстрые команды
+```bash
+# Новый инцидент (каркас)
+bash tools/sre/incident_new.sh "webhook-xtr-latency"
+# Запрос SLI к Prometheus
+PROM_URL=http://localhost:9090 bash tools/sre/sli_query.sh webhook_p95 5m
+```
+
+### Monitoring Stack
+- Используйте инструкции раздела P21 (выше) для запуска Prometheus/Grafana (`deploy/monitoring/docker-compose.monitoring.yml`).
+- Дашборд: Grafana → "NewsBot / Observability" (включает метрики SLO).

--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -1,0 +1,50 @@
+# Incident Response Guide
+
+## Severity Levels
+| Severity | Criteria | Examples |
+| --- | --- | --- |
+| **SEV-1** | Критичная деградация, ≥50% error budget расходуется за сутки, критические алерты `WebhookP95High` или `Http5xxRateHigh` >5% более 10 мин, массовые двойные платежи. | `/telegram/webhook` недоступен, HTTP 5xx >10%, DoS на импорт блокирует всех клиентов. |
+| **SEV-2** | Умеренная деградация, заметный рост ошибок, warning-уровни алертов дольше 15 мин, влияние на часть пользователей. | HTTP 5xx 2–10%, задержки webhook >1.5 s, дубликаты 1–2%. |
+| **SEV-3** | Ограниченные сбои, деградация не влияет на большинство пользователей, быстрый авто-восстановление. | Импорт by-url медленный, локальные шумовые алерты. |
+
+## Roles & Responsibilities
+- **Incident Commander (IC)** — управляет расследованием, держит контакт с заинтересованными сторонами, следит за временем реакции.
+- **Communications Lead** — готовит и распространяет сообщения (Slack статус, внешние апдейты).
+- **Ops/SRE** — проводит техническую диагностику, применяет mitigation, обновляет Grafana/Prometheus настройки.
+- **App Owner** — владеет соответствующим модулем (`billing`, `alerts`, `news`), реализует фиксы и кодовые изменения.
+
+## Escalation Matrix
+| Severity | Slack Channel | Alertmanager Route | Первичное реагирование |
+| --- | --- | --- | --- |
+| SEV-1 | `#newsbot-incident` + `@oncall-sre` | `route: webhook` (critical) | 5 минут для подтверждения, IC обязателен |
+| SEV-2 | `#newsbot-incident` | `route: webhook` (warning) | 15 минут для подтверждения |
+| SEV-3 | `#newsbot-reliability` | `route: webhook` (info) | 60 минут, возможно асинхронно |
+
+## Escalation Steps
+1. Alertmanager отправляет уведомление в указанный Slack.
+2. On-call подтверждает алерт и сообщает «Investigating ...».
+3. IC назначает роли (Communications, Ops/SRE, App Owner).
+4. Если требуется внешняя коммуникация, Communications Lead готовит сообщение согласно шаблону.
+
+## Communication Templates
+### Internal (Slack)
+```
+[INCIDENT][SEV-x] <краткое описание>
+Start: <UTC time>
+Owner: <IC>
+Impact: <кратко>
+Next update: <+30m>
+```
+
+### External Status (если требуется)
+```
+Incident: <summary>
+Impact: Users may experience <description>.
+Mitigation: We are actively working on remediation.
+Next update: <time>
+```
+
+## Post-Incident
+- Заполнить `docs/TEMPLATES/INCIDENT_TEMPLATE.md` (первичный отчёт) и `docs/TEMPLATES/POSTMORTEM_TEMPLATE.md` при SEV-1/2.
+- Обновить расход error budget в `docs/SLA_SLO_POLICY.md` и on-call handoff.
+- Создать задачи на follow-up в backlog (P0/P1/P2) с назначенными ответственными.

--- a/docs/ONCALL_ROTATION.md
+++ b/docs/ONCALL_ROTATION.md
@@ -1,0 +1,30 @@
+# On-call Rotation — News Bot
+
+## Schedule
+| Week (UTC) | Primary (role email) | Secondary | Timezone |
+| --- | --- | --- | --- |
+| 2024-W40 | oncall-sre@newsbot.example | sre-backup@newsbot.example | UTC+1 |
+| 2024-W41 | oncall-sre@newsbot.example | sre-backup@newsbot.example | UTC+1 |
+| 2024-W42 | sre-rotation-3@newsbot.example | sre-backup@newsbot.example | UTC+3 |
+| 2024-W43 | sre-rotation-4@newsbot.example | sre-backup@newsbot.example | UTC+3 |
+
+- Ротация недельная, hand-off каждый понедельник 09:00 UTC.
+- Используются роли email/Slack (`@oncall-sre`), персональные контакты не публикуются.
+
+## Handoff Checklist
+- [ ] Просмотреть `NewsBot / Observability` dashboard (webhook latency, HTTP 5xx, duplicates).
+- [ ] Проверить Alertmanager muted windows и снять временные mute, если срок истёк.
+- [ ] Обновить список открытых инцидентов и их статус в `incidents/` каталоге.
+- [ ] Проверить расход error budget за прошедшую неделю (`docs/SLA_SLO_POLICY.md`).
+- [ ] Прогнать SRE скрипты (пример ниже) и убедиться, что Prometheus доступен.
+
+## Playbooks & Tools
+- Runbooks: `docs/RUNBOOKS/*`.
+- Incident response: `docs/INCIDENT_RESPONSE.md`.
+- Templates: `docs/TEMPLATES/*`.
+- SRE scripts: `tools/sre/sli_query.sh`, `tools/sre/incident_new.sh`.
+
+## Communication Channels
+- Slack: `#newsbot-incident`, `#newsbot-reliability`.
+- Email: oncall-sre@newsbot.example.
+- Pager routing: Alertmanager webhook → incident tool.

--- a/docs/RUNBOOKS/ALERTS_NOISE.md
+++ b/docs/RUNBOOKS/ALERTS_NOISE.md
@@ -1,0 +1,28 @@
+# Runbook: Alert noise reduction
+
+- **Scenario**: множественные повторяющиеся уведомления `WebhookP95High`, `Http5xxRateHigh`, `StarsDuplicateRateHigh` без фактической деградации.
+- **Impact**: усталость on-call, пропущенные важные события, рост MTTA.
+
+## Диагностика
+1. Проверить историю алертов в Alertmanager (route `webhook`).
+2. Изучить корреляцию с реальными метриками на Grafana dashboard `NewsBot / Observability`.
+3. Сверить настройки в `deploy/monitoring/prometheus/alerts.rules.yml` (пороги, `for` интервал).
+4. Проверить настройки `alerts` модуля (ограничения бюджета пушей `alerts_budget_reject_total`).
+
+## Мгновенные действия
+1. **Quiet hours / Mute**: если совпадает с плановым окном, установите временный mute rule в Alertmanager (≤2 часа, согласовано с Incident Commander).
+2. **Hysteresis**: увеличьте `for:` в нужных правилах (например, с `5m` до `10m`) и задеплойте обновлённый `alerts.rules.yml` через `kubectl apply -f`.
+3. **Budget tuning**: скорректируйте лимиты в конфиге `alerts` сервиса (см. `routes/AlertsSettingsRoutes.kt`) и задокументируйте изменение.
+4. **API Patch**: для тарифов Pro+ доступен `PATCH /api/alerts/settings` — временно увеличьте cooldown и зафиксируйте изменение в тикете.
+
+## Проверки безопасности / compliance
+- Исключить публикацию PII в уведомлениях; используйте агрегированные данные.
+- Убедиться, что настройки и токены не попадают в репозитории/чаты.
+
+## Откат
+- Верните предыдущие значения hysteresis и quiet hours после подтверждения стабильности.
+- Отключите временные mute правила.
+
+## Пост-действия
+- Обновите `docs/SLA_SLO_POLICY.md`, если изменения постоянные.
+- Добавьте Lessons Learned в пост-мортем при частых шумовых инцидентах.

--- a/docs/RUNBOOKS/API_5XX.md
+++ b/docs/RUNBOOKS/API_5XX.md
@@ -1,0 +1,47 @@
+# Runbook: API 5xx rate spike
+
+- **Severity guidance**: SEV-1 при критическом `Http5xxRateHigh` (>5%) дольше 10 минут или множестве URIs; SEV-2 при warning (2–5%) более 15 минут; SEV-3 для кратковременных отклонений.
+- **Impact**: клиенты не могут использовать REST API (`/api/*`), Telegram miniapp и уведомления `alerts` зависают, возможны сбои биллинга.
+
+## Service Level
+- **SLI**: `sum(rate(http_server_requests_seconds_count{status=~"5.."}[5m])) / sum(rate(http_server_requests_seconds_count[5m]))`.
+- **SLO**: ≤ 2% ошибок 5xx на пятиминутный интервал, ≤5% нарушенных интервалов за 28 дней.
+- **Alerts**: `Http5xxRateHigh` warning/critical из `deploy/monitoring/prometheus/alerts.rules.yml`.
+
+## First Response Checklist
+1. Подтвердите алерт в Alertmanager и возьмите роль Incident Commander.
+2. Зафиксируйте время старта и сообщите в `#newsbot-incident` (без PII): «Investigating elevated 5xx rate, scope under analysis».
+
+## Диагностика
+1. **Prometheus**: проверьте общее значение и разбивку по URI:
+   ```promql
+   topk(5, sum by (uri) (rate(http_server_requests_seconds_count{status=~"5.."}[5m])))
+   ```
+2. **SRE скрипт**:
+   ```bash
+   PROM_URL=http://localhost:9090 bash tools/sre/sli_query.sh api_5xx_rate 5m
+   ```
+3. **Логи**:
+   - Локально: `docker compose -f deploy/compose/docker-compose.yml logs -f app | grep "ERROR"`
+   - Prod: `kubectl logs deploy/newsbot-app -c app --since=10m`
+4. **Трассировки по requestId/traceId**:
+   - В логах ищите MDC поля `requestId` (проставляется в `App.kt`).
+   - Используйте `rg "requestId=<ID>" -g"*.log" storage/logs` при наличии сохранённых логов.
+5. **Горячие маршруты**: `curl -s http://<app-host>:8080/metrics | grep http_server_requests_seconds_count{uri=`
+
+## Диагностика причин
+- Проверить базу данных (подключение, миграции) через `docker compose logs db` или `kubectl describe pod <db>`.
+- Сравнить с недавними деплоями (`git log --since=2h app/src/main/kotlin`).
+- Проверить внешние интеграции (см. `integrations` модуль) на таймауты.
+- Оценить, нет ли всплеска трафика из `alerts` (push) или `miniapp`.
+
+## Действия по восстановлению
+1. **Mitigation**: включить rate limiting/feature flag на проблемный роут (`App.kt` + `routes/*`).
+2. **Rollback**: если последние изменения затронули `App.kt` или `routes`, выполните `kubectl rollout undo deploy/newsbot-app`.
+3. **Fix forward**: задеплоить патч с проверками входных данных или повышенными таймаутами.
+4. **Stacktrace dump**: при необходимости снять `jstack` (без PII) и приложить к тикету.
+
+## Post Incident
+- Обновить статус в публичном канале (если SEV-1) через утверждённый шаблон.
+- Заполнить `docs/TEMPLATES/INCIDENT_TEMPLATE.md` и при необходимости пост-мортем.
+- Обновить ошибочные запросы/метрики в Grafana, указать влияние на error budget в `docs/SLA_SLO_POLICY.md`.

--- a/docs/RUNBOOKS/DUPLICATE_PAYMENTS.md
+++ b/docs/RUNBOOKS/DUPLICATE_PAYMENTS.md
@@ -1,0 +1,43 @@
+# Runbook: Duplicate Stars payments
+
+- **Severity guidance**: SEV-1 при `StarsDuplicateRateHigh` critical (>2%) >10 мин; SEV-2 при warning (1–2%); SEV-3 при разовых всплесках.
+- **Impact**: клиенты видят двойные списания или продления подписки; финансовые и compliance риски.
+
+## Service Level
+- **SLI**: `increase(webhook_stars_duplicate_total[5m]) / clamp_min(increase(webhook_stars_success_total[5m]), 1)`.
+- **SLO**: ≤1% дубликатов, допускается ≤5% нарушенных интервалов за 28 дней.
+- **Alerts**: `StarsDuplicateRateHigh` из `deploy/monitoring/prometheus/alerts.rules.yml`.
+
+## First Response Checklist
+1. Подтвердите алерт в Alertmanager, зафиксируйте время начала.
+2. Сообщите Incident Commander и Billing owner в `#newsbot-billing`.
+3. Заморозьте автодеплой биллинга до завершения расследования.
+
+## Диагностика
+1. **Prometheus**: проверьте тренд успехов и дубликатов:
+   ```promql
+   increase(webhook_stars_success_total{job="app"}[5m])
+   increase(webhook_stars_duplicate_total{job="app"}[5m])
+   ```
+2. **Логи StarsWebhookHandler**: `docker compose logs -f app | grep "stars-webhook"` или `kubectl logs ... --since=15m`.
+3. **База данных**: запросите последние платежи, убедитесь, что `provider_payment_charge_id` уникален.
+4. **Скрипт SLI**:
+   ```bash
+   PROM_URL=http://localhost:9090 bash tools/sre/sli_query.sh stars_duplicate_rate 5m
+   ```
+
+## Проверки
+- Убедиться, что `BillingService.applySuccessfulPayment` сохраняет `providerPaymentChargeId` и отвергает дубликаты (`core/src/main/kotlin/billing/service/BillingService.kt`).
+- Проверить идемпотентность webhook в `app/src/main/kotlin/billing/StarsWebhookHandler.kt` (сравнение `providerPaymentChargeId`).
+- Осмотреть журналы `alerts_budget_reject_total` на предмет лимитов, если клиенты повторяют оплату из-за отклонений.
+
+## Действия по восстановлению
+1. **Временный guard**: включить дополнительную проверку в инфраструктуре (например, фильтр на стороне Telegram Bot API, если доступно).
+2. **Компенсации**: сформировать список затронутых пользователей (ID без PII) и передать в финансы для возврата.
+3. **Fix forward**: задеплоить патч, усиливающий уникальность (например, использование `providerPaymentChargeId` + `userId`).
+4. **Rollback**: при необходимости откатить изменения в `BillingService`/`StarsWebhookHandler`.
+
+## Пост-инцидент
+- Обновить клиентов через статус-канал (без раскрытия персональных данных).
+- Заполнить шаблон инцидента и пост-мортема (`docs/TEMPLATES`).
+- Обновить error budget отчёт, указать реальное влияние.

--- a/docs/RUNBOOKS/IMPORT_DOS.md
+++ b/docs/RUNBOOKS/IMPORT_DOS.md
@@ -1,0 +1,37 @@
+# Runbook: Import by URL DoS mitigation
+
+- **Severity guidance**: SEV-1 при массовом отказе `/api/portfolio/{id}/trades/import/by-url` приводящем к деградации всей очереди; SEV-2 при целевом DoS одного клиента; SEV-3 при обнаружении подозрительного источника без видимого ущерба.
+- **Impact**: канал импорта сделок через URL (CSV) блокируется, клиенты не могут обновить портфель, инфраструктура перегружена.
+
+## Контекст
+- Маршрут: `routes/PortfolioImportRoutes.kt` (`post("/api/portfolio/{id}/trades/import/by-url")`).
+- Guard: `security/UploadLimits.kt` (`installUploadGuard()` в `App.kt`).
+
+## First Response Checklist
+1. Подтвердите алерт/инцидент, уведомите Incident Commander.
+2. Включите rate limit через API gateway (если доступно) и зафиксируйте источник (IP/host без PII).
+
+## Диагностика
+1. Проверить логи:
+   ```bash
+   docker compose logs -f app | grep "import-by-url"
+   kubectl logs deploy/newsbot-app -c app --since=10m | grep "import"
+   ```
+2. Проверить размер входящих файлов (метрики UploadGuard, логи с `payload_too_large`).
+3. Проверить очереди задач или нагрузку БД.
+4. Audit логи: убедиться, что PII не сохраняется; фиксируем только хэши URL или ID пользователя.
+
+## Действия по смягчению
+1. **Смещение лимитов UploadGuard**: обновить `upload.csvMaxBytes` в конфиге (через ConfigMap/Secret) и выполнить `kubectl rollout restart deploy/newsbot-app`.
+2. **Блокировка источника**: добавить правило в WAF/ingress для подозрительного домена/IP.
+3. **Временное отключение by-url**: активировать feature flag (env `IMPORT_BY_URL_DISABLED=true`) или временно вернуть HTTP 503. При отсутствии флага — закомментировать маршрут и деплоить hotfix.
+4. **Очистка очереди**: при использовании внешнего сториджа очистить отложенные задания (см. `storage` модуль).
+
+## Восстановление сервиса
+- После снижения нагрузки вернуть лимиты UploadGuard.
+- Подтвердить нормализацию SLI (latency/5xx).
+- Провести ретроспективу и при необходимости внедрить captcha/авторизацию на импорт.
+
+## Пост-инцидент
+- Заполнить шаблон инцидента и обновить `docs/ONCALL_ROTATION.md` handover (если применимо).
+- Описать принятые меры в пост-мортеме и добавить задач по автоматическому rate limiting.

--- a/docs/RUNBOOKS/WEBHOOK_XTR.md
+++ b/docs/RUNBOOKS/WEBHOOK_XTR.md
@@ -1,0 +1,43 @@
+# Runbook: Webhook XTR latency / errors
+
+- **Severity guidance**: SEV-1 при длительном `WebhookP95High` critical или отказе `/telegram/webhook`; SEV-2 при warning >15 мин.
+- **Impact**: задержка или потеря Telegram Stars вебхуков → подписки Pro/Pro+/VIP не активируются или истекают с задержкой, клиенты не получают доступ к `alerts` и `news` маршрутам.
+
+## Service Level
+- **SLI**: `histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{uri="/telegram/webhook"}[5m])))`.
+- **SLO**: p95 ≤ 1.5 s (см. `docs/SLA_SLO_POLICY.md`).
+- **Alerts**: `WebhookP95High` (warning/critical) из `deploy/monitoring/prometheus/alerts.rules.yml`.
+
+## First Response Checklist
+1. Подтвердите алерт в Alertmanager (`http://localhost:9093` локально) и убедитесь, что на вас назначена роль Incident Commander.
+2. Сообщите в `#newsbot-incident` короткое уведомление: «Investigating Webhook latency alert, status pending». Без PII.
+
+## Диагностика
+1. **Контейнеры**: `docker compose -f deploy/compose/docker-compose.yml logs -f app` — ищем задержки в `StarsWebhookHandler` и исключения.
+2. **Kubernetes** (prod): `kubectl logs deploy/newsbot-app -c app --since=10m | grep stars-webhook`.
+3. **Prometheus проверка**: выполните PromQL из Grafana Explore или `curl`:
+   ```bash
+   PROM_URL=http://localhost:9090 bash tools/sre/sli_query.sh webhook_p95 5m
+   ```
+4. **Метрики приложения**: `curl -s http://<app-host>:8080/metrics | grep webhook`
+5. **Alertmanager**: убедитесь, что не сработали дополнительные алерты (`Http5xxRateHigh`, `StarsDuplicateRateHigh`).
+
+## Диагностика причин
+- Проверить `BillingService.applySuccessfulPayment` (`core/src/main/kotlin/billing/service/BillingService.kt`) на ретраи/idempotency.
+- Убедиться, что `StarsWebhookHandler` (`app/src/main/kotlin/billing/StarsWebhookHandler.kt`) не блокируется внешними API.
+- Проверить внешние зависимости (Telegram API, база данных) через `docker compose logs db` или `kubectl describe`.
+- Просмотреть `observability/Metrics.kt` конфигурацию, чтобы убедиться, что таймеры создаются корректно.
+
+## Действия по восстановлению
+1. **Перезапуск воркеров**: `kubectl rollout restart deploy/newsbot-app` или локально `docker compose restart app`.
+2. **Idempotency guard**: если замечены дубликаты, включите дополнительный контроль (`BillingService` проверяет `providerPaymentChargeId`). Убедитесь, что счётчики `webhook_stars_duplicate_total` не растут аномально.
+3. **Проверка конфигурации**: сверить `telegram.webhookSecret` в `app/src/main/resources/application.conf` и секрет в инфраструктуре.
+4. При длительном заторе — временно перевести входящие вебхуки в очередь (описать в тикете, если используется сторонний буфер).
+
+## Rollback / Fix Forward
+- **Rollback**: откатить последние изменения в `StarsWebhookHandler` или `App.kt` (маршрут `post("/telegram/webhook")`) через предыдущий стабильный релиз.
+- **Fix forward**: задеплоить hotfix с оптимизацией логики биллинга/таймаутов; обязательно добавить тесты (`app/src/test/kotlin/billing/WebhookIntegrationTest.kt`).
+
+## Post Incident
+- Заполнить шаблон `docs/TEMPLATES/INCIDENT_TEMPLATE.md` → сохранить в `incidents/`.
+- Зафиксировать расход error budget и решение о freeze в соответствии с политикой `docs/SLA_SLO_POLICY.md`.

--- a/docs/SLA_SLO_POLICY.md
+++ b/docs/SLA_SLO_POLICY.md
@@ -1,0 +1,71 @@
+# SLA / SLO / SLI Policy — News Bot
+
+## Термины / Terms (RU/EN)
+- **SLI (Показатель уровня сервиса / Service Level Indicator)** — измеримая метрика качества, построенная на фактических данных Prometheus.
+- **SLO (Цель уровня сервиса / Service Level Objective)** — целевой уровень для конкретного SLI, измеряется на скользящем 28-дневном окне.
+- **SLA (Соглашение об уровне сервиса / Service Level Agreement)** — внешнее обещание клиентам; в текущем релизе SLA повторяет SLO и публикуется в Pro/Pro+/VIP тарифах.
+- **Error budget (Бюджет ошибок)** — доля допустимых отклонений от SLO за окно наблюдения. Бюджет расходуется при нарушении SLO и восстанавливается в новом окне.
+
+## Продуктовые SLI и SLO
+
+### Webhook XTR latency p95
+- **PromQL (Prometheus/Micrometer)**: `histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{uri="/telegram/webhook"}[5m])))`
+- **Источники данных**: `App.kt` (маршрут `post("/telegram/webhook")`) и `observability/Metrics.kt` (инициализация Micrometer; см. `DomainMetrics`).
+- **SLO**: 95-й перцентиль времени ответа ≤ 1.5 s в 95% пятиминутных интервалов внутри 28-дневного окна.
+- **Связанный алерт**: `WebhookP95High` из `deploy/monitoring/prometheus/alerts.rules.yml` (warning/critical пороги 1.5 s и 3 s).
+
+### API 5xx rate
+- **PromQL**: `sum(rate(http_server_requests_seconds_count{status=~"5.."}[5m])) / sum(rate(http_server_requests_seconds_count[5m]))`
+- **Источники данных**: метрики Ktor (`http_server_requests_seconds_count`) экспортируются через `observability` модуль.
+- **SLO**: доля ответов 5xx ≤ 2% в каждом пятиминутном окне; допускается максимум 5% нарушенных интервалов за 28 дней.
+- **Связанный алерт**: `Http5xxRateHigh` (warning 2%, critical 5%) из `alerts.rules.yml`.
+
+### Duplicate Stars payments rate
+- **PromQL**: `increase(webhook_stars_duplicate_total[5m]) / clamp_min(increase(webhook_stars_success_total[5m]), 1)`
+- **Источники данных**: `DomainMetrics.webhookStarsSuccess` (счётчик успехов) и обработчик `billing/StarsWebhookHandler.kt` (инкременты/guard), интеграция с `BillingService.applySuccessfulPayment` из `core/billing/service/BillingService.kt`.
+- **SLO**: доля дубликатов ≤ 1% в каждом пятиминутном интервале; максимум 5% нарушенных интервалов за 28 дней.
+- **Связанный алерт**: `StarsDuplicateRateHigh` (warning 1%, critical 2%).
+
+### Alerts push quality (observed KPI)
+- **PromQL**: `increase(alerts_budget_reject_total[5m]) / clamp_min(increase(alerts_push_total[5m]), 1)`
+- **Статус**: наблюдаемая метрика для внутренних обзоров; не входит в формальный SLA, но отслеживается на дашборде `NewsBot / Observability`.
+
+## Error Budget Management
+- **Окно**: 28 дней, дискретизация 5 минут.
+- **Инициализация**: бюджет = 100% в начале окна.
+- **Расход**:
+  - Для latency/5xx — процент интервалов, в которых SLI превышает порог SLO.
+  - Для дубликатов — процент интервалов с долей дубликатов > 1%.
+- **Политики**:
+  - >50% расхода: вводим code freeze на новые фичи в модулях `alerts` и `news`, разрешены только фиксы стабильности.
+  - 100% расхода: полный freeze, обязательные корректирующие задачи приоритета P0/P1 в `billing` и `observability` backlog, обязательный пост-мортем.
+- **Корреляция с алертами**: предупреждения (`warning`) сигнализируют ускоренный расход бюджета; `critical` означает, что бюджет расходуется быстрее допустимого и требуется немедленная реакция.
+
+## Отчётность и мониторинг
+- **Weekly SLO report**: автоматически генерируем из Grafana dashboard `NewsBot / Observability` (панели `Webhook latency`, `HTTP 5xx rate`, `Stars duplicate rate`). Рассылается в канал `#newsbot-reliability` и прикладывается к on-call handoff.
+- **Grafana / Prometheus доступ**: поднять стенд согласно `README.md` разделу P21 (см. `deploy/monitoring`).
+- **История бюджета**: фиксируется в тикетах `Reliability` со ссылками на графики Prometheus.
+
+## Действия при нарушении SLO
+1. Триггерится алерт (`WebhookP95High`, `Http5xxRateHigh`, `StarsDuplicateRateHigh`).
+2. On-call запускает соответствующий runbook из `docs/RUNBOOKS`.
+3. Incident Commander отслеживает расход error budget и принимает решение о freeze.
+4. По итогам инцидента — анализ и задачи по устранению первопричины.
+
+## Аннексы: PromQL-чекеры
+```promql
+# Latency p95 (manual check)
+histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job="app", uri="/telegram/webhook"}[5m])))
+
+# HTTP 5xx share
+sum(rate(http_server_requests_seconds_count{job="app", status=~"5.."}[5m])) /
+  sum(rate(http_server_requests_seconds_count{job="app"}[5m]))
+
+# Duplicate payments share
+increase(webhook_stars_duplicate_total{job="app"}[5m]) /
+  clamp_min(increase(webhook_stars_success_total{job="app"}[5m]), 1)
+
+# Alerts budget rejects (KPI)
+increase(alerts_budget_reject_total{job="app"}[5m]) /
+  clamp_min(increase(alerts_push_total{job="app"}[5m]), 1)
+```

--- a/docs/TEMPLATES/INCIDENT_TEMPLATE.md
+++ b/docs/TEMPLATES/INCIDENT_TEMPLATE.md
@@ -1,0 +1,49 @@
+# Incident Report Template
+
+- **Title / Number**: INCIDENT-<YYYYMMDD>-<slug>
+- **Start time (UTC)**:
+- **Detection time (UTC)**:
+- **End time (UTC)**: _(если открыто, укажите ETA)_
+- **Severity**: SEV-1 / SEV-2 / SEV-3
+- **Incident Commander**:
+- **Communications Lead**:
+- **Ops/SRE on-call**:
+- **App Owner**:
+
+## Impact
+- Затронутые сервисы/маршруты:
+- Пользовательские планы (Pro/Pro+/VIP):
+- Количество запросов/пользователей (оценка, без PII):
+
+## Timeline
+| Time (UTC) | Event |
+| --- | --- |
+|  |  |
+
+## Key Contributors
+- Имя (роль): вклад / действия
+
+## Root Cause Analysis
+- **5 Whys**:
+  1. Почему ...?
+  2. Почему ...?
+  3. Почему ...?
+  4. Почему ...?
+  5. Почему ...?
+
+## Mitigations Applied
+- [ ] Перезапуск сервисов
+- [ ] Изменения конфигурации
+- [ ] Ограничение трафика / feature flag
+- [ ] Communication updates
+- [ ] Иное: ___
+
+## Follow-ups
+| Item | Owner | Priority (P0/P1/P2) | Due date |
+| --- | --- | --- | --- |
+|  |  |  |  |
+
+## Attachments
+- Grafana dashboard ссылки
+- PR/коммиты
+- Логи (без PII)

--- a/docs/TEMPLATES/POSTMORTEM_TEMPLATE.md
+++ b/docs/TEMPLATES/POSTMORTEM_TEMPLATE.md
@@ -1,0 +1,32 @@
+# Postmortem Template
+
+## Summary
+- Incident: INCIDENT-<YYYYMMDD>-<slug>
+- Severity:
+- Duration:
+- Impact summary:
+- Error budget impact (%):
+
+## What Went Well
+- 
+
+## What Went Wrong
+- 
+
+## Where We Got Lucky
+- 
+
+## Action Items
+| Item | Owner | Priority (P0/P1/P2) | Due date |
+| --- | --- | --- | --- |
+|  |  |  |  |
+
+## SLO / SLA Impact
+- Нарушенные SLO: 
+- Потраченный error budget:
+- Корректирующие меры:
+
+## References
+- Grafana panels / Prometheus queries
+- Related PRs / commits
+- Incident report link

--- a/tools/sre/incident_new.sh
+++ b/tools/sre/incident_new.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") <slug>
+Creates incidents/INCIDENT_<YYYYMMDD>_<slug>.md from docs/TEMPLATES/INCIDENT_TEMPLATE.md
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+raw_slug="$1"
+normalized_slug=$(echo "$raw_slug" | tr '[:upper:]' '[:lower:]')
+normalized_slug=${normalized_slug//[^a-z0-9-]/-}
+normalized_slug=${normalized_slug##-}
+normalized_slug=${normalized_slug%%-}
+
+if [[ -z "$normalized_slug" ]]; then
+  echo "[error] slug must contain at least one alphanumeric character" >&2
+  exit 1
+fi
+
+current_date=$(date -u +%Y%m%d)
+incident_file="incidents/INCIDENT_${current_date}_${normalized_slug}.md"
+incident_title="INCIDENT-${current_date}-${normalized_slug}"
+
+if [[ -e "$incident_file" ]]; then
+  echo "[error] incident file already exists: $incident_file" >&2
+  exit 1
+fi
+
+if [[ ! -f docs/TEMPLATES/INCIDENT_TEMPLATE.md ]]; then
+  echo "[error] template not found: docs/TEMPLATES/INCIDENT_TEMPLATE.md" >&2
+  exit 1
+fi
+
+mkdir -p incidents
+sed "s|INCIDENT-<YYYYMMDD>-<slug>|$incident_title|g" docs/TEMPLATES/INCIDENT_TEMPLATE.md > "$incident_file"
+
+echo "$incident_file"

--- a/tools/sre/sli_query.sh
+++ b/tools/sre/sli_query.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: PROM_URL=<prometheus-url> $(basename "$0") <sli_name> <interval>
+Supported SLI names: webhook_p95, api_5xx_rate, stars_duplicate_rate
+Example:
+  PROM_URL=http://localhost:9090 $(basename "$0") webhook_p95 5m
+USAGE
+}
+
+if [[ ${PROM_URL:-} == "" ]]; then
+  echo "[error] PROM_URL environment variable is required" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ $# -ne 2 ]]; then
+  usage >&2
+  exit 1
+fi
+
+sli_name="$1"
+interval="$2"
+
+case "$sli_name" in
+  webhook_p95)
+    query="histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"app\", uri=\"/telegram/webhook\"}[$interval])))"
+    ;;
+  api_5xx_rate)
+    query="sum(rate(http_server_requests_seconds_count{job=\"app\", status=~\"5..\"}[$interval])) / sum(rate(http_server_requests_seconds_count{job=\"app\"}[$interval]))"
+    ;;
+  stars_duplicate_rate)
+    query="increase(webhook_stars_duplicate_total{job=\"app\"}[$interval]) / clamp_min(increase(webhook_stars_success_total{job=\"app\"}[$interval]), 1)"
+    ;;
+  *)
+    echo "[error] unknown SLI '$sli_name'" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+response=$(curl -sS -G "$PROM_URL/api/v1/query" --data-urlencode "query=$query")
+status=$(echo "$response" | jq -r '.status' 2>/dev/null || echo "")
+
+if [[ "$status" != "success" ]]; then
+  echo "[error] Prometheus query failed" >&2
+  echo "$response" >&2
+  exit 1
+fi
+
+value=$(echo "$response" | jq -r '.data.result[0].value[1]' 2>/dev/null || echo "null")
+
+echo "$sli_name ($interval) = $value"


### PR DESCRIPTION
## Summary
- add SLA/SLO policy, incident response process, runbooks, templates, and on-call rotation docs
- add SRE tooling for querying SLIs and bootstrapping incident reports
- add documentation validation workflow and reference the materials from the README

## Testing
- bash -n tools/sre/sli_query.sh
- bash -n tools/sre/incident_new.sh

------
https://chatgpt.com/codex/tasks/task_e_68d89732f3388321b104dad85186a81b