### PR TITLE
Add nightly k6 soak tests for staging

### DIFF
--- a/.github/workflows/load-nightly.yml
+++ b/.github/workflows/load-nightly.yml
@@ -1,0 +1,97 @@
+name: Nightly Load Soak
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  portfolio-ramp:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ secrets.STAGE_BASE_URL }}
+      JWT: ${{ secrets.STAGE_JWT }}
+      APP_PROFILE: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Precheck merge conflicts
+        run: |
+          if git ls-files -z | xargs -0 -r grep -n '<<<<<<< '; then
+            echo 'Merge conflict markers detected';
+            exit 1;
+          fi
+      - name: Setup k6
+        uses: grafana/setup-k6-action@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Guard environment profile
+        run: |
+          if [[ "${APP_PROFILE}" == "prod" ]]; then
+            echo 'Refusing to run load tests in production profile';
+            exit 2;
+          fi
+      - name: Run portfolio ramp soak
+        env:
+          PORTFOLIO_ID: ${{ secrets.STAGE_PORTFOLIO_ID }}
+        run: |
+          k6 run --summary-export=summary.json deploy/load/k6/portfolio_ramp.js
+      - name: Convert summary to JUnit
+        run: node deploy/load/k6/summary-to-junit.js summary.json junit.xml
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: portfolio-ramp-reports
+          path: |
+            summary.json
+            junit.xml
+
+  webhook-burst:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ secrets.STAGE_BASE_URL }}
+      WEBHOOK_SECRET: ${{ secrets.STAGE_WEBHOOK_SECRET }}
+      TG_USER_ID: ${{ secrets.STAGE_TG_USER_ID }}
+      APP_PROFILE: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Precheck merge conflicts
+        run: |
+          if git ls-files -z | xargs -0 -r grep -n '<<<<<<< '; then
+            echo 'Merge conflict markers detected';
+            exit 1;
+          fi
+      - name: Setup k6
+        uses: grafana/setup-k6-action@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Guard environment profile
+        run: |
+          if [[ "${APP_PROFILE}" == "prod" ]]; then
+            echo 'Refusing to run load tests in production profile';
+            exit 2;
+          fi
+      - name: Run webhook burst soak
+        run: |
+          k6 run --summary-export=summary.json deploy/load/k6/webhook_burst.js
+      - name: Convert summary to JUnit
+        run: node deploy/load/k6/summary-to-junit.js summary.json junit.xml
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: webhook-burst-reports
+          path: |
+            summary.json
+            junit.xml

--- a/README.md
+++ b/README.md
@@ -198,6 +198,17 @@ curl -s -X POST "$BASE/telegram/webhook" \
       }
     }
   }'
+
+## P24 — Nightly soak
+
+Ночной soak-тесты выполняются GitHub Actions workflow [`Nightly Load Soak`](.github/workflows/load-nightly.yml) по расписанию `0 2 * * *` (02:00 UTC) и вручную через `workflow_dispatch`. Для прогона нужны секреты окружения:
+
+- `STAGE_BASE_URL` — базовый URL стейджинга;
+- `STAGE_JWT` — JWT для портфельных запросов (опционально `STAGE_PORTFOLIO_ID`);
+- `STAGE_WEBHOOK_SECRET` — Telegram webhook secret;
+- `STAGE_TG_USER_ID` — Telegram user id для успешного платежа.
+
+Оба job'а выгружают артефакты `summary.json` и `junit.xml` (портфель и вебхук) через `Actions → Nightly Load Soak → <run> → Artifacts`.
 # 200 (быстрый ACK). Повторная отправка того же JSON → 200 (идемпотентность).
 
 PowerShell: замените export на $env:NAME="value".

--- a/deploy/load/k6/portfolio_ramp.js
+++ b/deploy/load/k6/portfolio_ramp.js
@@ -1,0 +1,71 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { baseUrl, headersAuth, rndPortfolioId, guardNonProd } from './helpers.js';
+
+export const options = {
+  stages: [
+    { duration: '2m', target: 10 },
+    { duration: '6m', target: 30 },
+    { duration: '2m', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<750'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export function setup() {
+  guardNonProd();
+  return {
+    baseUrl: baseUrl(),
+    headers: headersAuth({ Accept: 'application/json' }),
+  };
+}
+
+function extractPortfolioId(responseJson) {
+  if (!Array.isArray(responseJson)) {
+    return null;
+  }
+  const candidate = responseJson.find((item) => item && item.id);
+  return candidate ? candidate.id : null;
+}
+
+export default function main(data) {
+  const { baseUrl, headers } = data;
+  const listRes = http.get(`${baseUrl}/api/portfolio`, { headers });
+  check(listRes, {
+    'list portfolios 200': (res) => res.status === 200,
+  });
+
+  let portfolioId = rndPortfolioId();
+  if (!portfolioId) {
+    try {
+      portfolioId = extractPortfolioId(listRes.json());
+    } catch (error) {
+      portfolioId = null;
+    }
+  }
+
+  if (portfolioId) {
+    group('portfolio positions', () => {
+      const positionsRes = http.get(`${baseUrl}/api/portfolio/${portfolioId}/positions`, {
+        headers,
+      });
+      check(positionsRes, {
+        'positions 200': (res) => res.status === 200,
+      });
+    });
+
+    group('portfolio trades', () => {
+      const tradesRes = http.get(
+        `${baseUrl}/api/portfolio/${portfolioId}/trades?limit=50&offset=0`,
+        { headers },
+      );
+      check(tradesRes, {
+        'trades 200': (res) => res.status === 200,
+      });
+    });
+  }
+
+  sleep(1);
+}

--- a/deploy/load/k6/summary-to-junit.js
+++ b/deploy/load/k6/summary-to-junit.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function usage() {
+  console.error('Usage: node summary-to-junit.js <summary.json> <junit.xml>');
+}
+
+function readSummary(filePath) {
+  const absolutePath = path.resolve(process.cwd(), filePath);
+  try {
+    const content = fs.readFileSync(absolutePath, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    console.error(`Failed to read summary file ${filePath}: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+function metricValue(metric, keys) {
+  if (!metric || typeof metric !== 'object') {
+    return null;
+  }
+  const values = metric.values || {};
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(values, key)) {
+      return values[key];
+    }
+  }
+  return null;
+}
+
+function collectThresholdMessages(metric) {
+  if (!metric || typeof metric.thresholds !== 'object') {
+    return { failures: [], summaries: [] };
+  }
+  const failures = [];
+  const summaries = [];
+  for (const [name, result] of Object.entries(metric.thresholds)) {
+    const ok = Boolean(result && result.ok);
+    const actual = result && result.actual ? result.actual : 'n/a';
+    const threshold = result && result.threshold ? result.threshold : name;
+    summaries.push(`${threshold}: ${actual}`);
+    if (!ok) {
+      failures.push(`${threshold} violated (actual: ${actual})`);
+    }
+  }
+  return { failures, summaries };
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function ensureOutputDir(targetPath) {
+  const dir = path.dirname(path.resolve(process.cwd(), targetPath));
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function buildTestCase({ name, failureMessages, info }) {
+  const failureText = failureMessages.length > 0 ? failureMessages.join('; ') : null;
+  const infoText = info.filter(Boolean).join(' | ');
+  const systemOut = infoText ? `<system-out>${escapeXml(infoText)}</system-out>` : '';
+  const failureXml = failureText
+    ? `<failure message="${escapeXml(failureText)}"/>`
+    : '';
+  const lines = [`  <testcase classname="k6" name="${escapeXml(name)}" time="0">`];
+  if (failureXml) {
+    lines.push(`    ${failureXml}`);
+  }
+  if (systemOut) {
+    lines.push(`    ${systemOut}`);
+  }
+  lines.push('  </testcase>');
+  return lines.join('\n');
+}
+
+function main() {
+  const [summaryPath, junitPath] = process.argv.slice(2);
+  if (!summaryPath || !junitPath) {
+    usage();
+    process.exit(1);
+  }
+
+  const summary = readSummary(summaryPath);
+  const metrics = summary.metrics || {};
+
+  const httpDurationMetric = metrics.http_req_duration;
+  const durationValue = metricValue(httpDurationMetric, ['p(95)', 'p95']);
+  const durationThresholds = collectThresholdMessages(httpDurationMetric);
+  const durationTest = buildTestCase({
+    name: 'http_req_duration p95',
+    failureMessages: durationThresholds.failures,
+    info: [
+      durationValue !== null ? `p95=${durationValue} ms` : 'p95 unavailable',
+      ...durationThresholds.summaries,
+    ],
+  });
+
+  const failedMetric = metrics.http_req_failed;
+  const failedRate = metricValue(failedMetric, ['rate']);
+  const failedThresholds = collectThresholdMessages(failedMetric);
+  if (failedMetric && (!failedThresholds.failures.length && typeof failedRate === 'number' && failedRate > 0)) {
+    failedThresholds.failures.push(`http_req_failed rate ${failedRate}`);
+  }
+  const failedTest = buildTestCase({
+    name: 'http_req_failed rate',
+    failureMessages: failedThresholds.failures,
+    info: [
+      failedRate !== null ? `rate=${failedRate}` : 'rate unavailable',
+      ...failedThresholds.summaries,
+    ],
+  });
+
+  const checksMetric = metrics.checks || {};
+  const checksThresholds = collectThresholdMessages(checksMetric);
+  const passes = metricValue(checksMetric, ['passes']);
+  const fails = metricValue(checksMetric, ['fails']);
+  const checkFailures = [...checksThresholds.failures];
+  if (typeof fails === 'number' && fails > 0) {
+    checkFailures.push(`checks failed=${fails}`);
+  }
+  const checksTest = buildTestCase({
+    name: 'checks aggregate',
+    failureMessages: checkFailures,
+    info: [
+      typeof passes === 'number' ? `passes=${passes}` : null,
+      typeof fails === 'number' ? `fails=${fails}` : null,
+      ...checksThresholds.summaries,
+    ],
+  });
+
+  const testcases = [durationTest, failedTest, checksTest];
+  const failureCount = testcases.filter((tc) => tc.includes('<failure')).length;
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<testsuite name="k6" tests="${testcases.length}" failures="${failureCount}" time="0">`,
+    ...testcases,
+    '</testsuite>',
+  ].join('\n');
+
+  ensureOutputDir(junitPath);
+  try {
+    fs.writeFileSync(junitPath, `${xml}\n`, 'utf-8');
+  } catch (error) {
+    console.error(`Failed to write junit file ${junitPath}: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/deploy/load/k6/webhook_burst.js
+++ b/deploy/load/k6/webhook_burst.js
@@ -1,0 +1,81 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { fail } from 'k6';
+import { baseUrl, guardNonProd } from './helpers.js';
+
+export const options = {
+  scenarios: {
+    burst: {
+      executor: 'ramping-arrival-rate',
+      startRate: 5,
+      timeUnit: '1s',
+      stages: [
+        { target: 40, duration: '2m30s' },
+        { target: 60, duration: '1m' },
+        { target: 0, duration: '1m30s' },
+      ],
+      preAllocatedVUs: 50,
+      maxVUs: 100,
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<1500'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+function requireEnv(name) {
+  const value = (__ENV[name] || '').trim();
+  if (!value) {
+    fail(`${name} environment variable is required`);
+  }
+  return value;
+}
+
+export function setup() {
+  guardNonProd();
+  return {
+    baseUrl: baseUrl(),
+    secret: requireEnv('WEBHOOK_SECRET'),
+    tgUserId: requireEnv('TG_USER_ID'),
+  };
+}
+
+function buildHeaders(secret) {
+  return {
+    'Content-Type': 'application/json',
+    'X-Telegram-Bot-Api-Secret-Token': secret,
+  };
+}
+
+function uniqueProviderId(iteration) {
+  if (iteration % 7 === 0) {
+    return `pmt_repeat_${__VU}_${Math.floor(iteration / 7)}`;
+  }
+  const timestamp = Date.now();
+  return `pmt_${__VU}_${iteration}_${timestamp}`;
+}
+
+export default function main(data) {
+  const providerId = uniqueProviderId(__ITER);
+  const userId = /^\d+$/.test(data.tgUserId) ? Number(data.tgUserId) : data.tgUserId;
+  const payload = {
+    message: {
+      from: { id: userId },
+      successful_payment: {
+        currency: 'XTR',
+        total_amount: 1234,
+        invoice_payload: `${data.tgUserId}:PRO:${__VU}`,
+        provider_payment_charge_id: providerId,
+      },
+    },
+  };
+
+  const res = http.post(`${data.baseUrl}/telegram/webhook`, JSON.stringify(payload), {
+    headers: buildHeaders(data.secret),
+  });
+
+  check(res, {
+    'webhook 200': (response) => response.status === 200,
+  });
+}


### PR DESCRIPTION
## Summary
- add dedicated nightly soak scenarios for portfolio ramp and webhook burst
- convert exported k6 summaries to junit for artifact publication
- schedule a nightly GitHub Actions workflow with staging guardrails and secrets

## Testing
- node deploy/load/k6/summary-to-junit.js /tmp/sample-summary.json /tmp/sample-junit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d8a0cf793c83219af7fb57ca057783