### PR TITLE
Implement blue/green deployment tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ curl -s -X PATCH -H "Authorization: Bearer $JWT" -H "content-type: application/j
 - PATCH доступен только аккаунтам из `admin.adminUserIds`; для поиска `user_id` возьмите значение из Telegram (например, `/my_id` в @userinfobot или payload от Stars-платежей).
 - Ответы компактные JSON без PII, ошибки 401/403/400 покрывают неаутентифицированные/неадминские/битые запросы.
 
+## P34 — Blue/Green & Canary
+
+```bash
+# запуск стека
+docker compose -f deploy/compose/docker-compose.bluegreen.yml up -d
+
+# canary 10% на green
+bash tools/release/switch_traffic.sh GREEN 10
+
+# полный перевод на green
+bash tools/release/switch_traffic.sh GREEN 0
+
+# включить/выключить maintenance
+bash tools/release/maintenance.sh on
+bash tools/release/maintenance.sh off
+```
+
+- Заметка: health через /healthz, метрики через /metrics.
+
 ## P27 — Integrations hardening
 
 ## P28 — Metrics wiring

--- a/deploy/compose/docker-compose.bluegreen.yml
+++ b/deploy/compose/docker-compose.bluegreen.yml
@@ -1,0 +1,112 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: newsbot-bg-postgres
+    env_file:
+      - .env
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-newsbot}
+      POSTGRES_USER: ${POSTGRES_USER:-app}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-app_pass}
+      TZ: UTC
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB} -h 127.0.0.1 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+      - ./postgres/init.sql:/docker-entrypoint-initdb.d/001-init.sql:ro
+    restart: unless-stopped
+
+  app_blue:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    image: newsbot-app:latest
+    container_name: newsbot-app-blue
+    env_file:
+      - .env
+    environment:
+      TZ: UTC
+      APP_PORT: 8080
+      APP_PROFILE: ${APP_PROFILE:-prod}
+      DATABASE_URL: jdbc:postgresql://db:5432/${POSTGRES_DB:-newsbot}
+      DATABASE_USER: ${DATABASE_USER:-app}
+      DATABASE_PASS: ${DATABASE_PASS:-app_pass}
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-dummy_token}
+      TELEGRAM_WEBHOOK_SECRET: ${TELEGRAM_WEBHOOK_SECRET:-dummy_secret}
+    depends_on:
+      db:
+        condition: service_healthy
+    expose:
+      - "8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/health/db || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    restart: unless-stopped
+
+  app_green:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    image: newsbot-app:latest
+    container_name: newsbot-app-green
+    env_file:
+      - .env
+    environment:
+      TZ: UTC
+      APP_PORT: 8080
+      APP_PROFILE: ${APP_PROFILE:-prod}
+      DATABASE_URL: jdbc:postgresql://db:5432/${POSTGRES_DB:-newsbot}
+      DATABASE_USER: ${DATABASE_USER:-app}
+      DATABASE_PASS: ${DATABASE_PASS:-app_pass}
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-dummy_token}
+      TELEGRAM_WEBHOOK_SECRET: ${TELEGRAM_WEBHOOK_SECRET:-dummy_secret}
+    depends_on:
+      db:
+        condition: service_healthy
+    expose:
+      - "8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/health/db || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: newsbot-nginx-bluegreen
+    depends_on:
+      app_blue:
+        condition: service_healthy
+      app_green:
+        condition: service_healthy
+    ports:
+      - "${NGINX_HTTP_PORT:-8081}:80"
+      - "${NGINX_HTTPS_PORT:-8443}:443"
+    volumes:
+      - ./nginx/nginx.bluegreen.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./nginx/certs:/etc/nginx/certs:ro
+      - ./nginx/maintenance.html:/usr/share/nginx/html/maintenance.html:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/healthz || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    restart: unless-stopped
+
+volumes:
+  dbdata:

--- a/deploy/compose/nginx/conf.d/maintenance_toggle.conf
+++ b/deploy/compose/nginx/conf.d/maintenance_toggle.conf
@@ -1,0 +1,1 @@
+set $maintenance off;

--- a/deploy/compose/nginx/conf.d/upstream_weights.conf
+++ b/deploy/compose/nginx/conf.d/upstream_weights.conf
@@ -1,0 +1,2 @@
+server app_blue:8080 weight=100;
+server app_green:8080 weight=0;

--- a/deploy/compose/nginx/maintenance.html
+++ b/deploy/compose/nginx/maintenance.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Maintenance</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; padding: 0; background: #0f172a; color: #f8fafc; display: flex; align-items: center; justify-content: center; min-height: 100vh; }
+    main { text-align: center; max-width: 480px; padding: 2rem; }
+    h1 { font-size: 2rem; margin-bottom: 1rem; }
+    p { line-height: 1.5; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Scheduled maintenance</h1>
+    <p>We are performing a short maintenance to upgrade the service. Please retry in a few minutes.</p>
+    <p>Инженеры уже работают над задачей — попробуйте обновить страницу чуть позже.</p>
+  </main>
+</body>
+</html>

--- a/deploy/compose/nginx/nginx.bluegreen.conf
+++ b/deploy/compose/nginx/nginx.bluegreen.conf
@@ -1,0 +1,115 @@
+user  nginx;
+worker_processes  auto;
+
+events { worker_connections 1024; }
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+  sendfile      on;
+  keepalive_timeout 65;
+
+  set $maintenance off;
+  include /etc/nginx/conf.d/maintenance_toggle.conf;
+
+  map $maintenance $maintenance_mode {
+    default 0;
+    on      1;
+    off     0;
+  }
+
+  map $request_uri $maintenance_whitelist {
+    default 0;
+    /healthz 1;
+    /metrics 1;
+  }
+
+  map "$maintenance_mode:$maintenance_whitelist" $maintenance_gate {
+    default 0;
+    "1:0" 1;
+  }
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+  upstream app_pool {
+    zone app_pool 64k;
+    include /etc/nginx/conf.d/upstream_weights.conf;
+    keepalive 32;
+  }
+
+  server {
+    listen 80;
+    listen [::]:80;
+
+    location /healthz {
+      add_header Content-Type text/plain;
+      return 200 "ok\n";
+    }
+
+    location / {
+      return 301 https://$host$request_uri;
+    }
+  }
+
+  server {
+    listen              443 ssl http2;
+    listen              [::]:443 ssl http2;
+    server_name         _;
+
+    ssl_certificate     /etc/nginx/certs/tls.crt;
+    ssl_certificate_key /etc/nginx/certs/tls.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options DENY;
+    add_header Referrer-Policy no-referrer;
+
+    error_page 503 /maintenance.html;
+
+    if ($maintenance_gate) {
+      return 503;
+    }
+
+    location = /maintenance.html {
+      root /usr/share/nginx/html;
+      internal;
+    }
+
+    location /healthz {
+      add_header Content-Type text/plain;
+      return 200 "ok\n";
+    }
+
+    location /metrics {
+      proxy_pass         http://app_pool/metrics;
+      proxy_set_header   Host $host;
+      proxy_set_header   X-Real-IP $remote_addr;
+      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Proto https;
+      proxy_http_version 1.1;
+      proxy_set_header   Connection $connection_upgrade;
+      proxy_set_header   Upgrade $http_upgrade;
+      proxy_connect_timeout 5s;
+      proxy_read_timeout    60s;
+      proxy_buffering off;
+      add_header Cache-Control "no-store";
+    }
+
+    location / {
+      proxy_pass         http://app_pool;
+      proxy_set_header   Host $host;
+      proxy_set_header   X-Real-IP $remote_addr;
+      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Proto https;
+      proxy_http_version 1.1;
+      proxy_set_header   Connection $connection_upgrade;
+      proxy_set_header   Upgrade $http_upgrade;
+      proxy_connect_timeout 5s;
+      proxy_read_timeout    60s;
+    }
+  }
+}

--- a/docs/GO_LIVE_CUTOVER.md
+++ b/docs/GO_LIVE_CUTOVER.md
@@ -1,0 +1,62 @@
+# Go-live Cutover Runbook / План вывода в прод
+
+## Pre-checks / Предварительные проверки
+- ✅ Ensure `deploy/compose/.env` exists (`cp deploy/compose/.env.example deploy/compose/.env`) and contains production-like secrets via Vault/SOPS.
+- ✅ Bootstrap the blue/green stack:
+  ```bash
+  docker compose -f deploy/compose/docker-compose.bluegreen.yml up -d --build
+  docker compose -f deploy/compose/docker-compose.bluegreen.yml ps
+  ```
+- ✅ Confirm health gates:
+  - `curl -fsSL https://localhost:8443/healthz` → `ok` (or use `http://localhost:8081/healthz` without TLS).
+  - `curl -fsSL https://localhost:8443/metrics | head` to ensure the scrape endpoint responds.
+  - `curl -fsSL https://localhost:8443/health/db | jq .` from both `app_blue` and `app_green` containers if deeper DB check required.
+- ✅ Check Grafana dashboards from P21 for latency SLOs and error rates prior to traffic shifts.
+
+## Canary / Канарейка
+- 🔁 Start with BLUE as primary (100%) and GREEN as 10% canary:
+  ```bash
+  bash tools/release/switch_traffic.sh BLUE 10
+  ```
+- 👀 Observe for 10–15 minutes:
+  - Grafana panels: latency, error rate, saturation for the canary pod.
+  - Alertmanager silence status — no critical alerts should fire.
+  - `docker compose -f deploy/compose/docker-compose.bluegreen.yml exec nginx nginx -T | grep app_` (optional) to inspect live weights.
+- ✅ Health gates during canary:
+  - `curl -fsSL https://localhost:8443/metrics | head`
+  - `curl -fsSL https://localhost:8443/health/db`
+  - Application smoke via `/api/...` where applicable.
+
+## Promote / Промоут
+- ⬆️ When GREEN is stable, move full traffic:
+  ```bash
+  bash tools/release/switch_traffic.sh GREEN 0
+  ```
+- 🔄 Re-run health gates and Grafana checks to confirm GREEN owns 100% of the traffic and BLUE sits idle.
+- 📌 Update incident channel / release notes about completion.
+
+## Rollback / Откат
+- 🚨 If canary or promote fails, revert immediately:
+  ```bash
+  # return to BLUE primary, disable GREEN canary
+  bash tools/release/switch_traffic.sh BLUE 0
+  ```
+- ✅ Validate `/metrics`, `/healthz`, `/health/db` again.
+- 📝 Create incident note with timeline and observed failures; schedule a postmortem if needed.
+
+## Maintenance / Обслуживание
+- 🧰 Use maintenance mode during controlled outages (schema migrations, long-running ops):
+  ```bash
+  bash tools/release/maintenance.sh on
+  ```
+- 🌐 Users receive `503` with `deploy/compose/nginx/maintenance.html`, while `/healthz` and `/metrics` stay accessible for monitors.
+- 🔁 Disable maintenance promptly after work:
+  ```bash
+  bash tools/release/maintenance.sh off
+  ```
+- 📣 Announce start/end times in status channels.
+
+## Post-deploy / Постпроверки
+- 📊 Re-verify Grafana dashboards and alert silence status.
+- 🧪 Run smoke tests (`curl` critical APIs, Telegram webhook validation) to ensure business flows succeed.
+- 🗂️ Archive switch logs (`tools/release/switch_traffic.sh` output) in the release ticket and update runbook deviations if any occurred.

--- a/tools/release/maintenance.sh
+++ b/tools/release/maintenance.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") on|off" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+ACTION=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+
+if [[ "$ACTION" != "on" && "$ACTION" != "off" ]]; then
+  usage
+  exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+COMPOSE_FILE="$REPO_ROOT/deploy/compose/docker-compose.bluegreen.yml"
+TOGGLE_FILE="$REPO_ROOT/deploy/compose/nginx/conf.d/maintenance_toggle.conf"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "[error] compose file not found: $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TOGGLE_FILE" ]]; then
+  echo "[error] toggle file not found: $TOGGLE_FILE" >&2
+  exit 1
+fi
+
+TMP_FILE=$(mktemp "$(dirname "$TOGGLE_FILE")/maintenance_toggle.XXXXXX")
+trap 'rm -f "$TMP_FILE"' EXIT
+
+printf 'set $maintenance %s;\n' "$ACTION" >"$TMP_FILE"
+
+mv "$TMP_FILE" "$TOGGLE_FILE"
+trap - EXIT
+
+echo "[info] maintenance mode set to $ACTION"
+
+docker compose -f "$COMPOSE_FILE" ps
+
+docker compose -f "$COMPOSE_FILE" exec nginx nginx -s reload
+
+docker compose -f "$COMPOSE_FILE" exec nginx wget -qO- http://127.0.0.1/healthz >/dev/null
+
+docker compose -f "$COMPOSE_FILE" exec nginx wget -qO- http://127.0.0.1/metrics >/dev/null
+
+echo "[info] /healthz and /metrics remain reachable"

--- a/tools/release/switch_traffic.sh
+++ b/tools/release/switch_traffic.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") BLUE|GREEN <canary_weight>
+  BLUE|GREEN     Primary environment receiving 100% of the steady traffic.
+  canary_weight  Integer 0..50 defining the secondary weight for the other environment.
+USAGE
+}
+
+if [[ $# -ne 2 ]]; then
+  usage >&2
+  exit 1
+fi
+
+TARGET=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+CANARY_WEIGHT="$2"
+
+if [[ "$TARGET" != "BLUE" && "$TARGET" != "GREEN" ]]; then
+  echo "[error] target must be BLUE or GREEN" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! [[ "$CANARY_WEIGHT" =~ ^[0-9]+$ ]]; then
+  echo "[error] canary weight must be an integer" >&2
+  exit 1
+fi
+
+if (( CANARY_WEIGHT < 0 || CANARY_WEIGHT > 50 )); then
+  echo "[error] canary weight must be between 0 and 50" >&2
+  exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+COMPOSE_FILE="$REPO_ROOT/deploy/compose/docker-compose.bluegreen.yml"
+WEIGHTS_FILE="$REPO_ROOT/deploy/compose/nginx/conf.d/upstream_weights.conf"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "[error] compose file not found: $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$WEIGHTS_FILE" ]]; then
+  echo "[error] weights file not found: $WEIGHTS_FILE" >&2
+  exit 1
+fi
+
+case "$TARGET" in
+  BLUE)
+    BLUE_WEIGHT=100
+    GREEN_WEIGHT=$CANARY_WEIGHT
+    ;;
+  GREEN)
+    BLUE_WEIGHT=$CANARY_WEIGHT
+    GREEN_WEIGHT=100
+    ;;
+  *)
+    echo "[error] unsupported target $TARGET" >&2
+    exit 1
+    ;;
+esac
+
+TMP_FILE=$(mktemp "$(dirname "$WEIGHTS_FILE")/upstream_weights.XXXXXX")
+trap 'rm -f "$TMP_FILE"' EXIT
+
+cat <<CONFIG >"$TMP_FILE"
+server app_blue:8080 weight=$BLUE_WEIGHT;
+server app_green:8080 weight=$GREEN_WEIGHT;
+CONFIG
+
+mv "$TMP_FILE" "$WEIGHTS_FILE"
+trap - EXIT
+
+echo "[info] updated weights: app_blue=$BLUE_WEIGHT app_green=$GREEN_WEIGHT"
+
+docker compose -f "$COMPOSE_FILE" ps
+
+docker compose -f "$COMPOSE_FILE" exec nginx nginx -s reload
+
+docker compose -f "$COMPOSE_FILE" exec nginx wget -qO- http://127.0.0.1/healthz >/dev/null
+
+echo "[info] nginx reload complete and healthz reachable"


### PR DESCRIPTION
## Summary
- add a blue/green docker compose stack with weighted nginx upstream and maintenance assets
- provide release scripts for canary cutover and maintenance toggles plus supporting runbook
- document the workflow in the README with quick commands for switching traffic

## Testing
- ⚠️ `docker compose -f deploy/compose/docker-compose.bluegreen.yml config` *(fails: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1febfd9c832191934602a3d2d10d