### PR TITLE
Add webhook queue processing with metrics and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ curl -s -H "Authorization: Bearer $JWT" \
 
 ## P06 — Billing/Stars smoke
 
+## P26 — Webhook queue
+
+Очередь вебхука Telegram построена на ограниченном `Channel` с конфигурируемой вместимостью (`webhook.queue.capacity`), количеством воркеров (`webhook.queue.workers`) и стратегией переполнения (`webhook.queue.overflow` — `drop_oldest` или `drop_latest`). Маршрут `/telegram/webhook` читает тело один раз, мгновенно отвечает `200 OK` и передаёт `TgUpdate` в очередь, поэтому обработка платежей идёт в фоновых корутинах с корректным завершением на shutdown.
+
+Метрики очереди экспортируются в `/metrics` и включают `webhook_queue_size` (текущий размер), `webhook_queue_dropped_total` (дропы из-за переполнения), `webhook_queue_processed_total` (успешно обработанные элементы) и `webhook_handle_seconds` (таймер длительности обработчика).
+
 ### Планы (публично)
 ```bash
 export BASE="http://localhost:8080"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(libs.ktor.server.test.host)
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("org.junit.platform:junit-platform-suite:1.11.3")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${libs.versions.coroutines.get()}")
 }
 
 application {

--- a/app/src/main/kotlin/App.kt
+++ b/app/src/main/kotlin/App.kt
@@ -19,6 +19,7 @@ import di.installPortfolioModule
 import health.healthRoutes
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.call
 import io.ktor.server.auth.authenticate
 import io.ktor.server.request.receiveText
@@ -26,10 +27,15 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.util.AttributeKey
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import observability.DomainMetrics
 import observability.Observability
+import observability.WebhookMetrics
+import org.slf4j.LoggerFactory
 import repo.BillingRepositoryImpl
 import routes.BillingRouteServices
 import routes.BillingRouteServicesKey
@@ -42,18 +48,38 @@ import routes.portfolioValuationReportRoutes
 import routes.quotesRoutes
 import security.installSecurity
 import security.installUploadGuard
+import webhook.OverflowMode
+import webhook.WebhookQueue
 
 fun Application.module() {
     val prometheusRegistry = Observability.install(this)
     val metrics = DomainMetrics(prometheusRegistry)
+    val webhookMetrics = WebhookMetrics.create(prometheusRegistry)
 
     installSecurity()
     installUploadGuard()
     installPortfolioModule()
-    ensureBillingServices(metrics)
+    val services = ensureBillingServices(metrics)
+
+    val queueConfig = webhookQueueConfig()
+    val webhookQueue = WebhookQueue(
+        capacity = queueConfig.capacity,
+        mode = queueConfig.mode,
+        workers = queueConfig.workers,
+        scope = this,
+        metrics = webhookMetrics
+    ) { update ->
+        processStarsPayment(update, services.billingService, services.metrics)
+    }
+    webhookQueue.start()
+
+    environment.monitor.subscribe(ApplicationStopped) {
+        runBlocking {
+            webhookQueue.shutdown(queueConfig.shutdownTimeout)
+        }
+    }
 
     routing {
-        // Публичные
         healthRoutes()
         authRoutes()
         quotesRoutes()
@@ -67,7 +93,6 @@ fun Application.module() {
                 return@post
             }
 
-            val services = attributes[Services.Key]
             val rawUpdate = runCatching { call.receiveText() }.getOrElse {
                 call.respond(HttpStatusCode.OK)
                 return@post
@@ -78,32 +103,33 @@ fun Application.module() {
                 return@post
             }
 
-            StarsWebhookHandler.handleParsed(call, tgUpdate, services.billingService)
+            webhookQueue.offer(tgUpdate)
+            call.respond(HttpStatusCode.OK)
 
-            val update = runCatching { BotUtils.parseUpdate(rawUpdate) }.getOrNull()
-            if (update == null) {
+            val servicesAttr = this@module.attributes[Services.Key]
+            val botUpdate = runCatching { BotUtils.parseUpdate(rawUpdate) }.getOrNull()
+            if (botUpdate == null) {
                 return@post
             }
 
-            val bot = services.telegramBot
-            val billingSvc = services.billingService
-            val route = StarsBotRouter.route(update)
+            val bot = servicesAttr.telegramBot
+            val billingSvc = servicesAttr.billingService
+            val route = StarsBotRouter.route(botUpdate)
             if (route == BotRoute.Unknown) {
                 return@post
             }
 
             launch {
                 when (route) {
-                    Plans -> StarsBotCommands.handlePlans(update, bot, billingSvc)
-                    Buy -> StarsBotCommands.handleBuy(update, bot, billingSvc)
-                    Status -> StarsBotCommands.handleStatus(update, bot, billingSvc)
-                    Callback -> StarsBotCommands.handleCallback(update, bot, billingSvc)
+                    Plans -> StarsBotCommands.handlePlans(botUpdate, bot, billingSvc)
+                    Buy -> StarsBotCommands.handleBuy(botUpdate, bot, billingSvc)
+                    Status -> StarsBotCommands.handleStatus(botUpdate, bot, billingSvc)
+                    Callback -> StarsBotCommands.handleCallback(botUpdate, bot, billingSvc)
                     BotRoute.Unknown -> Unit
                 }
             }
         }
 
-        // Защищённые (под JWT)
         authenticate("auth-jwt") {
             portfolioRoutes()
             portfolioPositionsTradesRoutes()
@@ -141,6 +167,72 @@ private fun Application.ensureBillingServices(metrics: DomainMetrics): Services 
 private fun Application.billingDefaultDuration(): Long {
     val raw = environment.config.propertyOrNull("billing.defaultDurationDays")?.getString()
     return raw?.toLongOrNull() ?: 30L
+}
+
+private data class WebhookQueueConfig(
+    val capacity: Int,
+    val workers: Int,
+    val mode: OverflowMode,
+    val shutdownTimeout: Duration
+)
+
+private fun Application.webhookQueueConfig(): WebhookQueueConfig {
+    val config = environment.config
+    val capacity = config.propertyOrNull("webhook.queue.capacity")?.getString()?.toIntOrNull() ?: 1000
+    val workers = config.propertyOrNull("webhook.queue.workers")?.getString()?.toIntOrNull() ?: 4
+    val overflowRaw = config.propertyOrNull("webhook.queue.overflow")?.getString().orEmpty()
+    val mode = OverflowMode.entries.firstOrNull { it.name.equals(overflowRaw, ignoreCase = true) }
+        ?: OverflowMode.DROP_OLDEST
+    return WebhookQueueConfig(
+        capacity = capacity,
+        workers = workers,
+        mode = mode,
+        shutdownTimeout = 5.seconds
+    )
+}
+
+private val webhookLogger = LoggerFactory.getLogger("WebhookProcessor")
+
+private suspend fun processStarsPayment(
+    update: TgUpdate,
+    billing: BillingService,
+    metrics: DomainMetrics?
+) {
+    val successfulPayment = update.message?.successful_payment ?: return
+    if (!successfulPayment.currency.equals("XTR", ignoreCase = true)) {
+        return
+    }
+    val userId = update.message?.from?.id ?: return
+    val payloadData = parsePayload(successfulPayment.invoice_payload) ?: return
+    val (payloadUserId, tier) = payloadData
+    if (payloadUserId != userId) {
+        webhookLogger.info("webhook-queue reason=user_mismatch")
+        return
+    }
+
+    val result = billing.applySuccessfulPayment(
+        userId = userId,
+        tier = tier,
+        amountXtr = successfulPayment.total_amount,
+        providerPaymentId = successfulPayment.provider_payment_charge_id,
+        payload = successfulPayment.invoice_payload
+    )
+
+    if (result.isSuccess) {
+        metrics?.webhookStarsSuccess?.increment()
+        webhookLogger.info("webhook-queue reason=applied_ok")
+    } else {
+        webhookLogger.error("webhook-queue reason=apply_failed", result.exceptionOrNull())
+    }
+}
+
+private fun parsePayload(payload: String?): Pair<Long, billing.model.Tier>? {
+    if (payload.isNullOrBlank()) return null
+    val parts = payload.split(':')
+    if (parts.size < 3) return null
+    val userId = parts[0].toLongOrNull() ?: return null
+    val tier = runCatching { billing.model.Tier.valueOf(parts[1].uppercase()) }.getOrNull() ?: return null
+    return userId to tier
 }
 
 data class Services(

--- a/app/src/main/kotlin/observability/WebhookMetrics.kt
+++ b/app/src/main/kotlin/observability/WebhookMetrics.kt
@@ -1,0 +1,28 @@
+package observability
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import java.util.concurrent.atomic.AtomicInteger
+
+class WebhookMetrics private constructor(
+    private val registry: MeterRegistry,
+    val queueSize: AtomicInteger,
+    val dropped: Counter,
+    val processed: Counter,
+    val handleTimer: Timer
+) {
+    fun startSample(): Timer.Sample = Timer.start(registry)
+
+    companion object {
+        fun create(registry: MeterRegistry): WebhookMetrics {
+            val queueSize = AtomicInteger(0)
+            Gauge.builder("webhook_queue_size", queueSize) { it.get().toDouble() }.register(registry)
+            val dropped = Counter.builder("webhook_queue_dropped_total").register(registry)
+            val processed = Counter.builder("webhook_queue_processed_total").register(registry)
+            val handleTimer = Timer.builder("webhook_handle_seconds").register(registry)
+            return WebhookMetrics(registry, queueSize, dropped, processed, handleTimer)
+        }
+    }
+}

--- a/app/src/main/kotlin/webhook/WebhookQueue.kt
+++ b/app/src/main/kotlin/webhook/WebhookQueue.kt
@@ -1,0 +1,115 @@
+package webhook
+
+import billing.TgUpdate
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.max
+import kotlin.time.Duration
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import observability.WebhookMetrics
+import org.slf4j.LoggerFactory
+
+enum class OverflowMode { DROP_OLDEST, DROP_LATEST }
+
+class WebhookQueue(
+    private val capacity: Int,
+    private val mode: OverflowMode,
+    private val workers: Int,
+    private val scope: CoroutineScope,
+    private val metrics: WebhookMetrics,
+    private val handler: suspend (TgUpdate) -> Unit
+) {
+    private val logger = LoggerFactory.getLogger(WebhookQueue::class.java)
+    private val channel: Channel<TgUpdate> = Channel(capacity)
+    private val started = AtomicBoolean(false)
+    private val jobs = mutableListOf<Job>()
+
+    init {
+        require(capacity > 0) { "capacity must be > 0" }
+        require(workers > 0) { "workers must be > 0" }
+    }
+
+    fun offer(update: TgUpdate): Boolean {
+        val result = channel.trySend(update)
+        if (result.isSuccess) {
+            metrics.queueSize.incrementAndGet()
+            return true
+        }
+        if (result.isClosed) {
+            metrics.dropped.increment()
+            return false
+        }
+        return when (mode) {
+            OverflowMode.DROP_LATEST -> {
+                metrics.dropped.increment()
+                false
+            }
+            OverflowMode.DROP_OLDEST -> handleDropOldest(update)
+        }
+    }
+
+    fun start() {
+        if (!started.compareAndSet(false, true)) {
+            return
+        }
+        repeat(workers) {
+            val job = scope.launch {
+                for (update in channel) {
+                    decrementQueueSize()
+                    val sample = metrics.startSample()
+                    try {
+                        handler(update)
+                    } catch (ce: CancellationException) {
+                        sample.stop(metrics.handleTimer)
+                        throw ce
+                    } catch (t: Throwable) {
+                        logger.error("webhook-queue worker failed", t)
+                    } finally {
+                        metrics.processed.increment()
+                        sample.stop(metrics.handleTimer)
+                    }
+                }
+            }
+            jobs += job
+        }
+    }
+
+    suspend fun shutdown(timeout: Duration) {
+        channel.close()
+        val completed = withTimeoutOrNull(timeout) {
+            jobs.forEach { it.join() }
+            true
+        }
+        if (completed != true) {
+            jobs.forEach { it.cancel() }
+        }
+        metrics.queueSize.set(0)
+    }
+
+    private fun handleDropOldest(update: TgUpdate): Boolean {
+        val removed = channel.tryReceive().getOrNull()
+        return if (removed != null) {
+            decrementQueueSize()
+            metrics.dropped.increment()
+            val retry = channel.trySend(update)
+            if (retry.isSuccess) {
+                metrics.queueSize.incrementAndGet()
+                true
+            } else {
+                metrics.dropped.increment()
+                false
+            }
+        } else {
+            metrics.dropped.increment()
+            false
+        }
+    }
+
+    private fun decrementQueueSize() {
+        metrics.queueSize.updateAndGet { current -> max(0, current - 1) }
+    }
+}

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -9,6 +9,14 @@ telegram {
   adminUserId = 7446417641
 }
 
+webhook {
+  queue {
+    capacity = 1000          # max in-queue items
+    workers  = 4             # parallel consumers
+    overflow = "drop_oldest" # drop_oldest | drop_latest
+  }
+}
+
 db {
   jdbcUrl = ${?DATABASE_URL}
   username = ${?DATABASE_USER}

--- a/app/src/test/kotlin/webhook/WebhookIntegrationTest.kt
+++ b/app/src/test/kotlin/webhook/WebhookIntegrationTest.kt
@@ -1,0 +1,145 @@
+package webhook
+
+import app.Services
+import app.module
+import billing.model.BillingPlan
+import billing.model.Tier
+import billing.model.UserSubscription
+import billing.service.BillingService
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.testApplication
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+
+class WebhookIntegrationTest {
+
+    @Test
+    fun `webhook acknowledges immediately and processes updates via queue`() = testApplication {
+        val secret = "integration-secret"
+        val billing = TestBillingService()
+
+        environment {
+            config = MapApplicationConfig().apply {
+                put("telegram.webhookSecret", secret)
+                put("webhook.queue.capacity", "3")
+                put("webhook.queue.workers", "1")
+                put("webhook.queue.overflow", "drop_latest")
+                put("security.jwtSecret", "integration-test-secret")
+                put("security.issuer", "test-issuer")
+                put("security.audience", "test-audience")
+                put("security.realm", "test-realm")
+                put("security.accessTtlMinutes", "60")
+            }
+        }
+
+        application {
+            attributes.put(Services.Key, Services(billingService = billing, telegramBot = NoopTelegramBot()))
+            module()
+        }
+
+        val client = createClient { }
+
+        val warmupResponse = client.post("/telegram/webhook") {
+            header("X-Telegram-Bot-Api-Secret-Token", secret)
+            contentType(ContentType.Application.Json)
+            setBody(paymentUpdateJson(999L))
+        }
+        assertEquals(HttpStatusCode.OK, warmupResponse.status)
+
+        val firstAck = measureTime {
+            val response = client.post("/telegram/webhook") {
+                header("X-Telegram-Bot-Api-Secret-Token", secret)
+                contentType(ContentType.Application.Json)
+                setBody(paymentUpdateJson(1001L))
+            }
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+        assertTrue(firstAck < 200.milliseconds, "Expected quick ACK but was $firstAck")
+
+        repeat(20) { index ->
+            val response = client.post("/telegram/webhook") {
+                header("X-Telegram-Bot-Api-Secret-Token", secret)
+                contentType(ContentType.Application.Json)
+                setBody(paymentUpdateJson(2000L + index))
+            }
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+        withTimeout(5.seconds) {
+            while (billing.applied.get() == 0) {
+                delay(50.milliseconds)
+            }
+        }
+        delay(500.milliseconds)
+
+        val metricsBody = client.get("/metrics").bodyAsText()
+        val processed = metricValue(metricsBody, "webhook_queue_processed_total")
+        val dropped = metricValue(metricsBody, "webhook_queue_dropped_total")
+
+        assertTrue(billing.applied.get().toDouble() <= processed + 0.001)
+        assertTrue(dropped > 0.0)
+    }
+}
+
+private class TestBillingService : BillingService {
+    val applied: AtomicInteger = AtomicInteger(0)
+
+    override suspend fun listPlans(): Result<List<BillingPlan>> =
+        Result.failure(UnsupportedOperationException("not implemented"))
+
+    override suspend fun createInvoiceFor(userId: Long, tier: Tier): Result<String> =
+        Result.failure(UnsupportedOperationException("not implemented"))
+
+    override suspend fun applySuccessfulPayment(
+        userId: Long,
+        tier: Tier,
+        amountXtr: Long,
+        providerPaymentId: String?,
+        payload: String?
+    ): Result<Unit> = runCatching {
+        delay(200.milliseconds)
+        applied.incrementAndGet()
+    }
+
+    override suspend fun getMySubscription(userId: Long): Result<UserSubscription?> =
+        Result.failure(UnsupportedOperationException("not implemented"))
+}
+
+private class NoopTelegramBot : com.pengrad.telegrambot.TelegramBot("test-token")
+
+private fun paymentUpdateJson(userId: Long): String = """
+    {
+      "message": {
+        "from": {"id": $userId},
+        "successful_payment": {
+          "currency": "XTR",
+          "total_amount": 1000,
+          "invoice_payload": "$userId:PRO:payload",
+          "provider_payment_charge_id": "pid-$userId"
+        }
+      }
+    }
+""".trimIndent()
+
+private fun metricValue(metrics: String, name: String): Double {
+    val line = metrics.lineSequence()
+        .map { it.trim() }
+        .firstOrNull { it.startsWith(name) && !it.contains('{') }
+        ?: return 0.0
+    return line.substringAfter(' ').toDoubleOrNull() ?: 0.0
+}

--- a/app/src/test/kotlin/webhook/WebhookQueueTest.kt
+++ b/app/src/test/kotlin/webhook/WebhookQueueTest.kt
@@ -1,0 +1,69 @@
+package webhook
+
+import billing.TgUpdate
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import observability.WebhookMetrics
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WebhookQueueTest {
+
+    @Test
+    fun `capacity overflow drops updates and counts processed`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val metrics = WebhookMetrics.create(registry)
+        val processed = AtomicInteger(0)
+        val queue = WebhookQueue(
+            capacity = 3,
+            mode = OverflowMode.DROP_LATEST,
+            workers = 1,
+            scope = this,
+            metrics = metrics
+        ) { _ ->
+            processed.incrementAndGet()
+        }
+
+        queue.start()
+        repeat(5) { queue.offer(TgUpdate()) }
+
+        advanceUntilIdle()
+        queue.shutdown(1.seconds)
+
+        assertEquals(3, processed.get())
+        assertEquals(3.0, metrics.processed.count(), 0.0001)
+        assertTrue(metrics.dropped.count() >= 2.0)
+    }
+
+    @Test
+    fun `multiple workers consume updates`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val metrics = WebhookMetrics.create(registry)
+        val processed = AtomicInteger(0)
+        val queue = WebhookQueue(
+            capacity = 4,
+            mode = OverflowMode.DROP_LATEST,
+            workers = 2,
+            scope = this,
+            metrics = metrics
+        ) { _ ->
+            processed.incrementAndGet()
+        }
+
+        queue.start()
+        repeat(4) { queue.offer(TgUpdate()) }
+
+        advanceUntilIdle()
+        queue.shutdown(1.seconds)
+
+        assertEquals(4, processed.get())
+        assertEquals(4.0, metrics.processed.count(), 0.0001)
+        assertEquals(0.0, metrics.dropped.count(), 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
- add WebhookQueue with bounded channel, drop metrics, and shutdown handling
- wire the queue, metrics, and config into the Telegram webhook route and document the feature
- cover the queue and integration scenarios with new tests and add the coroutines test dependency

## Testing
- ./gradlew :app:compileKotlin :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d8af24b9108321a6d34b46e0a779fd