### PR TITLE
P27: harden integrations HTTP layer

### DIFF
--- a/app/src/main/kotlin/integrations/IntegrationsModule.kt
+++ b/app/src/main/kotlin/integrations/IntegrationsModule.kt
@@ -2,58 +2,133 @@ package integrations
 
 import cbr.CbrClient
 import coingecko.CoinGeckoClient
-import http.defaultHttpClient
+import http.CircuitBreaker
+import http.CircuitBreakerCfg
+import http.HttpClients
+import http.IntegrationsHttpConfig
+import http.IntegrationsMetrics
+import http.RetryCfg
+import http.TimeoutMs
 import io.ktor.client.HttpClient
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationEnvironment
 import io.ktor.server.application.ApplicationStopping
+import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.config.configOrNull
+import io.ktor.server.config.propertyOrNull
+import io.ktor.util.AttributeKey
+import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
-import io.ktor.util.AttributeKey
+import java.time.Clock
 import moex.MoexIssClient
 
-private val IntegrationsModuleKey = AttributeKey<IntegrationsModule>("IntegrationsModule")
+private val IntegrationsProviderKey = AttributeKey<IntegrationsProvider>("IntegrationsProvider")
 
-class IntegrationsModule(
+class IntegrationsProvider(
     val httpClient: HttpClient,
-    val meterRegistry: PrometheusMeterRegistry,
+    val metrics: IntegrationsMetrics,
+    val registry: MeterRegistry,
     val moexClient: MoexIssClient,
     val coinGeckoClient: CoinGeckoClient,
-    val cbrClient: CbrClient
+    val cbrClient: CbrClient,
+    val circuitBreakers: Map<String, CircuitBreaker>
 )
 
-fun Application.integrationsModule(): IntegrationsModule {
-    if (attributes.contains(IntegrationsModuleKey)) {
-        return attributes[IntegrationsModuleKey]
-    }
-    val config = environment.config
-    val integrationsConfig = config.configOrNull("integrations")
-    val appName = integrationsConfig?.propertyOrNull("appName")?.getString() ?: "newsbot/dev"
-    val moexBaseUrl = integrationsConfig?.configOrNull("moex")?.propertyOrNull("baseUrl")?.getString()
-        ?: "https://iss.moex.com"
-    val coinGeckoBaseUrl = integrationsConfig?.configOrNull("coingecko")?.propertyOrNull("baseUrl")?.getString()
-        ?: "https://api.coingecko.com"
-    val cbrBaseUrl = integrationsConfig?.configOrNull("cbr")?.propertyOrNull("baseUrl")?.getString()
-        ?: "https://www.cbr.ru"
+object IntegrationsModule {
+    fun provide(env: ApplicationEnvironment, registry: MeterRegistry): IntegrationsProvider {
+        val integrationsConfig = env.config.config("integrations")
+        val httpConfig = env.integrationsHttpConfig()
+        val metrics = IntegrationsMetrics(registry)
+        val clock = Clock.systemUTC()
+        val httpClient = HttpClients.build(httpConfig, metrics, clock)
+        val cbCfg = httpConfig.circuitBreaker
 
-    val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT).also {
+        val moexCb = newCircuitBreaker("moex", cbCfg, metrics, clock)
+        val coingeckoCb = newCircuitBreaker("coingecko", cbCfg, metrics, clock)
+        val cbrCb = newCircuitBreaker("cbr", cbCfg, metrics, clock)
+
+        val moexClient = MoexIssClient(httpClient, moexCb, metrics).apply {
+            setBaseUrl(integrationsConfig.baseUrl("moex", "https://iss.moex.com"))
+        }
+        val coinGeckoClient = CoinGeckoClient(httpClient, coingeckoCb, metrics).apply {
+            setBaseUrl(integrationsConfig.baseUrl("coingecko", "https://api.coingecko.com"))
+        }
+        val cbrClient = CbrClient(httpClient, cbrCb, metrics).apply {
+            setBaseUrl(integrationsConfig.baseUrl("cbr", "https://www.cbr.ru"))
+        }
+
+        return IntegrationsProvider(
+            httpClient = httpClient,
+            metrics = metrics,
+            registry = registry,
+            moexClient = moexClient,
+            coinGeckoClient = coinGeckoClient,
+            cbrClient = cbrClient,
+            circuitBreakers = mapOf(
+                "moex" to moexCb,
+                "coingecko" to coingeckoCb,
+                "cbr" to cbrCb
+            )
+        )
+    }
+
+    private fun newCircuitBreaker(
+        service: String,
+        cfg: CircuitBreakerCfg,
+        metrics: IntegrationsMetrics,
+        clock: Clock
+    ): CircuitBreaker = CircuitBreaker(service, cfg, metrics, clock)
+}
+
+fun Application.integrationsModule(): IntegrationsProvider {
+    if (attributes.contains(IntegrationsProviderKey)) {
+        return attributes[IntegrationsProviderKey]
+    }
+    val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT).also {
         it.config().commonTags("component", "integrations")
     }
-    val httpClient = defaultHttpClient(appName)
-
-    val module = IntegrationsModule(
-        httpClient = httpClient,
-        meterRegistry = meterRegistry,
-        moexClient = MoexIssClient(httpClient, moexBaseUrl, meterRegistry),
-        coinGeckoClient = CoinGeckoClient(httpClient, coinGeckoBaseUrl, meterRegistry),
-        cbrClient = CbrClient(httpClient, cbrBaseUrl, meterRegistry)
-    )
-    attributes.put(IntegrationsModuleKey, module)
+    val provider = IntegrationsModule.provide(environment, registry)
+    attributes.put(IntegrationsProviderKey, provider)
 
     environment.monitor.subscribe(ApplicationStopping) {
-        meterRegistry.close()
-        httpClient.close()
+        provider.httpClient.close()
+        if (registry is AutoCloseable) {
+            registry.close()
+        }
     }
 
-    return module
+    return provider
+}
+
+private fun ApplicationConfig.baseUrl(section: String, default: String): String =
+    configOrNull(section)?.propertyOrNull("baseUrl")?.getString() ?: default
+
+private fun ApplicationEnvironment.integrationsHttpConfig(): IntegrationsHttpConfig {
+    val integrationsRoot = config.config("integrations")
+    val httpRoot = integrationsRoot.config("http")
+    val timeout = httpRoot.config("timeoutMs")
+    val retry = httpRoot.config("retry")
+    val cb = httpRoot.config("circuitBreaker")
+    return IntegrationsHttpConfig(
+        userAgent = integrationsRoot.property("userAgent").getString(),
+        timeoutMs = TimeoutMs(
+            connect = timeout.property("connect").getString().toLong(),
+            socket = timeout.property("socket").getString().toLong(),
+            request = timeout.property("request").getString().toLong()
+        ),
+        retry = RetryCfg(
+            maxAttempts = retry.property("maxAttempts").getString().toInt(),
+            baseBackoffMs = retry.property("baseBackoffMs").getString().toLong(),
+            jitterMs = retry.property("jitterMs").getString().toLong(),
+            respectRetryAfter = retry.property("respectRetryAfter").getString().toBooleanStrict(),
+            retryOn = retry.property("retryOn").getList().map { it.toInt() }
+        ),
+        circuitBreaker = CircuitBreakerCfg(
+            failuresThreshold = cb.property("failuresThreshold").getString().toInt(),
+            windowSeconds = cb.property("windowSeconds").getString().toLong(),
+            openSeconds = cb.property("openSeconds").getString().toLong(),
+            halfOpenMaxCalls = cb.property("halfOpenMaxCalls").getString().toInt()
+        )
+    )
 }

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -30,6 +30,29 @@ db {
 integrations {
   appName = "newsbot/0.1.0"
   appName = ${?INTEGRATIONS_APP_NAME}
+  userAgent = "newsbot-integrations/1.0"
+  userAgent = ${?INTEGRATIONS_USER_AGENT}
+
+  http {
+    timeoutMs {
+      connect = 2000
+      socket  = 3000
+      request = 4000
+    }
+    retry {
+      maxAttempts = 3
+      baseBackoffMs = 300
+      jitterMs      = 200
+      respectRetryAfter = true
+      retryOn = [429, 500, 502, 503, 504]
+    }
+    circuitBreaker {
+      failuresThreshold = 5        # сколько ошибок в окне переводит CB в OPEN
+      windowSeconds     = 60       # окно ошибок
+      openSeconds       = 30       # пауза в OPEN
+      halfOpenMaxCalls  = 2        # пробные вызовы
+    }
+  }
 
   moex {
     baseUrl = "https://iss.moex.com"

--- a/integrations/src/main/kotlin/http/CircuitBreaker.kt
+++ b/integrations/src/main/kotlin/http/CircuitBreaker.kt
@@ -1,0 +1,163 @@
+package http
+
+import java.io.IOException
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.ArrayDeque
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.jvm.Volatile
+
+enum class CbState {
+    CLOSED,
+    OPEN,
+    HALF_OPEN
+}
+
+class CircuitBreaker(
+    private val service: String,
+    private val cfg: CircuitBreakerCfg,
+    private val metrics: IntegrationsMetrics,
+    private val clock: Clock
+) {
+    private val mutex = Mutex()
+    private val failures: ArrayDeque<Instant> = ArrayDeque()
+    private val stateValue = AtomicInteger(CbState.CLOSED.ordinal)
+    @Volatile
+    private var state: CbState = CbState.CLOSED
+    private var openedAt: Instant? = null
+    private var halfOpenInFlight: Int = 0
+
+    init {
+        metrics.cbStateGauge(service) { stateValue.get() }
+        stateValue.set(state.ordinal)
+    }
+
+    suspend fun <T> withPermit(block: suspend () -> T): T {
+        val callState = prepareCall()
+        return try {
+            val result = block()
+            onSuccess()
+            result
+        } catch (ex: Throwable) {
+            onFailure(ex)
+            throw ex
+        } finally {
+            if (callState == CbState.HALF_OPEN) {
+                releaseHalfOpenPermit()
+            }
+        }
+    }
+
+    val currentState: CbState
+        get() = state
+
+    private suspend fun prepareCall(): CbState {
+        return mutex.withLock {
+            val now = clock.instant()
+            when (state) {
+                CbState.OPEN -> {
+                    if (openedAt?.let { Duration.between(it, now).seconds >= cfg.openSeconds } == true) {
+                        transitionToHalfOpen()
+                    } else {
+                        throw CircuitBreakerOpenException(service)
+                    }
+                }
+                CbState.CLOSED -> evictExpiredFailures(now)
+                CbState.HALF_OPEN -> {
+                    // keep state
+                }
+            }
+            if (state == CbState.HALF_OPEN) {
+                if (halfOpenInFlight >= cfg.halfOpenMaxCalls) {
+                    throw CircuitBreakerOpenException(service)
+                }
+                halfOpenInFlight += 1
+            }
+            state
+        }
+    }
+
+    private suspend fun onSuccess() {
+        mutex.withLock {
+            val now = clock.instant()
+            when (state) {
+                CbState.HALF_OPEN -> {
+                    state = CbState.CLOSED
+                    stateValue.set(state.ordinal)
+                    failures.clear()
+                    openedAt = null
+                    halfOpenInFlight = 0
+                }
+                CbState.CLOSED -> evictExpiredFailures(now)
+                CbState.OPEN -> {
+                    // unreachable during call
+                }
+            }
+        }
+    }
+
+    private suspend fun onFailure(cause: Throwable) {
+        if (cause is CancellationException) {
+            return
+        }
+        mutex.withLock {
+            val now = clock.instant()
+            when (state) {
+                CbState.HALF_OPEN -> {
+                    open(now)
+                }
+                CbState.CLOSED -> {
+                    recordFailure(now)
+                }
+                CbState.OPEN -> {
+                    // ignored
+                }
+            }
+        }
+    }
+
+    private suspend fun releaseHalfOpenPermit() {
+        mutex.withLock {
+            if (halfOpenInFlight > 0) {
+                halfOpenInFlight -= 1
+            }
+        }
+    }
+
+    private fun recordFailure(now: Instant) {
+        failures.addLast(now)
+        evictExpiredFailures(now)
+        if (failures.size >= cfg.failuresThreshold) {
+            open(now)
+        }
+    }
+
+    private fun evictExpiredFailures(now: Instant) {
+        val windowAgo = now.minusSeconds(cfg.windowSeconds)
+        while (failures.isNotEmpty() && failures.first() < windowAgo) {
+            failures.removeFirst()
+        }
+    }
+
+    private fun open(now: Instant) {
+        state = CbState.OPEN
+        stateValue.set(state.ordinal)
+        openedAt = now
+        halfOpenInFlight = 0
+        failures.clear()
+        metrics.cbOpenCounter(service).increment()
+    }
+
+    private fun transitionToHalfOpen() {
+        state = CbState.HALF_OPEN
+        stateValue.set(state.ordinal)
+        openedAt = null
+        halfOpenInFlight = 0
+    }
+}
+
+class CircuitBreakerOpenException(service: String) : IOException("Circuit breaker OPEN for $service")

--- a/integrations/src/main/kotlin/http/IntegrationsConfig.kt
+++ b/integrations/src/main/kotlin/http/IntegrationsConfig.kt
@@ -1,0 +1,29 @@
+package http
+
+data class IntegrationsHttpConfig(
+    val userAgent: String,
+    val timeoutMs: TimeoutMs,
+    val retry: RetryCfg,
+    val circuitBreaker: CircuitBreakerCfg
+)
+
+data class TimeoutMs(
+    val connect: Long,
+    val socket: Long,
+    val request: Long
+)
+
+data class RetryCfg(
+    val maxAttempts: Int,
+    val baseBackoffMs: Long,
+    val jitterMs: Long,
+    val respectRetryAfter: Boolean,
+    val retryOn: List<Int>
+)
+
+data class CircuitBreakerCfg(
+    val failuresThreshold: Int,
+    val windowSeconds: Long,
+    val openSeconds: Long,
+    val halfOpenMaxCalls: Int
+)

--- a/integrations/src/main/kotlin/http/IntegrationsMetrics.kt
+++ b/integrations/src/main/kotlin/http/IntegrationsMetrics.kt
@@ -1,0 +1,45 @@
+package http
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.Timer
+import java.util.concurrent.ConcurrentHashMap
+
+class IntegrationsMetrics(private val registry: MeterRegistry) {
+    private val retryCounters = ConcurrentHashMap<String, Counter>()
+    private val retryAfterCounters = ConcurrentHashMap<String, Counter>()
+    private val cbOpenCounters = ConcurrentHashMap<String, Counter>()
+    private val cbStateSuppliers = ConcurrentHashMap<String, () -> Int>()
+    private val requestTimers = ConcurrentHashMap<Pair<String, String>, Timer>()
+
+    fun retryCounter(service: String): Counter = retryCounters.computeIfAbsent(service) {
+        registry.counter("integrations_retry_total", "service", it)
+    }
+
+    fun retryAfterHonored(service: String): Counter = retryAfterCounters.computeIfAbsent(service) {
+        registry.counter("integrations_retry_after_honored_total", "service", it)
+    }
+
+    fun cbOpenCounter(service: String): Counter = cbOpenCounters.computeIfAbsent(service) {
+        registry.counter("integrations_cb_open_total", "service", it)
+    }
+
+    fun cbStateGauge(service: String, supplier: () -> Int) {
+        cbStateSuppliers.computeIfAbsent(service) {
+            registry.gauge("integrations_cb_state", Tags.of("service", service), supplier) { it().toDouble() }
+            supplier
+        }
+    }
+
+    fun timerSample(): Timer.Sample = Timer.start(registry)
+
+    fun stopTimer(sample: Timer.Sample, service: String, outcome: String) {
+        sample.stop(requestTimer(service, outcome))
+    }
+
+    fun requestTimer(service: String, outcome: String): Timer = requestTimers.computeIfAbsent(service to outcome) {
+        registry.timer("integrations_request_seconds", "service", service, "outcome", outcome)
+    }
+
+}

--- a/integrations/src/test/kotlin/TestHttpClientFactory.kt
+++ b/integrations/src/test/kotlin/TestHttpClientFactory.kt
@@ -1,18 +1,55 @@
 package testutils
 
-import http.configureDefaultHttpClient
+import http.CircuitBreakerCfg
+import http.HttpClients
+import http.IntegrationsHttpConfig
+import http.IntegrationsMetrics
+import http.RetryCfg
+import http.TimeoutMs
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.HttpResponseData
+import java.time.Clock
 
 fun testHttpClient(
-    appName: String = "newsbot/test",
+    metrics: IntegrationsMetrics,
+    clock: Clock = Clock.systemUTC(),
+    config: IntegrationsHttpConfig = testHttpConfig(),
     handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData
-): HttpClient = HttpClient(MockEngine) {
-    configureDefaultHttpClient(appName)
-    engine {
-        addHandler(handler)
+): HttpClient {
+    val client = HttpClient(MockEngine) {
+        HttpClients.run {
+            configure(config, metrics, clock)
+        }
+        engine {
+            addHandler(handler)
+        }
     }
+    HttpClients.registerRetryMonitor(client, metrics)
+    return client
 }
+
+fun testHttpConfig(
+    userAgent: String = "newsbot-test",
+    timeoutMs: TimeoutMs = TimeoutMs(connect = 1000, socket = 1000, request = 1000),
+    retryCfg: RetryCfg = RetryCfg(
+        maxAttempts = 3,
+        baseBackoffMs = 1,
+        jitterMs = 0,
+        respectRetryAfter = true,
+        retryOn = listOf(429, 500, 502, 503, 504)
+    ),
+    circuitBreakerCfg: CircuitBreakerCfg = CircuitBreakerCfg(
+        failuresThreshold = 5,
+        windowSeconds = 60,
+        openSeconds = 30,
+        halfOpenMaxCalls = 2
+    )
+): IntegrationsHttpConfig = IntegrationsHttpConfig(
+    userAgent = userAgent,
+    timeoutMs = timeoutMs,
+    retry = retryCfg,
+    circuitBreaker = circuitBreakerCfg
+)

--- a/integrations/src/test/kotlin/clients/ClientsSmokeTest.kt
+++ b/integrations/src/test/kotlin/clients/ClientsSmokeTest.kt
@@ -1,0 +1,192 @@
+package clients
+
+import cbr.CbrClient
+import coingecko.CoinGeckoClient
+import http.CircuitBreaker
+import http.CircuitBreakerCfg
+import http.CircuitBreakerOpenException
+import http.HttpClients
+import http.IntegrationsHttpConfig
+import http.IntegrationsMetrics
+import http.RetryCfg
+import http.TimeoutMs
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.io.IOException
+import java.math.BigDecimal
+import java.time.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import moex.MoexIssClient
+
+class ClientsSmokeTest {
+    @Test
+    fun `clients retry and report metrics`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val metrics = IntegrationsMetrics(registry)
+        val clock = Clock.systemUTC()
+        val cfg = IntegrationsHttpConfig(
+            userAgent = "test-agent",
+            timeoutMs = TimeoutMs(connect = 5000, socket = 5000, request = 5000),
+            retry = RetryCfg(
+                maxAttempts = 3,
+                baseBackoffMs = 1,
+                jitterMs = 0,
+                respectRetryAfter = false,
+                retryOn = listOf(429, 500, 502, 503, 504)
+            ),
+            circuitBreaker = CircuitBreakerCfg(
+                failuresThreshold = 3,
+                windowSeconds = 60,
+                openSeconds = 30,
+                halfOpenMaxCalls = 1
+            )
+        )
+        val attempts = mutableMapOf<String, Int>()
+        val engine = MockEngine { request ->
+            val key = request.url.encodedPath
+            val count = attempts.merge(key, 1, Int::plus) ?: 1
+            if (count == 1) {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.InternalServerError,
+                    headers = headersOf(HttpHeaders.ContentType, listOf(ContentType.Application.Json.toString()))
+                )
+            } else {
+                when (key) {
+                    "/iss/engines/stock/markets/shares/marketstatus.json" -> respond(
+                        content = """{"marketstatus":{"columns":["boardid","market","state","title"],"data":[["TQBR","stock","OPEN","Trading"]]}}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, listOf(ContentType.Application.Json.toString()))
+                    )
+                    "/api/v3/simple/price" -> respond(
+                        content = """{"bitcoin":{"usd":50000}}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, listOf(ContentType.Application.Json.toString()))
+                    )
+                    "/scripts/XML_daily.asp" -> respond(
+                        content = """<?xml version="1.0" encoding="UTF-8"?><ValCurs Date="02.11.2024"><Valute><CharCode>USD</CharCode><Nominal>1</Nominal><Value>95,0000</Value></Valute></ValCurs>""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, listOf(ContentType.Application.Xml.toString()))
+                    )
+                    else -> respond(
+                        content = "{}",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, listOf(ContentType.Application.Json.toString()))
+                    )
+                }
+            }
+        }
+        val client = HttpClient(engine) {
+            HttpClients.run {
+                configure(cfg, metrics, clock)
+            }
+        }
+        HttpClients.registerRetryMonitor(client, metrics)
+
+        val cbCfg = CircuitBreakerCfg(
+            failuresThreshold = 3,
+            windowSeconds = 60,
+            openSeconds = 30,
+            halfOpenMaxCalls = 1
+        )
+        val moexCb = CircuitBreaker("moex", cbCfg, metrics, clock)
+        val cgCb = CircuitBreaker("coingecko", cbCfg, metrics, clock)
+        val cbrCb = CircuitBreaker("cbr", cbCfg, metrics, clock)
+
+        val moexClient = MoexIssClient(client, moexCb, metrics, clock).apply { setBaseUrl("https://example.com") }
+        val cgClient = CoinGeckoClient(client, cgCb, metrics, clock, minRequestInterval = kotlin.time.Duration.ZERO).apply {
+            setBaseUrl("https://example.com")
+        }
+        val cbrClient = CbrClient(client, cbrCb, metrics, clock).apply { setBaseUrl("https://example.com") }
+
+        val moexResult = moexClient.getMarketStatus()
+        assertTrue(moexResult.isSuccess)
+        assertEquals("OPEN", moexResult.getOrNull()?.statuses?.firstOrNull()?.state)
+
+        val cgResult = cgClient.getSimplePrice(listOf("bitcoin"), listOf("usd"))
+        assertTrue(cgResult.isSuccess)
+        assertEquals(BigDecimal("50000"), cgResult.getOrNull()?.get("bitcoin")?.get("usd"))
+
+        val cbrResult = cbrClient.getXmlDaily(null)
+        assertTrue(cbrResult.isSuccess)
+        assertEquals("USD", cbrResult.getOrNull()?.firstOrNull()?.currencyCode)
+
+        assertEquals(2, attempts["/iss/engines/stock/markets/shares/marketstatus.json"])
+        assertEquals(2, attempts["/api/v3/simple/price"])
+        assertEquals(2, attempts["/scripts/XML_daily.asp"])
+
+        assertEquals(1.0, registry.counter("integrations_retry_total", "service", "moex").count())
+        assertEquals(1.0, registry.counter("integrations_retry_total", "service", "coingecko").count())
+        assertEquals(1.0, registry.counter("integrations_retry_total", "service", "cbr").count())
+
+        assertEquals(1L, registry.timer("integrations_request_seconds", "service", "moex", "outcome", "success").count())
+        assertEquals(1L, registry.timer("integrations_request_seconds", "service", "coingecko", "outcome", "success").count())
+        assertEquals(1L, registry.timer("integrations_request_seconds", "service", "cbr", "outcome", "success").count())
+
+        client.close()
+    }
+
+    @Test
+    fun `open breaker prevents call`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val metrics = IntegrationsMetrics(registry)
+        val clock = Clock.systemUTC()
+        val cfg = IntegrationsHttpConfig(
+            userAgent = "test-agent",
+            timeoutMs = TimeoutMs(connect = 1000, socket = 1000, request = 1000),
+            retry = RetryCfg(
+                maxAttempts = 2,
+                baseBackoffMs = 1,
+                jitterMs = 0,
+                respectRetryAfter = false,
+                retryOn = listOf(429, 500)
+            ),
+            circuitBreaker = CircuitBreakerCfg(
+                failuresThreshold = 1,
+                windowSeconds = 60,
+                openSeconds = 30,
+                halfOpenMaxCalls = 1
+            )
+        )
+        var called = 0
+        val engine = MockEngine {
+            called += 1
+            respond(
+                content = """{"marketstatus":{"columns":[],"data":[]}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val client = HttpClient(engine) {
+            HttpClients.run {
+                configure(cfg, metrics, clock)
+            }
+        }
+        HttpClients.registerRetryMonitor(client, metrics)
+
+        val cb = CircuitBreaker("moex", cfg.circuitBreaker, metrics, clock)
+        val moexClient = MoexIssClient(client, cb, metrics, clock).apply { setBaseUrl("https://example.com") }
+
+        assertFailsWith<IOException> {
+            cb.withPermit { throw IOException("boom") }
+        }
+
+        val result = moexClient.getMarketStatus()
+        val failure = result.exceptionOrNull()
+        assertIs<CircuitBreakerOpenException>(failure)
+        assertEquals(0, called)
+
+        client.close()
+    }
+}

--- a/integrations/src/test/kotlin/http/CircuitBreakerTest.kt
+++ b/integrations/src/test/kotlin/http/CircuitBreakerTest.kt
@@ -1,0 +1,97 @@
+package http
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.io.IOException
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+
+class CircuitBreakerTest {
+    @Test
+    fun `transitions update metrics`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val metrics = IntegrationsMetrics(registry)
+        val clock = MutableClock(Instant.parse("2024-01-01T00:00:00Z"))
+        val cfg = CircuitBreakerCfg(
+            failuresThreshold = 2,
+            windowSeconds = 60,
+            openSeconds = 30,
+            halfOpenMaxCalls = 1
+        )
+        val breaker = CircuitBreaker("test", cfg, metrics, clock)
+
+        assertEquals(CbState.CLOSED, breaker.currentState)
+        assertEquals(0.0, gaugeValue(registry))
+
+        repeat(2) {
+            assertFailsWith<IOException> {
+                breaker.withPermit { throw IOException("fail-$it") }
+            }
+        }
+
+        assertEquals(CbState.OPEN, breaker.currentState)
+        assertEquals(1.0, gaugeValue(registry))
+        assertEquals(1.0, registry.counter("integrations_cb_open_total", "service", "test").count())
+
+        assertFailsWith<CircuitBreakerOpenException> {
+            breaker.withPermit { "should not execute" }
+        }
+
+        clock.advanceSeconds(31)
+        val result = breaker.withPermit {
+            assertEquals(CbState.HALF_OPEN, breaker.currentState)
+            assertEquals(2.0, gaugeValue(registry))
+            "ok"
+        }
+        assertEquals("ok", result)
+        assertEquals(CbState.CLOSED, breaker.currentState)
+        assertEquals(0.0, gaugeValue(registry))
+
+        repeat(2) {
+            assertFailsWith<IOException> {
+                breaker.withPermit { throw IOException("again-$it") }
+            }
+        }
+        assertEquals(CbState.OPEN, breaker.currentState)
+        assertEquals(1.0, gaugeValue(registry))
+        assertEquals(2.0, registry.counter("integrations_cb_open_total", "service", "test").count())
+
+        clock.advanceSeconds(31)
+        assertFailsWith<IOException> {
+            breaker.withPermit {
+                assertEquals(CbState.HALF_OPEN, breaker.currentState)
+                assertEquals(2.0, gaugeValue(registry))
+                throw IOException("half-open failure")
+            }
+        }
+        assertEquals(CbState.OPEN, breaker.currentState)
+        assertEquals(1.0, gaugeValue(registry))
+        assertEquals(3.0, registry.counter("integrations_cb_open_total", "service", "test").count())
+
+        assertFailsWith<CircuitBreakerOpenException> {
+            breaker.withPermit { "blocked" }
+        }
+    }
+
+    private fun gaugeValue(registry: SimpleMeterRegistry): Double =
+        registry.find("integrations_cb_state").tags("service", "test").gauge()?.value() ?: error("gauge missing")
+
+    private class MutableClock(initial: Instant) : Clock() {
+        private var current: Instant = initial
+
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+
+        override fun withZone(zone: ZoneId): Clock = this
+
+        override fun instant(): Instant = current
+
+        fun advanceSeconds(seconds: Long) {
+            current = current.plusSeconds(seconds)
+        }
+    }
+}

--- a/integrations/src/test/kotlin/http/RetryRespectRetryAfterTest.kt
+++ b/integrations/src/test/kotlin/http/RetryRespectRetryAfterTest.kt
@@ -1,0 +1,128 @@
+package http
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+
+class RetryRespectRetryAfterTest {
+    @Test
+    fun `retries honor numeric retry-after header`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val metrics = IntegrationsMetrics(registry)
+        val clock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC)
+        var attempts = 0
+        val engine = MockEngine {
+            attempts += 1
+            if (attempts == 1) {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.TooManyRequests,
+                    headers = headersOf(HttpHeaders.RetryAfter, listOf("2"))
+                )
+            } else {
+                respond(
+                    content = "{}",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, listOf(ContentType.Application.Json.toString()))
+                )
+            }
+        }
+        val client = HttpClient(engine) {
+            HttpClients.run {
+                configure(testConfig(respectRetryAfter = true), metrics, clock)
+            }
+        }
+        HttpClients.registerRetryMonitor(client, metrics)
+
+        val response = HttpClients.measure("test-service") {
+            client.get("https://example.com/test")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(2, attempts)
+        assertEquals(1.0, registry.counter("integrations_retry_total", "service", "test-service").count())
+        assertEquals(
+            1.0,
+            registry.counter("integrations_retry_after_honored_total", "service", "test-service").count()
+        )
+
+        client.close()
+    }
+
+    @Test
+    fun `retries honor http-date retry-after header`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val metrics = IntegrationsMetrics(registry)
+        val clock = Clock.fixed(Instant.parse("2024-05-05T12:00:00Z"), ZoneOffset.UTC)
+        var attempts = 0
+        val retryAfterValue = java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME.format(
+            clock.instant().plusSeconds(3).atZone(ZoneOffset.UTC)
+        )
+        val engine = MockEngine {
+            attempts += 1
+            if (attempts == 1) {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.TooManyRequests,
+                    headers = headersOf(HttpHeaders.RetryAfter, listOf(retryAfterValue))
+                )
+            } else {
+                respond(
+                    content = "{}",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, listOf(ContentType.Application.Json.toString()))
+                )
+            }
+        }
+        val client = HttpClient(engine) {
+            HttpClients.run {
+                configure(testConfig(respectRetryAfter = true), metrics, clock)
+            }
+        }
+        HttpClients.registerRetryMonitor(client, metrics)
+
+        val response = HttpClients.measure("test-service") {
+            client.get("https://example.com/test-date")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(2, attempts)
+        assertEquals(1.0, registry.counter("integrations_retry_total", "service", "test-service").count())
+        assertEquals(
+            1.0,
+            registry.counter("integrations_retry_after_honored_total", "service", "test-service").count()
+        )
+
+        client.close()
+    }
+
+    private fun testConfig(respectRetryAfter: Boolean): IntegrationsHttpConfig = IntegrationsHttpConfig(
+        userAgent = "test-agent",
+        timeoutMs = TimeoutMs(connect = 500, socket = 500, request = 500),
+        retry = RetryCfg(
+            maxAttempts = 3,
+            baseBackoffMs = 1,
+            jitterMs = 0,
+            respectRetryAfter = respectRetryAfter,
+            retryOn = listOf(429, 500, 502, 503, 504)
+        ),
+        circuitBreaker = CircuitBreakerCfg(
+            failuresThreshold = 3,
+            windowSeconds = 60,
+            openSeconds = 30,
+            halfOpenMaxCalls = 1
+        )
+    )
+}


### PR DESCRIPTION
## Summary
- add a centralized integrations HttpClient with typed config, retry/backoff + Retry-After handling, metrics, and a lightweight circuit breaker
- wire the app module to build shared clients/circuit breakers and refactor MOEX, CoinGecko, and CBR integrations to use the shared stack
- document the new configuration and add retry/circuit-breaker unit and smoke tests

## Testing
- ./gradlew :integrations:compileKotlin :integrations:test :app:compileKotlin --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68dbc6c4cbb883218441a3b7c24e9973