### PR TITLE
Add analytics tracking and reporting

### DIFF
--- a/.github/workflows/analytics-daily.yml
+++ b/.github/workflows/analytics-daily.yml
@@ -1,0 +1,30 @@
+name: Analytics Daily Report
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch: {}
+
+env:
+  DATABASE_URL: ${{ secrets.STAGE_DB_URL }}
+
+jobs:
+  daily-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      - name: Run analytics report
+        run: |
+          psql "$DATABASE_URL" -At -F $'\t' -f tools/analytics/daily_report.sql -o analytics_daily.txt
+
+      - name: Upload analytics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: analytics-daily-report
+          path: analytics_daily.txt
+          retention-days: 7

--- a/app/src/main/kotlin/routes/AuthRoutes.kt
+++ b/app/src/main/kotlin/routes/AuthRoutes.kt
@@ -1,5 +1,6 @@
 package routes
 
+import analytics.AnalyticsPort
 import auth.WebAppVerify
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
@@ -13,7 +14,7 @@ import kotlinx.serialization.Serializable
 import security.JwtSupport
 import kotlin.collections.buildMap
 
-fun Route.authRoutes() {
+fun Route.authRoutes(analytics: AnalyticsPort = AnalyticsPort.Noop) {
     post("/api/auth/telegram/verify") {
         val request = runCatching { call.receive<TelegramVerifyRequest>() }.getOrElse {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse("bad_request"))
@@ -70,6 +71,13 @@ fun Route.authRoutes() {
         )
 
         call.respond(response)
+
+        analytics.track(
+            type = "miniapp_auth",
+            userId = userId,
+            source = "api",
+            props = mapOf("auth" to "ok"),
+        )
     }
 }
 

--- a/app/src/main/kotlin/routes/RedirectRoutes.kt
+++ b/app/src/main/kotlin/routes/RedirectRoutes.kt
@@ -1,0 +1,22 @@
+package routes
+
+import analytics.AnalyticsPort
+import io.ktor.server.application.call
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import security.userIdOrNull
+
+fun Route.redirectRoutes(analytics: AnalyticsPort = AnalyticsPort.Noop) {
+    get("/go/{id}") {
+        val id = call.parameters["id"].orEmpty()
+        analytics.track(
+            type = "cta_click",
+            userId = call.userIdOrNull?.toLongOrNull(),
+            source = "redirect",
+            props = mapOf("id" to id),
+        )
+        val targetId = id.ifBlank { "news_bot" }
+        call.respondRedirect("https://t.me/$targetId", permanent = false)
+    }
+}

--- a/app/src/test/kotlin/analytics/IntegrationEventsTest.kt
+++ b/app/src/test/kotlin/analytics/IntegrationEventsTest.kt
@@ -1,0 +1,238 @@
+package analytics
+
+import analytics.AnalyticsPort
+import billing.StarsWebhookHandler
+import billing.TgMessage
+import billing.TgSuccessfulPayment
+import billing.TgUpdate
+import billing.TgUser
+import billing.model.BillingPlan
+import billing.model.Tier
+import billing.model.UserSubscription
+import billing.service.ApplyPaymentOutcome
+import billing.service.BillingServiceWithOutcome
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.request.receiveText
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.ArrayDeque
+import java.util.LinkedHashMap
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import routes.authRoutes
+import routes.redirectRoutes
+import security.installSecurity
+
+class IntegrationEventsTest {
+    @Test
+    fun `critical flows emit analytics events`() = testApplication {
+        val analytics = RecordingAnalyticsPort()
+        val billing = StubBillingService()
+        val botToken = "123456:ABCDEF"
+
+        environment {
+            config = MapApplicationConfig(
+                "telegram.botToken" to botToken,
+                "security.jwtSecret" to "supersecretkeysupersecretkey",
+                "security.issuer" to "test-issuer",
+                "security.audience" to "test-audience",
+                "security.realm" to "test-realm",
+                "security.accessTtlMinutes" to "60",
+                "security.webappTtlMinutes" to "15",
+            )
+        }
+
+        application {
+            installSecurity()
+            routing {
+                authRoutes(analytics)
+                redirectRoutes(analytics)
+                post("/telegram/webhook/test") {
+                    val raw = call.receiveText()
+                    val update = StarsWebhookHandler.json.decodeFromString<TgUpdate>(raw)
+                    StarsWebhookHandler.handleParsed(call, update, billing, analytics = analytics)
+                }
+            }
+        }
+
+        val badResponse = client.post("/api/auth/telegram/verify") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            setBody("{}")
+        }
+        assertEquals(HttpStatusCode.BadRequest, badResponse.status)
+        assertTrue(analytics.events.isEmpty())
+
+        val initData = telegramInitData(botToken, userId = 777L, now = Instant.now())
+        val authResponse = client.post("/api/auth/telegram/verify") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            val body = Json.encodeToString(mapOf("initData" to initData))
+            setBody(body)
+        }
+        assertEquals(HttpStatusCode.OK, authResponse.status)
+        assertEquals("miniapp_auth", analytics.events.firstOrNull()?.type)
+
+        val redirectClient = client.config {
+            followRedirects = false
+        }
+        val redirectResponse = redirectClient.get("/go/promo")
+        assertEquals(HttpStatusCode.Found, redirectResponse.status)
+        assertEquals("https://t.me/promo", redirectResponse.headers[HttpHeaders.Location])
+
+        billing.enqueueResult(Result.success(ApplyPaymentOutcome(duplicate = false)))
+        val update = TgUpdate(
+            message = TgMessage(
+                from = billing.userStub,
+                successful_payment = TgSuccessfulPayment(
+                    currency = "XTR",
+                    total_amount = 1234L,
+                    invoice_payload = "${billing.userStub.id}:${Tier.PRO.name}:abc",
+                    provider_payment_charge_id = "pid-1"
+                )
+            )
+        )
+        val updateJson = StarsWebhookHandler.json.encodeToString(TgUpdate.serializer(), update)
+        val firstWebhook = client.post("/telegram/webhook/test") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            setBody(updateJson)
+        }
+        assertEquals(HttpStatusCode.OK, firstWebhook.status)
+
+        billing.enqueueResult(Result.success(ApplyPaymentOutcome(duplicate = true)))
+        val duplicateWebhook = client.post("/telegram/webhook/test") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            setBody(updateJson)
+        }
+        assertEquals(HttpStatusCode.OK, duplicateWebhook.status)
+
+        val types = analytics.events.map { it.type }
+        assertEquals(listOf("miniapp_auth", "cta_click", "stars_payment_succeeded", "stars_payment_duplicate"), types)
+
+        val authEvent = analytics.events[0]
+        assertEquals(777L, authEvent.userId)
+        assertEquals(mapOf("auth" to "ok"), authEvent.props)
+
+        val ctaEvent = analytics.events[1]
+        assertNull(ctaEvent.userId)
+        assertEquals(mapOf("id" to "promo"), ctaEvent.props)
+
+        val successEvent = analytics.events[2]
+        assertEquals(billing.userStub.id, successEvent.userId)
+        assertEquals(mapOf("tier" to Tier.PRO.name), successEvent.props)
+
+        val duplicateEvent = analytics.events[3]
+        assertEquals(billing.userStub.id, duplicateEvent.userId)
+        assertEquals(mapOf("tier" to Tier.PRO.name), duplicateEvent.props)
+    }
+
+    private fun telegramInitData(botToken: String, userId: Long, now: Instant): String {
+        val authDate = now.epochSecond.toString()
+        val userJson = """{"id":$userId,"username":"tester","first_name":"Test"}"""
+        val rawParams = mapOf(
+            "auth_date" to authDate,
+            "user" to userJson,
+        )
+        val dataCheckString = rawParams.entries
+            .sortedBy { it.key }
+            .joinToString("\n") { (key, value) -> "$key=$value" }
+        val secret = hmacSha256("WebAppData".toByteArray(StandardCharsets.UTF_8), botToken.toByteArray(StandardCharsets.UTF_8))
+        val hash = hmacSha256(secret, dataCheckString.toByteArray(StandardCharsets.UTF_8)).toHex()
+        val params = LinkedHashMap(rawParams)
+        params["hash"] = hash
+        return params.entries.joinToString("&") { (key, value) ->
+            "${urlEncode(key)}=${urlEncode(value)}"
+        }
+    }
+
+    private fun hmacSha256(key: ByteArray, message: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(message)
+    }
+
+    private fun ByteArray.toHex(): String = joinToString(separator = "") { byte ->
+        val unsigned = byte.toInt() and 0xff
+        unsigned.toString(16).padStart(2, '0')
+    }
+
+    private fun urlEncode(value: String): String =
+        URLEncoder.encode(value, StandardCharsets.UTF_8.name())
+
+    private class RecordingAnalyticsPort : AnalyticsPort {
+        val events = mutableListOf<TrackedEvent>()
+
+        override suspend fun track(
+            type: String,
+            userId: Long?,
+            source: String?,
+            sessionId: String?,
+            props: Map<String, Any?>,
+            ts: Instant
+        ) {
+            events += TrackedEvent(type, userId, source, sessionId, props)
+        }
+    }
+
+    private data class TrackedEvent(
+        val type: String,
+        val userId: Long?,
+        val source: String?,
+        val sessionId: String?,
+        val props: Map<String, Any?>,
+    )
+
+    private class StubBillingService : BillingServiceWithOutcome {
+        private val outcomes = ArrayDeque<Result<ApplyPaymentOutcome>>()
+        val userStub = TgUser(id = 42L)
+
+        fun enqueueResult(result: Result<ApplyPaymentOutcome>) {
+            outcomes.addLast(result)
+        }
+
+        override suspend fun applySuccessfulPaymentWithOutcome(
+            userId: Long,
+            tier: Tier,
+            amountXtr: Long,
+            providerPaymentId: String?,
+            payload: String?
+        ): Result<ApplyPaymentOutcome> {
+            check(outcomes.isNotEmpty()) { "No billing outcome enqueued" }
+            return outcomes.removeFirst()
+        }
+
+        override suspend fun applySuccessfulPayment(
+            userId: Long,
+            tier: Tier,
+            amountXtr: Long,
+            providerPaymentId: String?,
+            payload: String?
+        ): Result<Unit> = applySuccessfulPaymentWithOutcome(userId, tier, amountXtr, providerPaymentId, payload).map { }
+
+        override suspend fun listPlans(): Result<List<BillingPlan>> =
+            throw UnsupportedOperationException("not used")
+
+        override suspend fun createInvoiceFor(userId: Long, tier: Tier): Result<String> =
+            throw UnsupportedOperationException("not used")
+
+        override suspend fun getMySubscription(userId: Long): Result<UserSubscription?> =
+            throw UnsupportedOperationException("not used")
+    }
+}

--- a/core/src/main/kotlin/analytics/Events.kt
+++ b/core/src/main/kotlin/analytics/Events.kt
@@ -1,0 +1,29 @@
+package analytics
+
+import java.time.Instant
+
+interface AnalyticsPort {
+    suspend fun track(
+        type: String,
+        userId: Long?,
+        source: String?,
+        sessionId: String? = null,
+        props: Map<String, Any?> = emptyMap(),
+        ts: Instant = Instant.now()
+    )
+
+    companion object {
+        val Noop: AnalyticsPort = object : AnalyticsPort {
+            override suspend fun track(
+                type: String,
+                userId: Long?,
+                source: String?,
+                sessionId: String?,
+                props: Map<String, Any?>,
+                ts: Instant
+            ) {
+                // no-op
+            }
+        }
+    }
+}

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -1,0 +1,51 @@
+# Product Analytics / Аналитика продукта
+
+## Events storage / Хранилище событий
+- Таблица `events` создаётся миграцией [`V5__analytics_events.sql`][migration].
+- Схема: автоинкремент `event_id`, временная метка `ts` (UTC), `user_id` (опционально), `type`, `source`, `session_id`, `props` (`JSONB`).
+- Индексы по времени, типу, пользователю и JSONB гарантируют быстрые отчёты по сегментам.
+- Ключевые типы событий:
+  - `post_published` — публикация поста в канале.
+  - `cta_click` — переход по CTA (`/go/{id}`).
+  - `miniapp_auth` — успешная валидация initData и выдача JWT.
+  - `stars_payment_succeeded` — первичное применение платежа Stars.
+  - `stars_payment_duplicate` — повторная доставка платежа.
+  - (Расширяемый список, хранится в `props`).
+
+## Where tracked / Где интегрировано
+- `news/src/main/kotlin/news/publisher/ChannelPublisher.kt` — событие `post_published` после успешной отправки поста.
+- `app/src/main/kotlin/routes/AuthRoutes.kt` → `redirectRoutes` → `app/src/main/kotlin/routes/RedirectRoutes.kt` — события `miniapp_auth` и `cta_click`.
+- `app/src/main/kotlin/billing/StarsWebhookHandler.kt` — события `stars_payment_succeeded` / `stars_payment_duplicate`.
+- Все события пишутся через `AnalyticsPort` с реализацией [`AnalyticsRepository.kt`][repo-link].
+
+## Run reports / Как запускать отчёты
+1. Экспортируйте `DATABASE_URL` в формате `postgres://user:pass@host:port/db` (например, staging через `kubectl port-forward`).
+2. Запустите команду локально:
+   ```bash
+   DATABASE_URL="postgres://user:pass@localhost:5432/newsbot" \
+     psql "$DATABASE_URL" -At -F $'\t' -f tools/analytics/daily_report.sql
+   ```
+3. Вывод содержит:
+   - DAU и счётчики ключевых событий за 24 часа.
+   - Конверсионную воронку по дням за 7 дней.
+   - Недельные когорты миниаппа → платёж.
+4. Для staging используйте `$DATABASE_URL` из секретов (например, в CI — `secrets.STAGE_DB_URL`).
+
+## Privacy & Safety / Приватность и безопасность
+- В событиях не передаются PII, payload, суммы или токены.
+- Допустимые значения: числовые `user_id`, технические идентификаторы (`cluster_key`, `tier`, `id`).
+- При добавлении новых полей всегда проверяйте, что они не раскрывают персональные данные.
+
+## Extensibility / Расширение
+1. Добавьте новый `type` в место генерации события через `AnalyticsPort` (предпочтительно перечислить его в комментариях миграции и документации).
+2. Включите безопасные `props` (строки, числа, булевы значения) без PII.
+3. Расширьте отчёты (`tools/analytics/daily_report.sql`) по необходимости.
+4. Обновите тесты, проверяющие интеграцию (`storage/src/test/kotlin/repo/AnalyticsRepositoryTest.kt`, `app/src/test/kotlin/analytics/IntegrationEventsTest.kt`).
+
+## Daily export / Ежедневный выгруз (CI)
+- Workflow [`analytics-daily.yml`][workflow] запускает отчёт ежедневно в 06:00 UTC и по запросу (`workflow_dispatch`).
+- Результат сохраняется артефактом `analytics_daily_report` (retention 7 дней). Секреты не логируются: используется только `${{ secrets.STAGE_DB_URL }}`.
+
+[migration]: ../storage/src/main/resources/db/migration/V5__analytics_events.sql
+[repo-link]: ../storage/src/main/kotlin/repo/AnalyticsRepository.kt
+[workflow]: ../.github/workflows/analytics-daily.yml

--- a/news/build.gradle.kts
+++ b/news/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":core"))
     implementation(libs.coroutines.core)
     implementation("io.ktor:ktor-client-core-jvm:${libs.versions.ktor.get()}")
     implementation("io.ktor:ktor-client-cio:${libs.versions.ktor.get()}")

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.flyway.postgresql)
     testImplementation(libs.coroutines.core)
+    testImplementation("com.h2database:h2:2.2.224")
     testRuntimeOnly(libs.logback.classic)
 }
 

--- a/storage/src/main/kotlin/repo/AnalyticsRepository.kt
+++ b/storage/src/main/kotlin/repo/AnalyticsRepository.kt
@@ -1,0 +1,66 @@
+package repo
+
+import analytics.AnalyticsPort
+import db.DatabaseFactory.dbQuery
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+import org.jetbrains.exposed.sql.json.jsonb
+
+object EventsTable : Table("events") {
+    val eventId = long("event_id").autoIncrement()
+    val ts = timestampWithTimeZone("ts")
+    val userId = long("user_id").nullable()
+    val type = text("type")
+    val eventSource = text("source").nullable()
+    val sessionId = text("session_id").nullable()
+    val props = jsonb<JsonObject>("props", Json, JsonObject.serializer())
+    override val primaryKey = PrimaryKey(eventId)
+}
+
+class AnalyticsRepository : AnalyticsPort {
+    private fun mapToJson(props: Map<String, Any?>): JsonObject {
+        return buildJsonObject {
+            props.forEach { (key, value) ->
+                when (value) {
+                    null -> put(key, JsonNull)
+                    is Number -> put(key, JsonPrimitive(value))
+                    is Boolean -> put(key, JsonPrimitive(value))
+                    is String -> put(key, JsonPrimitive(value))
+                    is Instant -> put(key, JsonPrimitive(value.toString()))
+                    is Enum<*> -> put(key, JsonPrimitive(value.name))
+                    else -> put(key, JsonPrimitive(value.toString()))
+                }
+            }
+        }
+    }
+
+    override suspend fun track(
+        type: String,
+        userId: Long?,
+        source: String?,
+        sessionId: String?,
+        props: Map<String, Any?>,
+        ts: Instant
+    ) {
+        val jsonProps = mapToJson(props)
+        dbQuery {
+            EventsTable.insert {
+                it[EventsTable.ts] = ts.atOffset(ZoneOffset.UTC)
+                it[EventsTable.userId] = userId
+                it[EventsTable.type] = type
+                it[EventsTable.eventSource] = source
+                it[EventsTable.sessionId] = sessionId
+                it[EventsTable.props] = jsonProps
+            }
+        }
+    }
+}

--- a/storage/src/main/resources/db/migration/V5__analytics_events.sql
+++ b/storage/src/main/resources/db/migration/V5__analytics_events.sql
@@ -1,0 +1,16 @@
+-- Product analytics events storage
+CREATE TABLE events (
+  event_id   BIGSERIAL PRIMARY KEY,
+  ts         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  user_id    BIGINT NULL,                -- Telegram user id if known
+  type       TEXT    NOT NULL,           -- e.g. 'post_published','cta_click','bot_start','miniapp_auth','stars_payment_succeeded','stars_payment_duplicate','portfolio_import','alerts_push_sent','alerts_push_blocked'
+  source     TEXT    NULL,               -- e.g. 'news_publisher','webhook','api'
+  session_id TEXT    NULL,               -- optional correlation (miniapp session)
+  props      JSONB   NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- Indexes for time- and type-based queries
+CREATE INDEX idx_events_ts_desc   ON events (ts DESC);
+CREATE INDEX idx_events_type_ts   ON events (type, ts DESC);
+CREATE INDEX idx_events_user_ts   ON events (user_id, ts DESC);
+CREATE INDEX idx_events_props_gin ON events USING GIN (props);

--- a/storage/src/test/kotlin/repo/AnalyticsRepositoryTest.kt
+++ b/storage/src/test/kotlin/repo/AnalyticsRepositoryTest.kt
@@ -1,0 +1,70 @@
+package repo
+
+import it.TestDb
+import java.time.Instant
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.sql.selectAll
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AnalyticsRepositoryTest {
+    @Test
+    fun `track inserts analytics event`() = runBlocking {
+        TestDb.withMigratedDatabase {
+            val repository = AnalyticsRepository()
+            val ts = Instant.parse("2024-01-01T00:00:00Z")
+
+            repository.track(
+                type = "post_published",
+                userId = 123L,
+                source = "test",
+                sessionId = "abc-session",
+                props = mapOf("cluster_key" to "cluster-1", "attempt" to 2, "success" to true, "optional" to null),
+                ts = ts
+            )
+
+            val events = TestDb.tx {
+                EventsTable.selectAll().map { row ->
+                    val json = row[EventsTable.props]
+                    EventSnapshot(
+                        ts = row[EventsTable.ts].toInstant(),
+                        userId = row[EventsTable.userId],
+                        type = row[EventsTable.type],
+                        source = row[EventsTable.eventSource],
+                        sessionId = row[EventsTable.sessionId],
+                        clusterKey = json["cluster_key"]?.jsonPrimitive?.content,
+                        attempt = json["attempt"]?.jsonPrimitive?.content,
+                        success = json["success"]?.jsonPrimitive?.content,
+                        optional = json["optional"]?.jsonPrimitive?.content,
+                    )
+                }
+            }
+
+            assertEquals(1, events.size)
+            val event = events.single()
+            assertEquals(ts, event.ts)
+            assertEquals(123L, event.userId)
+            assertEquals("post_published", event.type)
+            assertEquals("test", event.source)
+            assertEquals("abc-session", event.sessionId)
+            assertEquals("cluster-1", event.clusterKey)
+            assertEquals("2", event.attempt)
+            assertEquals("true", event.success)
+            assertNull(event.optional)
+        }
+    }
+
+    private data class EventSnapshot(
+        val ts: Instant,
+        val userId: Long?,
+        val type: String,
+        val source: String?,
+        val sessionId: String?,
+        val clusterKey: String?,
+        val attempt: String?,
+        val success: String?,
+        val optional: String?,
+    )
+}

--- a/tools/analytics/daily_report.sql
+++ b/tools/analytics/daily_report.sql
@@ -1,0 +1,66 @@
+-- Events daily report (UTC)
+-- 1) DAU (distinct users) и события по типам за последние 24 часа
+WITH e AS (
+  SELECT *
+  FROM events
+  WHERE ts >= now() - interval '24 hours'
+)
+SELECT
+  (SELECT COUNT(DISTINCT user_id) FROM e WHERE user_id IS NOT NULL) AS dau,
+  (SELECT COUNT(*) FROM e WHERE type='post_published') AS post_published,
+  (SELECT COUNT(*) FROM e WHERE type='cta_click') AS cta_click,
+  (SELECT COUNT(*) FROM e WHERE type='miniapp_auth') AS miniapp_auth,
+  (SELECT COUNT(*) FROM e WHERE type='stars_payment_succeeded') AS stars_pay_ok,
+  (SELECT COUNT(*) FROM e WHERE type='stars_payment_duplicate') AS stars_pay_dup;
+
+-- 2) Conversion funnel за 7 дней (Post -> Click -> Start -> Pay)
+WITH e7 AS (
+  SELECT *
+  FROM events
+  WHERE ts >= now() - interval '7 days'
+),
+funnel AS (
+  SELECT
+    date_trunc('day', ts) AS d,
+    SUM(CASE WHEN type='post_published' THEN 1 ELSE 0 END) AS post,
+    SUM(CASE WHEN type='cta_click' THEN 1 ELSE 0 END) AS click,
+    SUM(CASE WHEN type='miniapp_auth' THEN 1 ELSE 0 END) AS start,
+    SUM(CASE WHEN type='stars_payment_succeeded' THEN 1 ELSE 0 END) AS pay
+  FROM e7
+  GROUP BY 1
+  ORDER BY 1
+)
+SELECT d::date, post, click, start, pay,
+       ROUND(100.0*click/NULLIF(post,0),2)  AS ctr_pc,
+       ROUND(100.0*start/NULLIF(click,0),2) AS start_rate_pc,
+       ROUND(100.0*pay/NULLIF(start,0),2)   AS pay_rate_pc
+FROM funnel;
+
+-- 3) Cohort по неделям первой авторизации miniapp → платёж
+WITH first_start AS (
+  SELECT user_id, MIN(ts)::date AS first_day
+  FROM events
+  WHERE type='miniapp_auth' AND user_id IS NOT NULL
+  GROUP BY user_id
+),
+cohort AS (
+  SELECT
+    date_trunc('week', first_day)::date AS cohort_week,
+    COUNT(*) AS users
+  FROM first_start
+  GROUP BY 1
+),
+pay_after AS (
+  SELECT DISTINCT e.user_id, date_trunc('week', fs.first_day)::date AS cohort_week
+  FROM events e
+  JOIN first_start fs ON fs.user_id = e.user_id
+  WHERE e.type='stars_payment_succeeded'
+)
+SELECT c.cohort_week,
+       c.users AS cohort_users,
+       COUNT(pay_after.user_id) AS paid_users,
+       ROUND(100.0*COUNT(pay_after.user_id)/NULLIF(c.users,0),2) AS pay_rate_pc
+FROM cohort c
+LEFT JOIN pay_after USING (cohort_week)
+GROUP BY 1,2
+ORDER BY 1;


### PR DESCRIPTION
## Summary
- add storage and repository for analytics events
- instrument publisher, auth, redirect, and billing flows to emit analytics
- document reporting, add SQL report and daily workflow, and cover with tests

## Testing
- ./gradlew :storage:flywayMigrate :storage:test :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dbf447ace0832184361688ed356857