### PR TITLE
Add rate limit and feature flag for by-url portfolio import

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ curl -s -X POST "$BASE/telegram/webhook" \
     }
   }'
 
+## P25 — Import by-URL: feature-flag & rate-limit
+
+Toggle and configure the CSV import via URL guard with HOCON:
+
+```hocon
+import {
+  byUrlEnabled = true
+  byUrlRateLimit { capacity = 3, refillPerMinute = 3 }
+}
+```
+
+- `503 Service Unavailable` + `{ "error":"by_url_disabled" }` when the feature flag is off.
+- `429 Too Many Requests` + `Retry-After` header and `{ "error":"rate_limited" }` when the per-subject bucket is empty.
+
 ## P24 — Nightly soak
 
 Ночной soak-тесты выполняются GitHub Actions workflow [`Nightly Load Soak`](.github/workflows/load-nightly.yml) по расписанию `0 2 * * *` (02:00 UTC) и вручную через `workflow_dispatch`. Для прогона нужны секреты окружения:

--- a/app/src/main/kotlin/routes/HttpUtils.kt
+++ b/app/src/main/kotlin/routes/HttpUtils.kt
@@ -59,6 +59,15 @@ suspend fun ApplicationCall.respondPayloadTooLarge(limit: Long) {
     respond(HttpStatusCode.PayloadTooLarge, HttpErrorResponse(error = "payload_too_large", limit = limit))
 }
 
+suspend fun ApplicationCall.respondTooManyRequests(retryAfterSeconds: Long) {
+    response.headers.append("Retry-After", retryAfterSeconds.toString(), safeOnly = false)
+    respond(HttpStatusCode.TooManyRequests, mapOf("error" to "rate_limited"))
+}
+
+suspend fun ApplicationCall.respondServiceUnavailable(reason: String = "by_url_disabled") {
+    respond(HttpStatusCode.ServiceUnavailable, mapOf("error" to reason))
+}
+
 suspend fun ApplicationCall.respondInternal() {
     respond(HttpStatusCode.InternalServerError, HttpErrorResponse(error = "internal"))
 }

--- a/app/src/main/kotlin/security/RateLimit.kt
+++ b/app/src/main/kotlin/security/RateLimit.kt
@@ -1,0 +1,56 @@
+package security
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.floor
+import kotlin.math.min
+
+data class RateLimitConfig(val capacity: Int, val refillPerMinute: Int)
+
+private class TokenBucket(
+    private val capacity: Int,
+    private val refillPerMinute: Int,
+    private val clock: Clock
+) {
+    private var tokens: Double = capacity.toDouble()
+    private var lastRefill: Instant = Instant.now(clock)
+
+    @Synchronized
+    fun tryConsume(): Pair<Boolean, Long?> {
+        refill()
+        return if (tokens >= 1.0) {
+            tokens -= 1.0
+            true to null
+        } else {
+            val need = 1.0 - tokens
+            val perSec = refillPerMinute / 60.0
+            val seconds = if (perSec > 0) floor(need / perSec).toLong().coerceAtLeast(1) else 60L
+            false to seconds
+        }
+    }
+
+    private fun refill() {
+        val now = Instant.now(clock)
+        val elapsed = Duration.between(lastRefill, now).toMillis().coerceAtLeast(0)
+        if (elapsed == 0L || refillPerMinute <= 0) return
+        val perMs = refillPerMinute / 60_000.0
+        tokens = min(capacity.toDouble(), tokens + elapsed * perMs)
+        lastRefill = now
+    }
+}
+
+class RateLimiter(
+    private val cfg: RateLimitConfig,
+    private val clock: Clock
+) {
+    private val buckets = ConcurrentHashMap<String, TokenBucket>()
+
+    fun tryAcquire(subject: String): Pair<Boolean, Long?> {
+        val bucket = buckets.computeIfAbsent(subject) {
+            TokenBucket(cfg.capacity, cfg.refillPerMinute, clock)
+        }
+        return bucket.tryConsume()
+    }
+}

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -53,6 +53,14 @@ portfolio {
   autoCreateInstruments = ${?PORTFOLIO_AUTO_CREATE_INSTRUMENTS}
 }
 
+import {
+  byUrlEnabled = false
+  byUrlRateLimit {
+    capacity = 3
+    refillPerMinute = 3
+  }
+}
+
 billing {
   # Дней к продлению подписки при успешном платеже
   defaultDurationDays = 30

--- a/app/src/test/kotlin/routes/CsvSheetsImportRateLimitTest.kt
+++ b/app/src/test/kotlin/routes/CsvSheetsImportRateLimitTest.kt
@@ -1,0 +1,215 @@
+package routes
+
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.jwt.jwt
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import portfolio.service.CsvImportService
+import routes.ImportByUrlRateLimiterHolder
+import routes.PortfolioImportDeps
+import routes.PortfolioImportDepsKey
+import routes.RemoteCsv
+import routes.UploadSettings
+import routes.dto.ImportReportResponse
+import routes.portfolioImportRoutes
+import routes.setImportByUrlLimiterHolder
+import security.JwtConfig
+import security.JwtSupport
+
+class CsvSheetsImportRateLimitTest {
+    private val jwtConfig = JwtConfig(
+        issuer = "newsbot",
+        audience = "newsbot-clients",
+        realm = "newsbot-api",
+        secret = "test-secret",
+        accessTtlMinutes = 60,
+    )
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `returns 503 when import by url disabled`() = testApplication {
+        val deps = FakeDeps().apply {
+            importResult = Result.success(
+                CsvImportService.ImportReport(inserted = 1, skippedDuplicates = 0, failed = emptyList()),
+            )
+        }
+        val clock = MutableClock(Instant.parse("2024-01-01T00:00:00Z"))
+        environment {
+            config = MapApplicationConfig(
+                "import.byUrlEnabled" to "false",
+                "import.byUrlRateLimit.capacity" to "3",
+                "import.byUrlRateLimit.refillPerMinute" to "3",
+            )
+        }
+        application { configureTestApp(deps.toDeps(), clock) }
+
+        val token = issueToken("user-disabled")
+        val response = client.post("/api/portfolio/${UUID.randomUUID()}/trades/import/by-url") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody("""{"url":"https://example.com/report.csv"}""")
+        }
+
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+        val payload = json.parseToJsonElement(response.bodyAsText()).jsonObject
+        assertEquals("by_url_disabled", payload["error"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `rate limit enforces capacity and refills after wait`() = testApplication {
+        val deps = FakeDeps().apply {
+            importResult = Result.success(
+                CsvImportService.ImportReport(inserted = 1, skippedDuplicates = 0, failed = emptyList()),
+            )
+        }
+        val clock = MutableClock(Instant.parse("2024-01-01T00:00:00Z"))
+        environment {
+            config = MapApplicationConfig(
+                "import.byUrlEnabled" to "true",
+                "import.byUrlRateLimit.capacity" to "2",
+                "import.byUrlRateLimit.refillPerMinute" to "2",
+            )
+        }
+        application { configureTestApp(deps.toDeps(), clock) }
+
+        val token = issueToken("user-rate-limit")
+        val path = "/api/portfolio/${UUID.randomUUID()}/trades/import/by-url"
+
+        suspend fun authorizedRequest(): HttpResponse = client.post(path) {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody("""{"url":"https://example.com/data.csv"}""")
+        }
+
+        val first = authorizedRequest()
+        assertEquals(HttpStatusCode.OK, first.status)
+        val firstPayload = json.decodeFromString<ImportReportResponse>(first.bodyAsText())
+        assertEquals(1, firstPayload.inserted)
+
+        val second = authorizedRequest()
+        assertEquals(HttpStatusCode.OK, second.status)
+
+        val third = authorizedRequest()
+        assertEquals(HttpStatusCode.TooManyRequests, third.status)
+        val retryHeader = third.headers[HttpHeaders.RetryAfter]
+        assertNotNull(retryHeader)
+        assertTrue(retryHeader.toLong() >= 1)
+        val limitedPayload = json.parseToJsonElement(third.bodyAsText()).jsonObject
+        assertEquals("rate_limited", limitedPayload["error"]?.jsonPrimitive?.content)
+
+        clock.advance(Duration.ofSeconds(30))
+
+        val fourth = authorizedRequest()
+        assertEquals(HttpStatusCode.OK, fourth.status)
+    }
+
+    @Test
+    fun `missing JWT returns 401`() = testApplication {
+        val deps = FakeDeps()
+        val clock = MutableClock(Instant.parse("2024-01-01T00:00:00Z"))
+        environment {
+            config = MapApplicationConfig(
+                "import.byUrlEnabled" to "true",
+                "import.byUrlRateLimit.capacity" to "3",
+                "import.byUrlRateLimit.refillPerMinute" to "3",
+            )
+        }
+        application { configureTestApp(deps.toDeps(), clock) }
+
+        val response = client.post("/api/portfolio/${UUID.randomUUID()}/trades/import/by-url") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"url":"https://example.com/data.csv"}""")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    private fun Application.configureTestApp(deps: PortfolioImportDeps, clock: MutableClock) {
+        install(ContentNegotiation) {
+            json(json)
+        }
+        install(Authentication) {
+            jwt("auth-jwt") {
+                realm = jwtConfig.realm
+                verifier(JwtSupport.verify(jwtConfig))
+                validate { credentials -> credentials.payload.subject?.let { JWTPrincipal(credentials.payload) } }
+            }
+        }
+        attributes.put(PortfolioImportDepsKey, deps)
+        setImportByUrlLimiterHolder(ImportByUrlRateLimiterHolder(clock))
+        routing {
+            authenticate("auth-jwt") {
+                portfolioImportRoutes()
+            }
+        }
+    }
+
+    private fun issueToken(subject: String): String = JwtSupport.issueToken(jwtConfig, subject)
+
+    private class FakeDeps {
+        var importResult: Result<CsvImportService.ImportReport> = Result.success(CsvImportService.ImportReport())
+        var downloadBytes: ByteArray = "ext_id,datetime\n".toByteArray()
+        var downloadContentType: ContentType? = ContentType.Text.CSV
+
+        fun toDeps(): PortfolioImportDeps = PortfolioImportDeps(
+            importCsv = { _, reader ->
+                reader.use { it.readText() }
+                importResult
+            },
+            uploadSettings = UploadSettings(
+                csvMaxBytes = 1_048_576,
+                allowedContentTypes = setOf(ContentType.Text.CSV, ContentType.Application.OctetStream),
+            ),
+            downloadCsv = { _, _ -> RemoteCsv(contentType = downloadContentType, bytes = downloadBytes) },
+        )
+    }
+
+    private class MutableClock(initialInstant: Instant) : Clock() {
+        private var instantValue: Instant = initialInstant
+        private var zoneId: ZoneId = ZoneOffset.UTC
+
+        override fun getZone(): ZoneId = zoneId
+
+        override fun withZone(zone: ZoneId): Clock = MutableClock(instantValue).also { it.zoneId = zone }
+
+        override fun instant(): Instant = instantValue
+
+        fun advance(duration: Duration) {
+            instantValue = instantValue.plus(duration)
+        }
+    }
+}

--- a/app/src/test/kotlin/routes/CsvSheetsImportRoutesTest.kt
+++ b/app/src/test/kotlin/routes/CsvSheetsImportRoutesTest.kt
@@ -19,6 +19,7 @@ import io.ktor.server.routing.routing
 import java.io.ByteArrayOutputStream
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.time.Clock
 import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -28,9 +29,14 @@ import kotlin.test.assertTrue
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import portfolio.service.CsvImportService
+import routes.ImportByUrlRateLimiterHolder
+import routes.ImportByUrlSettings
 import routes.dto.ImportReportResponse
+import routes.setImportByUrlLimiterHolder
+import routes.setImportByUrlSettings
 import security.JwtConfig
 import security.JwtSupport
+import security.RateLimitConfig
 
 class CsvSheetsImportRoutesTest {
     private val jwtConfig = JwtConfig(
@@ -308,6 +314,13 @@ class CsvSheetsImportRoutesTest {
             }
         }
         attributes.put(PortfolioImportDepsKey, deps)
+        setImportByUrlSettings(
+            ImportByUrlSettings(
+                enabled = true,
+                rateLimit = RateLimitConfig(capacity = 100, refillPerMinute = 100),
+            ),
+        )
+        setImportByUrlLimiterHolder(ImportByUrlRateLimiterHolder(Clock.systemUTC()))
         routing {
             authenticate("auth-jwt") {
                 portfolioImportRoutes()


### PR DESCRIPTION
## Summary
- add import.byUrl configuration block and in-memory token bucket rate limiter for URL-based imports
- update HTTP utilities and portfolio import route to enforce the feature flag, rate limiting, and Retry-After handling
- document the flag and add coverage for rate limiting scenarios and existing CSV import tests

## Testing
- ./gradlew :app:compileKotlin :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d8a28aef5483219567f364bf1b1f33