### PR TITLE
feat: add admin feature flag controls

### DIFF
--- a/app/src/main/kotlin/di/FeatureFlagsModule.kt
+++ b/app/src/main/kotlin/di/FeatureFlagsModule.kt
@@ -1,0 +1,82 @@
+package di
+
+import app.Services
+import features.FeatureFlags
+import features.FeatureFlagsService
+import features.FeatureFlagsServiceImpl
+import io.ktor.server.application.Application
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.util.AttributeKey
+import repo.FeatureOverridesRepositoryImpl
+
+object FeatureFlagsModule {
+    data class Component(
+        val service: FeatureFlagsService,
+        val adminUserIds: Set<Long>
+    )
+
+    private val Key: AttributeKey<Component> = AttributeKey("FeatureFlagsModule")
+
+    fun install(application: Application): Component {
+        val attributes = application.attributes
+        if (attributes.contains(Key)) {
+            val component = attributes[Key]
+            attributes.updateServices(component)
+            return component
+        }
+
+        val config = application.environment.config
+        val defaults = config.loadFeatureDefaults()
+        val adminIds = config.loadAdminUserIds()
+        val repository = FeatureOverridesRepositoryImpl()
+        val service = FeatureFlagsServiceImpl(defaults, repository)
+        val component = Component(service = service, adminUserIds = adminIds)
+
+        attributes.put(Key, component)
+        attributes.updateServices(component)
+        return component
+    }
+
+    private fun io.ktor.util.Attributes.updateServices(component: Component) {
+        if (contains(Services.Key)) {
+            val current = this[Services.Key]
+            val enriched = current.withFeatureFlags(component.service, component.adminUserIds)
+            put(Services.Key, enriched)
+        }
+    }
+}
+
+private fun ApplicationConfig.loadFeatureDefaults(): FeatureFlags {
+    return FeatureFlags(
+        importByUrl = getFlag("features.importByUrl", default = false),
+        webhookQueue = getFlag("features.webhookQueue", default = true),
+        newsPublish = getFlag("features.newsPublish", default = true),
+        alertsEngine = getFlag("features.alertsEngine", default = true),
+        billingStars = getFlag("features.billingStars", default = true),
+        miniApp = getFlag("features.miniApp", default = true),
+    )
+}
+
+private fun ApplicationConfig.loadAdminUserIds(): Set<Long> {
+    return propertyOrNull("admin.adminUserIds")
+        ?.getList()
+        ?.mapNotNull { raw -> raw.trim().takeIf { it.isNotEmpty() }?.toLongOrNull() }
+        ?.toSet()
+        ?: emptySet()
+}
+
+private fun ApplicationConfig.getFlag(path: String, default: Boolean): Boolean {
+    val raw = propertyOrNull(path)?.getString()?.trim() ?: return default
+    return when (raw.lowercase()) {
+        "true", "1", "yes", "y" -> true
+        "false", "0", "no", "n" -> false
+        else -> default
+    }
+}
+
+private fun Services.withFeatureFlags(
+    service: FeatureFlagsService,
+    adminUserIds: Set<Long>
+): Services {
+    return copy(featureFlags = service, adminUserIds = adminUserIds)
+}

--- a/app/src/main/kotlin/routes/AdminFeaturesRoutes.kt
+++ b/app/src/main/kotlin/routes/AdminFeaturesRoutes.kt
@@ -1,0 +1,63 @@
+package routes
+
+import app.Services
+import features.FeatureFlagsPatch
+import features.FeatureFlagsService
+import features.FeatureFlagsValidationException
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.plugins.ContentTransformationException
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.route
+import kotlinx.serialization.SerializationException
+import security.userIdOrNull
+
+fun Route.adminFeaturesRoutes() {
+    route("/api/admin/features") {
+        get {
+            if (call.userIdOrNull == null) {
+                call.respondUnauthorized()
+                return@get
+            }
+            val services = call.application.attributes[Services.Key]
+            val flags = services.featureFlags.effective()
+            call.respond(HttpStatusCode.OK, flags)
+        }
+
+        patch {
+            val subject = call.userIdOrNull?.toLongOrNull() ?: run {
+                call.respondUnauthorized()
+                return@patch
+            }
+            val services = call.application.attributes[Services.Key]
+            if (!services.adminUserIds.contains(subject)) {
+                call.respond(HttpStatusCode.Forbidden, mapOf("error" to "forbidden"))
+                return@patch
+            }
+
+            val patch = try {
+                call.receive<FeatureFlagsPatch>()
+            } catch (_: ContentTransformationException) {
+                call.respondBadRequest(listOf("invalid_json"))
+                return@patch
+            } catch (_: SerializationException) {
+                call.respondBadRequest(listOf("invalid_json"))
+                return@patch
+            }
+
+            val service: FeatureFlagsService = services.featureFlags
+            try {
+                service.upsertGlobal(patch)
+            } catch (error: FeatureFlagsValidationException) {
+                call.respondBadRequest(error.errors)
+                return@patch
+            }
+
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -145,3 +145,16 @@ alerts {
     }
   }
 }
+
+admin {
+  adminUserIds = [ 7446417641 ]
+}
+
+features {
+  importByUrl  = false
+  webhookQueue = true
+  newsPublish  = true
+  alertsEngine = true
+  billingStars = true
+  miniApp      = true
+}

--- a/app/src/test/kotlin/routes/AdminFeaturesRoutesTest.kt
+++ b/app/src/test/kotlin/routes/AdminFeaturesRoutesTest.kt
@@ -1,0 +1,212 @@
+package routes
+
+import app.Services
+import billing.model.Tier
+import billing.model.UserSubscription
+import billing.service.BillingService
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.pengrad.telegrambot.TelegramBot
+import features.FeatureFlags
+import features.FeatureFlagsService
+import features.FeatureFlagsServiceImpl
+import features.FeatureOverridesRepository
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.patch
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.server.application.install
+import io.ktor.server.auth.authentication
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class AdminFeaturesRoutesTest {
+
+    @Test
+    fun `GET requires authentication`() = testApplication {
+        val repository = InMemoryFeatureOverridesRepository()
+        val service = service(repository)
+        configure(service)
+
+        val response = client.get("/api/admin/features")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `PATCH requires authentication`() = testApplication {
+        val repository = InMemoryFeatureOverridesRepository()
+        val service = service(repository)
+        configure(service)
+
+        val response = client.patch("/api/admin/features") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"importByUrl":true}""")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `PATCH rejects non admins`() = testApplication {
+        val repository = InMemoryFeatureOverridesRepository()
+        val service = service(repository)
+        configure(service)
+
+        val response = client.patch("/api/admin/features") {
+            header(HttpHeaders.Authorization, bearerFor("100"))
+            contentType(ContentType.Application.Json)
+            setBody("""{"importByUrl":true}""")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    @Test
+    fun `GET returns effective flags`() = testApplication {
+        val repository = InMemoryFeatureOverridesRepository()
+        val service = service(repository)
+        configure(service)
+
+        val response = client.get("/api/admin/features") {
+            header(HttpHeaders.Authorization, bearerFor("200"))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText())
+        val json = body.jsonObject
+        assertEquals(false, json["importByUrl"]?.jsonPrimitive?.boolean)
+        assertEquals(true, json["webhookQueue"]?.jsonPrimitive?.boolean)
+    }
+
+    @Test
+    fun `PATCH applies overrides immediately`() = testApplication {
+        val repository = InMemoryFeatureOverridesRepository()
+        val service = service(repository)
+        configure(service)
+
+        assertEquals(0L, service.updatesFlow.value)
+
+        val patchResponse = client.patch("/api/admin/features") {
+            header(HttpHeaders.Authorization, bearerFor(ADMIN_ID.toString()))
+            contentType(ContentType.Application.Json)
+            setBody("""{"importByUrl":true}""")
+        }
+
+        assertEquals(HttpStatusCode.NoContent, patchResponse.status)
+        assertEquals(1L, service.updatesFlow.value)
+
+        val response = client.get("/api/admin/features") {
+            header(HttpHeaders.Authorization, bearerFor("300"))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText())
+        val json = body.jsonObject
+        assertEquals(true, json["importByUrl"]?.jsonPrimitive?.boolean)
+        assertEquals(true, json["newsPublish"]?.jsonPrimitive?.boolean)
+    }
+
+    @Test
+    fun `PATCH validates payload`() = testApplication {
+        val repository = InMemoryFeatureOverridesRepository()
+        val service = service(repository)
+        configure(service)
+
+        val response = client.patch("/api/admin/features") {
+            header(HttpHeaders.Authorization, bearerFor(ADMIN_ID.toString()))
+            contentType(ContentType.Application.Json)
+            setBody("""{"importByUrl":"yes"}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    private fun ApplicationTestBuilder.configure(service: FeatureFlagsService) {
+        application {
+            install(ContentNegotiation) { json() }
+            install(testAuthPlugin)
+            attributes.put(
+                Services.Key,
+                Services(
+                    billingService = object : BillingService {
+                        override suspend fun listPlans() = Result.success(emptyList<billing.model.BillingPlan>())
+                        override suspend fun createInvoiceFor(userId: Long, tier: Tier) = Result.failure<String>(IllegalStateException("unused"))
+                        override suspend fun applySuccessfulPayment(
+                            userId: Long,
+                            tier: Tier,
+                            amountXtr: Long,
+                            providerPaymentId: String?,
+                            payload: String?
+                        ) = Result.failure<Unit>(IllegalStateException("unused"))
+                        override suspend fun getMySubscription(userId: Long) = Result.success<UserSubscription?>(null)
+                    },
+                    telegramBot = TelegramBot("test-token"),
+                    featureFlags = service,
+                    adminUserIds = setOf(ADMIN_ID)
+                )
+            )
+            routing { adminFeaturesRoutes() }
+        }
+    }
+
+    private fun service(repository: FeatureOverridesRepository): FeatureFlagsService {
+        val defaults = FeatureFlags(
+            importByUrl = false,
+            webhookQueue = true,
+            newsPublish = true,
+            alertsEngine = true,
+            billingStars = true,
+            miniApp = true
+        )
+        return FeatureFlagsServiceImpl(defaults, repository)
+    }
+
+    private fun bearerFor(subject: String): String {
+        val token = JWT.create().withSubject(subject).sign(Algorithm.HMAC256("test-secret"))
+        return "Bearer $token"
+    }
+
+    private class InMemoryFeatureOverridesRepository(
+        private var stored: String = "{}"
+    ) : FeatureOverridesRepository {
+        override suspend fun upsertGlobal(json: String) {
+            stored = json
+        }
+
+        override suspend fun findGlobal(): String = stored
+    }
+
+    private val testAuthPlugin = createApplicationPlugin(name = "TestAuth") {
+        onCall { call ->
+            val header = call.request.headers[HttpHeaders.Authorization]
+            if (header != null && header.startsWith("Bearer ")) {
+                val token = header.removePrefix("Bearer ")
+                val decoded = JWT.decode(token)
+                call.authentication.principal(JWTPrincipal(decoded))
+            }
+        }
+    }
+
+    private companion object {
+        private const val ADMIN_ID = 7446417641L
+    }
+}

--- a/core/src/main/kotlin/features/FeatureFlags.kt
+++ b/core/src/main/kotlin/features/FeatureFlags.kt
@@ -1,0 +1,151 @@
+package features
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class FeatureFlags(
+    val importByUrl: Boolean,
+    val webhookQueue: Boolean,
+    val newsPublish: Boolean,
+    val alertsEngine: Boolean,
+    val billingStars: Boolean,
+    val miniApp: Boolean,
+)
+
+@Serializable
+data class FeatureFlagsPatch(
+    val importByUrl: Boolean? = null,
+    val webhookQueue: Boolean? = null,
+    val newsPublish: Boolean? = null,
+    val alertsEngine: Boolean? = null,
+    val billingStars: Boolean? = null,
+    val miniApp: Boolean? = null,
+)
+
+fun FeatureFlags.merge(patch: FeatureFlagsPatch): FeatureFlags = FeatureFlags(
+    importByUrl = patch.importByUrl ?: importByUrl,
+    webhookQueue = patch.webhookQueue ?: webhookQueue,
+    newsPublish = patch.newsPublish ?: newsPublish,
+    alertsEngine = patch.alertsEngine ?: alertsEngine,
+    billingStars = patch.billingStars ?: billingStars,
+    miniApp = patch.miniApp ?: miniApp,
+)
+
+fun FeatureFlagsPatch.validate(): List<String> = emptyList()
+
+interface FeatureOverridesRepository {
+    suspend fun upsertGlobal(json: String)
+    suspend fun findGlobal(): String?
+}
+
+interface FeatureFlagsService {
+    val updatesFlow: StateFlow<Long>
+    suspend fun defaults(): FeatureFlags
+    suspend fun effective(): FeatureFlags
+    suspend fun upsertGlobal(patch: FeatureFlagsPatch)
+}
+
+class FeatureFlagsValidationException(val errors: List<String>) : IllegalArgumentException(
+    "Invalid feature flags patch"
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+class FeatureFlagsServiceImpl(
+    private val defaults: FeatureFlags,
+    private val repository: FeatureOverridesRepository,
+    private val json: Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+        explicitNulls = false
+    }
+) : FeatureFlagsService {
+    private val mutex = Mutex()
+    private val _updatesFlow = MutableStateFlow(0L)
+    @Volatile
+    private var loaded = false
+    @Volatile
+    private var globalPatch: FeatureFlagsPatch = FeatureFlagsPatch()
+
+    override val updatesFlow: StateFlow<Long> = _updatesFlow.asStateFlow()
+
+    override suspend fun defaults(): FeatureFlags = defaults
+
+    override suspend fun effective(): FeatureFlags {
+        val patch = currentPatch()
+        return defaults.merge(patch)
+    }
+
+    override suspend fun upsertGlobal(patch: FeatureFlagsPatch) {
+        val errors = patch.validate()
+        if (errors.isNotEmpty()) {
+            throw FeatureFlagsValidationException(errors)
+        }
+        mutex.withLock {
+            val existing = ensureLoadedLocked()
+            val merged = mergePatches(existing, patch)
+            val normalized = merged.normalized()
+            if (normalized == existing) {
+                return@withLock
+            }
+            val serialized = json.encodeToString(normalized)
+            repository.upsertGlobal(serialized)
+            globalPatch = normalized
+            _updatesFlow.update { value -> value + 1 }
+        }
+    }
+
+    private suspend fun currentPatch(): FeatureFlagsPatch = mutex.withLock { ensureLoadedLocked() }
+
+    private suspend fun ensureLoadedLocked(): FeatureFlagsPatch {
+        if (!loaded) {
+            val stored = repository.findGlobal()
+            globalPatch = stored?.let { decodePatch(it) } ?: FeatureFlagsPatch()
+            loaded = true
+        }
+        return globalPatch
+    }
+
+    private fun decodePatch(raw: String): FeatureFlagsPatch {
+        return try {
+            json.decodeFromString<FeatureFlagsPatch>(raw).normalized()
+        } catch (exception: SerializationException) {
+            throw IllegalStateException("Failed to decode feature overrides", exception)
+        }
+    }
+
+    private fun mergePatches(
+        base: FeatureFlagsPatch,
+        incoming: FeatureFlagsPatch
+    ): FeatureFlagsPatch {
+        return FeatureFlagsPatch(
+            importByUrl = incoming.importByUrl ?: base.importByUrl,
+            webhookQueue = incoming.webhookQueue ?: base.webhookQueue,
+            newsPublish = incoming.newsPublish ?: base.newsPublish,
+            alertsEngine = incoming.alertsEngine ?: base.alertsEngine,
+            billingStars = incoming.billingStars ?: base.billingStars,
+            miniApp = incoming.miniApp ?: base.miniApp,
+        )
+    }
+
+    private fun FeatureFlagsPatch.normalized(): FeatureFlagsPatch {
+        return FeatureFlagsPatch(
+            importByUrl = importByUrl,
+            webhookQueue = webhookQueue,
+            newsPublish = newsPublish,
+            alertsEngine = alertsEngine,
+            billingStars = billingStars,
+            miniApp = miniApp,
+        )
+    }
+}

--- a/storage/src/main/kotlin/repo/FeatureOverridesRepository.kt
+++ b/storage/src/main/kotlin/repo/FeatureOverridesRepository.kt
@@ -1,0 +1,66 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+import org.jetbrains.exposed.sql.json.jsonb
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.update
+
+interface FeatureOverridesRepository : features.FeatureOverridesRepository
+
+class FeatureOverridesRepositoryImpl(
+    private val json: Json = Json { ignoreUnknownKeys = true }
+) : FeatureOverridesRepository {
+    override suspend fun upsertGlobal(json: String) {
+        val element = parsePayload(json)
+        val now = Instant.now().atOffset(ZoneOffset.UTC)
+        dbQuery {
+            val updated = FeatureOverridesTable.update({ FeatureOverridesTable.key eq GLOBAL_KEY }) {
+                it[FeatureOverridesTable.payload] = element
+                it[FeatureOverridesTable.updatedAt] = now
+            }
+            if (updated == 0) {
+                FeatureOverridesTable.insert {
+                    it[FeatureOverridesTable.key] = GLOBAL_KEY
+                    it[FeatureOverridesTable.payload] = element
+                    it[FeatureOverridesTable.updatedAt] = now
+                }
+            }
+        }
+    }
+
+    override suspend fun findGlobal(): String? = dbQuery {
+        FeatureOverridesTable
+            .select { FeatureOverridesTable.key eq GLOBAL_KEY }
+            .firstOrNull()
+            ?.get(FeatureOverridesTable.payload)
+            ?.let { payload -> json.encodeToString(JsonElement.serializer(), payload) }
+    }
+
+    private fun parsePayload(raw: String): JsonElement {
+        val element = json.parseToJsonElement(raw)
+        require(element is JsonObject) { "payload must be a JSON object" }
+        return element
+    }
+
+    private companion object {
+        private const val GLOBAL_KEY = "global"
+    }
+}
+
+object FeatureOverridesTable : Table("feature_overrides") {
+    val key = text("key")
+    val payload = jsonb("payload", Json, JsonElement.serializer())
+    val updatedAt = timestampWithTimeZone("updated_at")
+
+    override val primaryKey = PrimaryKey(key)
+}

--- a/storage/src/main/resources/db/migration/V4__feature_overrides.sql
+++ b/storage/src/main/resources/db/migration/V4__feature_overrides.sql
@@ -1,0 +1,10 @@
+-- Глобальные оверрайды фич (одна запись с ключом 'global')
+CREATE TABLE feature_overrides (
+  key         TEXT PRIMARY KEY,   -- 'global'
+  payload     JSONB NOT NULL,     -- частичный объект (patch)
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Идемпотентный seed пустого патча
+INSERT INTO feature_overrides(key, payload) VALUES ('global', '{}'::jsonb)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- add typed feature flag models with persistence and in-memory overrides
- expose feature flag admin API with JWT access control and immediate updates
- wire feature flag module into application startup and document configuration

## Testing
- `./gradlew :core:test :app:test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68dbe8c513c883218f2fa7bf81fd6bca