### PR TITLE
Add growth funnels and experiments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ curl -s -X PATCH -H "Authorization: Bearer $JWT" -H "content-type: application/j
 - PATCH доступен только аккаунтам из `admin.adminUserIds`; для поиска `user_id` возьмите значение из Telegram (например, `/my_id` в @userinfobot или payload от Stars-платежей).
 - Ответы компактные JSON без PII, ошибки 401/403/400 покрывают неаутентифицированные/неадминские/битые запросы.
 
+## P38 — Growth & Funnels
+
+Документация: [docs/GROWTH_FUNNELS.md](docs/GROWTH_FUNNELS.md).
+
+```bash
+# Админ: создать/обновить эксперимент
+curl -s -X POST -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{ "key":"cta_copy", "enabled":true, "traffic":{"A":50,"B":50} }' \
+  "$BASE/api/admin/experiments/upsert" -i
+
+# Клиент: получить свои варианты
+curl -s -H "Authorization: Bearer $JWT" "$BASE/api/experiments/assignments" | jq .
+
+# Redirect с UTM/ref/cta
+curl -I "$BASE/go/news?utm_source=channel&utm_medium=cta&utm_campaign=oct&ref=R7G5K2&cta=promo"
+# → 302 Location: https://t.me/<bot>?start=id=news|src=channel|med=cta|cmp=oct|ref=R7G5K2|cta=promo|ab=<variant>
+```
+
 ## P34 — Blue/Green & Canary
 
 ```bash

--- a/app/src/main/kotlin/routes/AdminExperimentsRoutes.kt
+++ b/app/src/main/kotlin/routes/AdminExperimentsRoutes.kt
@@ -1,0 +1,52 @@
+package routes
+
+import ab.Experiment
+import ab.ExperimentsPort
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import kotlinx.serialization.Serializable
+import security.userIdOrNull
+
+@Serializable
+data class ExperimentUpsert(val key: String, val enabled: Boolean, val traffic: Map<String, Int>)
+
+fun Route.adminExperimentsRoutes(port: ExperimentsPort, adminUserIds: Set<Long>) {
+    route("/api/admin/experiments") {
+        post("/upsert") {
+            val userId = call.userIdOrNull?.toLongOrNull()
+            if (userId == null) {
+                call.respond(HttpStatusCode.Unauthorized)
+                return@post
+            }
+            if (userId !in adminUserIds) {
+                call.respond(HttpStatusCode.Forbidden, mapOf("error" to "forbidden"))
+                return@post
+            }
+            val request = runCatching { call.receive<ExperimentUpsert>() }
+                .getOrElse { exception ->
+                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to (exception.message ?: "invalid payload")))
+                    return@post
+                }
+            val totalTraffic = request.traffic.values.sum()
+            if (totalTraffic != 100) {
+                call.respond(HttpStatusCode.BadRequest, mapOf("error" to "traffic sum must be 100"))
+                return@post
+            }
+            if (request.traffic.isEmpty()) {
+                call.respond(HttpStatusCode.BadRequest, mapOf("error" to "traffic is empty"))
+                return@post
+            }
+            port.upsert(Experiment(key = request.key, enabled = request.enabled, traffic = request.traffic))
+            call.respond(HttpStatusCode.NoContent)
+        }
+        get {
+            call.respond(HttpStatusCode.OK, port.list())
+        }
+    }
+}

--- a/app/src/main/kotlin/routes/ExperimentsRoutes.kt
+++ b/app/src/main/kotlin/routes/ExperimentsRoutes.kt
@@ -1,0 +1,21 @@
+package routes
+
+import ab.ExperimentsService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import security.userIdOrNull
+
+fun Route.experimentsRoutes(service: ExperimentsService) {
+    get("/api/experiments/assignments") {
+        val userId = call.userIdOrNull?.toLongOrNull()
+        if (userId == null) {
+            call.respond(HttpStatusCode.Unauthorized)
+            return@get
+        }
+        val assignments = service.activeAssignments(userId)
+        call.respond(HttpStatusCode.OK, assignments)
+    }
+}

--- a/app/src/main/kotlin/routes/RedirectRoutes.kt
+++ b/app/src/main/kotlin/routes/RedirectRoutes.kt
@@ -1,22 +1,94 @@
 package routes
 
 import analytics.AnalyticsPort
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.encodeURLParameter
 import io.ktor.server.application.call
+import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import referrals.ReferralsPort
+import referrals.UTM
+import kotlin.text.Charsets
 import security.userIdOrNull
 
-fun Route.redirectRoutes(analytics: AnalyticsPort = AnalyticsPort.Noop) {
+fun Route.redirectRoutes(
+    analytics: AnalyticsPort,
+    referrals: ReferralsPort,
+    botDeepLinkBase: String,
+    maxPayloadBytes: Int
+) {
     get("/go/{id}") {
-        val id = call.parameters["id"].orEmpty()
+        val id = call.parameters["id"].orEmpty().trim()
+        if (id.isEmpty()) {
+            call.respond(HttpStatusCode.BadRequest)
+            return@get
+        }
+        val utm = UTM(
+            source = call.request.queryParameters["utm_source"],
+            medium = call.request.queryParameters["utm_medium"],
+            campaign = call.request.queryParameters["utm_campaign"],
+            ctaId = call.request.queryParameters["cta"]
+        )
+        val ref = call.request.queryParameters["ref"]?.takeIf { it.isNotBlank() }
+        if (ref != null) {
+            referrals.recordVisit(ref, null, utm)
+        }
         analytics.track(
             type = "cta_click",
             userId = call.userIdOrNull?.toLongOrNull(),
             source = "redirect",
-            props = mapOf("id" to id),
+            props = mapOf(
+                "id" to id,
+                "utm_source" to (utm.source ?: ""),
+                "utm_medium" to (utm.medium ?: ""),
+                "utm_campaign" to (utm.campaign ?: ""),
+                "ref" to (ref ?: ""),
+                "cta" to (utm.ctaId ?: "")
+            )
         )
-        val targetId = id.ifBlank { "news_bot" }
-        call.respondRedirect("https://t.me/$targetId", permanent = false)
+        val payload = buildPayload(id = id, utm = utm, ref = ref, maxBytes = maxPayloadBytes)
+        val sanitizedBase = botDeepLinkBase.trim().trimEnd('/', '?')
+        val encodedPayload = payload.encodeURLParameter()
+        val target = "$sanitizedBase?start=$encodedPayload"
+        call.respondRedirect(target, permanent = false)
     }
+}
+
+private fun buildPayload(id: String, utm: UTM, ref: String?, maxBytes: Int): String {
+    val parts = mutableListOf("id=${sanitizeToken(id)}")
+    utm.source?.let { parts += "src=${sanitizeToken(it)}" }
+    utm.medium?.let { parts += "med=${sanitizeToken(it)}" }
+    utm.campaign?.let { parts += "cmp=${sanitizeToken(it)}" }
+    utm.ctaId?.let { parts += "cta=${sanitizeToken(it)}" }
+    ref?.let { parts += "ref=${sanitizeToken(it)}" }
+    val raw = parts.joinToString(separator = "|")
+    return trimToBytes(raw, maxBytes)
+}
+
+private fun sanitizeToken(value: String): String {
+    val filtered = value.trim().take(64).map { ch ->
+        when {
+            ch.isLetterOrDigit() -> ch
+            ch in listOf('-', '_', '.', ':') -> ch
+            else -> '_'
+        }
+    }
+    return filtered.joinToString(separator = "")
+}
+
+private fun trimToBytes(value: String, maxBytes: Int): String {
+    require(maxBytes > 0) { "maxBytes must be positive" }
+    var bytes = 0
+    val builder = StringBuilder()
+    for (ch in value) {
+        val charBytes = ch.toString().toByteArray(Charsets.UTF_8).size
+        if (bytes + charBytes > maxBytes) {
+            break
+        }
+        builder.append(ch)
+        bytes += charBytes
+    }
+    return builder.toString()
 }

--- a/app/src/test/kotlin/routes/ExperimentsRoutesTest.kt
+++ b/app/src/test/kotlin/routes/ExperimentsRoutesTest.kt
@@ -1,0 +1,111 @@
+package routes
+
+import ab.Assignment
+import ab.Experiment
+import ab.ExperimentsPort
+import ab.ExperimentsServiceImpl
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.server.application.install
+import io.ktor.server.auth.authentication
+import io.ktor.http.HttpHeaders
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class ExperimentsRoutesTest {
+    @Test
+    fun `returns 401 without authentication`() = testApplication {
+        val port = StubExperimentsPort()
+        val service = ExperimentsServiceImpl(port)
+        application {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; encodeDefaults = true })
+            }
+            install(testAuthPlugin)
+            routing { experimentsRoutes(service) }
+        }
+
+        val response = client.get("/api/experiments/assignments")
+        assertEquals(401, response.status.value)
+    }
+
+    @Test
+    fun `returns deterministic assignments`() = testApplication {
+        val port = StubExperimentsPort()
+        val service = ExperimentsServiceImpl(port)
+        val userId = 1234L
+        val expected = runBlocking { service.assign(userId, "cta_copy") }.variant
+
+        application {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; encodeDefaults = true })
+            }
+            install(testAuthPlugin)
+            routing { experimentsRoutes(service) }
+        }
+
+        val token = bearerFor(userId.toString())
+        val firstResponse = client.get("/api/experiments/assignments") {
+            header(HttpHeaders.Authorization, token)
+        }
+        assertEquals(200, firstResponse.status.value)
+        val firstBody = firstResponse.bodyAsText()
+        val firstVariant = Json.parseToJsonElement(firstBody).jsonArray.first().jsonObject["variant"]?.jsonPrimitive?.content
+        assertEquals(expected, firstVariant)
+
+        val secondResponse = client.get("/api/experiments/assignments") {
+            header(HttpHeaders.Authorization, token)
+        }
+        assertEquals(200, secondResponse.status.value)
+        val secondBody = secondResponse.bodyAsText()
+        val secondVariant = Json.parseToJsonElement(secondBody).jsonArray.first().jsonObject["variant"]?.jsonPrimitive?.content
+        assertEquals(expected, secondVariant)
+
+        assertTrue(port.assignments.containsKey(userId to "cta_copy"))
+    }
+
+    private fun bearerFor(subject: String): String {
+        val token = JWT.create().withSubject(subject).sign(Algorithm.HMAC256("test-secret"))
+        return "Bearer $token"
+    }
+
+    private val testAuthPlugin = createApplicationPlugin(name = "TestAuthExperiments") {
+        onCall { call ->
+            val header = call.request.headers[HttpHeaders.Authorization]
+            if (header != null && header.startsWith("Bearer ")) {
+                val token = header.removePrefix("Bearer ")
+                val decoded = JWT.decode(token)
+                call.authentication.principal(io.ktor.server.auth.jwt.JWTPrincipal(decoded))
+            }
+        }
+    }
+
+    private class StubExperimentsPort : ExperimentsPort {
+        private val experiments = listOf(Experiment(key = "cta_copy", enabled = true, traffic = mapOf("A" to 60, "B" to 40)))
+        val assignments = mutableMapOf<Pair<Long, String>, Assignment>()
+
+        override suspend fun list(): List<Experiment> = experiments
+
+        override suspend fun upsert(e: Experiment) {}
+
+        override suspend fun getAssignment(userId: Long, key: String): Assignment? = assignments[userId to key]
+
+        override suspend fun saveAssignment(a: Assignment) {
+            assignments.putIfAbsent(a.userId to a.key, a)
+        }
+    }
+}

--- a/app/src/test/kotlin/routes/RedirectRoutesTest.kt
+++ b/app/src/test/kotlin/routes/RedirectRoutesTest.kt
@@ -1,0 +1,118 @@
+package routes
+
+import analytics.AnalyticsPort
+import io.ktor.client.request.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import java.net.URI
+import java.net.URLDecoder
+import java.time.Instant
+import java.nio.charset.StandardCharsets
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import referrals.ReferralCode
+import referrals.ReferralsPort
+import referrals.UTM
+
+class RedirectRoutesTest {
+    @Test
+    fun `redirect returns deep link and tracks analytics`() = testApplication {
+        val analytics = RecordingAnalytics()
+        val referrals = RecordingReferrals()
+
+        application {
+            routing {
+                redirectRoutes(analytics, referrals, "https://t.me/test_bot", 64)
+            }
+        }
+
+        val client = createClient {
+            followRedirects = false
+        }
+        val response = client.get("/go/news")
+        assertEquals(302, response.status.value)
+        val location = response.headers["Location"] ?: error("missing location")
+        assertTrue(location.startsWith("https://t.me/test_bot?start="))
+
+        val payload = extractStartPayload(location)
+        assertTrue(payload.startsWith("id=news"))
+        assertTrue(payload.toByteArray(StandardCharsets.UTF_8).size <= 64)
+
+        val event = analytics.events.single()
+        assertEquals("cta_click", event.type)
+        assertEquals("news", event.props["id"])
+    }
+
+    @Test
+    fun `redirect captures referral and utm params`() = testApplication {
+        val analytics = RecordingAnalytics()
+        val referrals = RecordingReferrals()
+
+        application {
+            routing {
+                redirectRoutes(analytics, referrals, "https://t.me/test_bot", 64)
+            }
+        }
+
+        val client = createClient {
+            followRedirects = false
+        }
+        val response = client.get("/go/promo?ref=R7G5K2&utm_source=channel&utm_medium=cta&utm_campaign=october&utm_extra=${"x".repeat(100)}")
+        assertEquals(302, response.status.value)
+        val payload = extractStartPayload(response.headers["Location"]!!)
+        assertTrue(payload.contains("ref=R7G5K2"))
+        assertTrue(payload.toByteArray(StandardCharsets.UTF_8).size <= 64)
+
+        val visit = referrals.visits.single()
+        assertEquals("R7G5K2", visit.code)
+        assertEquals("channel", visit.utm.source)
+        assertEquals("cta", visit.utm.medium)
+        assertEquals("october", visit.utm.campaign)
+
+        val event = analytics.events.single { it.props["id"] == "promo" }
+        assertEquals("", event.props["cta"])
+    }
+
+    private fun extractStartPayload(location: String): String {
+        val uri = URI(location)
+        val query = uri.query ?: return ""
+        val startParam = query.split('&').firstOrNull { it.startsWith("start=") } ?: return ""
+        val value = startParam.substringAfter('=')
+        return URLDecoder.decode(value, StandardCharsets.UTF_8)
+    }
+
+    private class RecordingAnalytics : AnalyticsPort {
+        data class Event(val type: String, val userId: Long?, val source: String?, val props: Map<String, String>)
+        val events = mutableListOf<Event>()
+
+        override suspend fun track(
+            type: String,
+            userId: Long?,
+            source: String?,
+            sessionId: String?,
+            props: Map<String, Any?>,
+            ts: java.time.Instant
+        ) {
+            val normalized = props.mapValues { it.value?.toString() ?: "" }
+            events += Event(type, userId, source, normalized)
+        }
+    }
+
+    private class RecordingReferrals : ReferralsPort {
+        data class Visit(val code: String, val utm: UTM, val tgUserId: Long?)
+        val visits = mutableListOf<Visit>()
+
+        override suspend fun create(ownerUserId: Long, code: String): ReferralCode = ReferralCode(code, ownerUserId)
+
+        override suspend fun find(code: String): ReferralCode? = null
+
+        override suspend fun recordVisit(code: String, tgUserId: Long?, utm: UTM) {
+            visits += Visit(code, utm, tgUserId)
+        }
+
+        override suspend fun attachUser(code: String, tgUserId: Long) {
+            visits += Visit(code, UTM(null, null, null), tgUserId)
+        }
+    }
+}

--- a/core/src/main/kotlin/ab/Experiments.kt
+++ b/core/src/main/kotlin/ab/Experiments.kt
@@ -1,0 +1,72 @@
+package ab
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Experiment(val key: String, val enabled: Boolean, val traffic: Map<String, Int>)
+
+@Serializable
+data class Assignment(val userId: Long, val key: String, val variant: String)
+
+interface ExperimentsPort {
+    suspend fun list(): List<Experiment>
+    suspend fun upsert(e: Experiment)
+    suspend fun getAssignment(userId: Long, key: String): Assignment?
+    suspend fun saveAssignment(a: Assignment)
+}
+
+interface ExperimentsService {
+    suspend fun assign(userId: Long, key: String): Assignment
+    suspend fun activeAssignments(userId: Long): List<Assignment>
+}
+
+class ExperimentsServiceImpl(private val port: ExperimentsPort) : ExperimentsService {
+    private fun pickDeterministic(userId: Long, experiment: Experiment): String {
+        require(experiment.traffic.isNotEmpty()) { "experiment traffic must not be empty" }
+        val digest = MessageDigest.getInstance("SHA-256")
+        val bytes = digest.digest("${experiment.key}:$userId".toByteArray(StandardCharsets.UTF_8))
+        val bucket = (bytes[0].toInt() and 0xFF) % 100
+        var cumulative = 0
+        val entries = experiment.traffic.entries.sortedBy { it.key }
+        val total = entries.sumOf { (_, percent) -> percent.coerceAtLeast(0) }
+        if (total <= 0) {
+            return entries.first().key
+        }
+        for ((variant, percent) in entries) {
+            val clamped = percent.coerceAtLeast(0)
+            if (clamped == 0) {
+                continue
+            }
+            cumulative += clamped
+            val scaledThreshold = (cumulative * 100) / total
+            if (bucket < scaledThreshold) {
+                return variant
+            }
+        }
+        return entries.last().key
+    }
+
+    private suspend fun ensureAssignment(userId: Long, experiment: Experiment): Assignment {
+        val existing = port.getAssignment(userId, experiment.key)
+        if (existing != null) {
+            return existing
+        }
+        val variant = pickDeterministic(userId, experiment)
+        val assignment = Assignment(userId, experiment.key, variant)
+        port.saveAssignment(assignment)
+        return assignment
+    }
+
+    override suspend fun assign(userId: Long, key: String): Assignment {
+        val experiment = port.list().firstOrNull { it.key == key && it.enabled }
+            ?: throw NoSuchElementException("experiment disabled or missing")
+        return ensureAssignment(userId, experiment)
+    }
+
+    override suspend fun activeAssignments(userId: Long): List<Assignment> {
+        val experiments = port.list().filter { it.enabled }
+        return experiments.map { experiment -> ensureAssignment(userId, experiment) }
+    }
+}

--- a/core/src/main/kotlin/referrals/Referrals.kt
+++ b/core/src/main/kotlin/referrals/Referrals.kt
@@ -1,0 +1,16 @@
+package referrals
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReferralCode(val code: String, val ownerUserId: Long)
+
+interface ReferralsPort {
+    suspend fun create(ownerUserId: Long, code: String): ReferralCode
+    suspend fun find(code: String): ReferralCode?
+    suspend fun recordVisit(code: String, tgUserId: Long?, utm: UTM)
+    suspend fun attachUser(code: String, tgUserId: Long)
+}
+
+@Serializable
+data class UTM(val source: String?, val medium: String?, val campaign: String?, val ctaId: String? = null)

--- a/docs/GROWTH_FUNNELS.md
+++ b/docs/GROWTH_FUNNELS.md
@@ -1,0 +1,29 @@
+# P38 — Growth & Funnels
+
+## UTM и рефералы / UTM & Referrals
+- Поддерживаемые параметры: `utm_source`, `utm_medium`, `utm_campaign`, а также `ref` (буквенно-цифровой код) и `cta` (идентификатор кнопки/лендинга).
+- Каждый `ref` привязан к `referrals.ref_code` и владельцу (`owner_user_id`). Код уникальный, рекомендованный формат — 5–8 символов `[A-Z0-9]`.
+- При первом переходе `/go/{id}` сохраняем визит в `referral_visits` с UTM-метками и, если доступно, `cta_id`. После авторизации /start Telegram — вызываем `attachUser`, чтобы дополнить визит `tg_user_id` (идемпотентно по паре `ref_code`, `tg_user_id`).
+- Событие `cta_click` в `events` фиксирует идентификатор CTA и UTM-метки для аналитики.
+
+## Deep-link payload (≤64 bytes)
+- Шаблон `id=<id>|src=<source>|med=<medium>|cmp=<campaign>|cta=<cta>|ref=<code>|ab=<variant>` — маркеры добавляются только при наличии данных.
+- Payload обрезается по байтам (UTF-8) до лимита, затем URL-энкодится в `?start=`. Значения безопасно нормализуются (латиница/цифры/`-_.:`).
+- Базовый URL берётся из `news.botDeepLinkBase`, по умолчанию `https://t.me/<bot_username>`.
+
+## Эксперименты / Experiments
+- Конфигурация хранится в `experiments` (`traffic` в процентах, сумма = 100). Админ-API: `POST /api/admin/experiments/upsert` (JWT + `adminUserIds`).
+- Назначение варианта детерминировано: `hash(userId + key) mod 100`, persistent storage `experiment_assignments`. Повторное назначение возвращает сохранённый вариант.
+- Клиентский API: `GET /api/experiments/assignments` (JWT) → список активных экспериментальных вариантов пользователя.
+- Mini App читает ассайнменты и отображает их в настройках (read-only).
+
+## SQL отчёты
+- Файл `tools/analytics/funnels.sql` содержит три запроса:
+  1. Воронка Post → Click → Start → Pay (скользящее окно 7 дней).
+  2. Производительность рефералов (визиты и привязанные пользователи за 7 дней).
+  3. Лифт A/B по эксперименту `cta_copy` (клики и оплаты за 14 дней).
+- Запуск: `psql $DATABASE_URL -f tools/analytics/funnels.sql` либо через BI-инструмент с доступом к продовой БД.
+
+## Privacy / Конфиденциальность
+- События не содержат PII: храним только числовые идентификаторы (`user_id`, `ref_code`, UTM). Параметры/токены не логируются.
+- Сроки хранения задаются в `privacy.retention` (см. P36). Регулярно запускаем процессы очистки, чтобы соответствовать требованиям.

--- a/miniapp/src/lib/experiments.ts
+++ b/miniapp/src/lib/experiments.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from "react";
+import { clearJwt, getJwt } from "./session";
+
+const API_BASE = (import.meta.env.VITE_API_BASE ?? "").replace(/\/$/, "");
+
+function withBase(path: string): string {
+  if (!API_BASE) {
+    return path;
+  }
+  if (path.startsWith("http")) {
+    return path;
+  }
+  return `${API_BASE}${path}`;
+}
+
+export interface Assignment {
+  userId: number;
+  key: string;
+  variant: string;
+}
+
+export async function fetchAssignments(): Promise<Assignment[]> {
+  const token = getJwt();
+  if (!token) {
+    throw new Error("Unauthorized");
+  }
+  const response = await fetch(withBase("/api/experiments/assignments"), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (response.status === 401) {
+    clearJwt();
+    throw new Error("Unauthorized");
+  }
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || "Failed to fetch assignments");
+  }
+  const text = await response.text();
+  if (!text) {
+    return [];
+  }
+  const data = JSON.parse(text) as Assignment[];
+  return data.map((assignment) => ({
+    userId: Number(assignment.userId),
+    key: assignment.key,
+    variant: assignment.variant,
+  }));
+}
+
+export function useExperiments(): {
+  assignments: Assignment[];
+  loading: boolean;
+  error: Error | null;
+  variant: (key: string) => string | undefined;
+} {
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchAssignments()
+      .then((items) => {
+        if (!cancelled) {
+          setAssignments(items);
+          setError(null);
+        }
+      })
+      .catch((err: Error) => {
+        if (!cancelled) {
+          setError(err);
+          setAssignments([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const variant = useCallback(
+    (key: string) => assignments.find((assignment) => assignment.key === key)?.variant,
+    [assignments],
+  );
+
+  return {
+    assignments,
+    loading,
+    error,
+    variant,
+  };
+}

--- a/miniapp/src/pages/Settings.tsx
+++ b/miniapp/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { LanguageSelect } from "../components/LanguageSelect";
 import type { InitDataUnsafe } from "../lib/telegram";
 import type { ThemeMode } from "../lib/session";
 import { clearJwt, clearUIPreferences, setThemePreference } from "../lib/session";
+import { useExperiments } from "../lib/experiments";
 
 interface SettingsProps {
   theme: ThemeMode;
@@ -13,6 +14,7 @@ interface SettingsProps {
 export function Settings({ theme, onThemeChange, initDataUnsafe }: SettingsProps): JSX.Element {
   const { t } = useTranslation();
   const username = initDataUnsafe?.user?.username ?? "-";
+  const { assignments, loading, error } = useExperiments();
 
   const handleThemeChange = (nextTheme: ThemeMode) => {
     setThemePreference(nextTheme);
@@ -58,6 +60,39 @@ export function Settings({ theme, onThemeChange, initDataUnsafe }: SettingsProps
           <strong>{username}</strong>
         </div>
         <p role="note">{t("settings.jwtNote")}</p>
+      </section>
+
+      <section className="card">
+        <h3>Experiments (read-only) / Эксперименты (только чтение)</h3>
+        {loading && <p role="status">Loading… / Загрузка…</p>}
+        {error && (
+          <p role="alert" className="error-text">
+            {error.message}
+          </p>
+        )}
+        {!loading && !error && assignments.length === 0 && (
+          <p role="status">No active experiments / Нет активных экспериментов</p>
+        )}
+        {!loading && assignments.length > 0 && (
+          <div className="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Key / Ключ</th>
+                  <th scope="col">Variant / Вариант</th>
+                </tr>
+              </thead>
+              <tbody>
+                {assignments.map((assignment) => (
+                  <tr key={assignment.key}>
+                    <td>{assignment.key}</td>
+                    <td>{assignment.variant}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/news/src/main/kotlin/news/cta/CtaBuilder.kt
+++ b/news/src/main/kotlin/news/cta/CtaBuilder.kt
@@ -8,48 +8,63 @@ import java.util.Locale
 
 object CtaBuilder {
     /** base: https://t.me/<bot_username>, payload ≤ maxBytes */
-    fun deepLink(base: String, payload: String, maxBytes: Int): String {
+    fun deepLink(base: String, payload: String, maxBytes: Int, abVariant: String? = null): String {
         require(maxBytes > 0) { "maxBytes must be positive" }
         val sanitizedBase = base.trim().trimEnd { it == '/' || it == '?' }
-        val trimmedPayload = trimToBytes(payload, maxBytes)
+        val payloadWithAb = appendAbMarker(payload, abVariant)
+        val trimmedPayload = trimToBytes(payloadWithAb, maxBytes)
         val encodedPayload = URLEncoder.encode(trimmedPayload, StandardCharsets.UTF_8)
         return "$sanitizedBase?start=$encodedPayload"
     }
 
-    fun watchTicker(base: String, ticker: String, maxBytes: Int): InlineKeyboardButton {
+    fun watchTicker(base: String, ticker: String, maxBytes: Int, abVariant: String? = null): InlineKeyboardButton {
         val normalizedTicker = normalizeTicker(ticker)
         val payload = "TICKER_${normalizedTicker.ifEmpty { "MARKET" }}"
-        val link = deepLink(base, payload, maxBytes)
+        val link = deepLink(base, payload, maxBytes, abVariant)
         return InlineKeyboardButton("Следить за ${displayTicker(ticker)}").url(link)
     }
 
-    fun btcFast(base: String, maxBytes: Int): InlineKeyboardButton {
-        val link = deepLink(base, "TICKER_BTC_2PCT", maxBytes)
+    fun btcFast(base: String, maxBytes: Int, abVariant: String? = null): InlineKeyboardButton {
+        val link = deepLink(base, "TICKER_BTC_2PCT", maxBytes, abVariant)
         return InlineKeyboardButton("BTC: +2% за час?").url(link)
     }
 
-    fun weeklyReminders(base: String, maxBytes: Int): InlineKeyboardButton {
-        val link = deepLink(base, "TOPIC_WEEKLY", maxBytes)
+    fun weeklyReminders(base: String, maxBytes: Int, abVariant: String? = null): InlineKeyboardButton {
+        val link = deepLink(base, "TOPIC_WEEKLY", maxBytes, abVariant)
         return InlineKeyboardButton("Еженед. напоминания").url(link)
     }
 
-    fun myPortfolio(base: String, maxBytes: Int): InlineKeyboardButton {
-        val link = deepLink(base, "PORTFOLIO_HOME", maxBytes)
+    fun myPortfolio(base: String, maxBytes: Int, abVariant: String? = null): InlineKeyboardButton {
+        val link = deepLink(base, "PORTFOLIO_HOME", maxBytes, abVariant)
         return InlineKeyboardButton("Мой портфель").url(link)
     }
 
     /** Стандартная раскладка 2×2 */
-    fun defaultMarkup(base: String, maxBytes: Int, primaryTicker: String?): InlineKeyboardMarkup {
+    fun defaultMarkup(base: String, maxBytes: Int, primaryTicker: String?, abVariant: String?): InlineKeyboardMarkup {
         val firstRowFirst = primaryTicker?.takeIf { it.isNotBlank() }
-            ?.let { watchTicker(base, it, maxBytes) }
-            ?: InlineKeyboardButton("Рынок сейчас").url(deepLink(base, "TOPIC_MARKET", maxBytes))
-        val firstRowSecond = btcFast(base, maxBytes)
-        val secondRowFirst = weeklyReminders(base, maxBytes)
-        val secondRowSecond = myPortfolio(base, maxBytes)
+            ?.let { watchTicker(base, it, maxBytes, abVariant) }
+            ?: InlineKeyboardButton("Рынок сейчас").url(deepLink(base, "TOPIC_MARKET", maxBytes, abVariant))
+        val firstRowSecond = btcFast(base, maxBytes, abVariant)
+        val secondRowFirst = weeklyReminders(base, maxBytes, abVariant)
+        val secondRowSecond = myPortfolio(base, maxBytes, abVariant)
         return InlineKeyboardMarkup(
             arrayOf(firstRowFirst, firstRowSecond),
             arrayOf(secondRowFirst, secondRowSecond)
         )
+    }
+
+    private fun appendAbMarker(payload: String, abVariant: String?): String {
+        val sanitized = abVariant?.let { sanitizeVariant(it) } ?: return payload
+        if (sanitized.isEmpty()) {
+            return payload
+        }
+        return if (payload.isEmpty()) "ab=$sanitized" else "$payload|ab=$sanitized"
+    }
+
+    private fun sanitizeVariant(value: String): String {
+        val trimmed = value.trim().take(16)
+        val filtered = trimmed.filter { it.isLetterOrDigit() || it == '_' }
+        return filtered.uppercase(Locale.US)
     }
 
     private fun trimToBytes(value: String, maxBytes: Int): String {

--- a/news/src/main/kotlin/news/pipeline/PublishBreaking.kt
+++ b/news/src/main/kotlin/news/pipeline/PublishBreaking.kt
@@ -1,5 +1,6 @@
 package news.pipeline
 
+import ab.ExperimentsService
 import java.security.MessageDigest
 import java.util.Base64
 import kotlin.text.Charsets
@@ -11,12 +12,14 @@ import news.render.PostTemplates
 
 class PublishBreaking(
     private val cfg: NewsConfig,
-    private val publisher: ChannelPublisher
+    private val publisher: ChannelPublisher,
+    private val experiments: ExperimentsService? = null
 ) {
     suspend fun publish(cluster: Cluster, primaryTicker: String?): Boolean {
         val deepLink = deepLink(cluster.clusterKey)
         val text = PostTemplates.renderBreaking(cluster, deepLink)
-        val markup = CtaBuilder.defaultMarkup(cfg.botDeepLinkBase, cfg.maxPayloadBytes, primaryTicker)
+        val abVariant = resolveVariant()
+        val markup = CtaBuilder.defaultMarkup(cfg.botDeepLinkBase, cfg.maxPayloadBytes, primaryTicker, abVariant)
         return publisher.publish(cluster.clusterKey, text, markup)
     }
 
@@ -29,5 +32,11 @@ class PublishBreaking(
         val digest = MessageDigest.getInstance("SHA-256")
         val hashed = digest.digest(clusterKey.toByteArray(Charsets.UTF_8)).copyOf(16)
         return Base64.getUrlEncoder().withoutPadding().encodeToString(hashed)
+    }
+
+    private suspend fun resolveVariant(): String? {
+        val service = experiments ?: return null
+        val subject = cfg.channelId.takeIf { it != 0L } ?: 0L
+        return runCatching { service.assign(subject, "cta_copy").variant }.getOrNull()
     }
 }

--- a/news/src/test/kotlin/news/cta/CtaBuilderTest.kt
+++ b/news/src/test/kotlin/news/cta/CtaBuilderTest.kt
@@ -19,36 +19,61 @@ class CtaBuilderTest {
     }
 
     @Test
+    fun `deep link appends ab marker within limit`() {
+        val payload = "id=news|src=channel|cmp=${"x".repeat(20)}"
+        val link = CtaBuilder.deepLink(base, payload, 64, "variant_beta")
+        val encoded = link.substringAfter("start=")
+        val decoded = URLDecoder.decode(encoded, StandardCharsets.UTF_8)
+        assertTrue(decoded.contains("|ab=VARIANT_BETA"))
+        assertTrue(decoded.toByteArray(StandardCharsets.UTF_8).size <= 64)
+    }
+
+    @Test
     fun `deep link has no spaces`() {
         val link = CtaBuilder.deepLink(base, "TICKER Test", 64)
         assertTrue(!link.contains(' '))
     }
 
     @Test
-    fun `default markup contains expected buttons`() {
-        val markup = CtaBuilder.defaultMarkup(base, 64, "SBER")
+    fun `default markup contains expected buttons with ab`() {
+        val markup = CtaBuilder.defaultMarkup(base, 64, "SBER", "B")
         val rows = markup.inlineKeyboard()
         assertEquals(2, rows.size)
         assertTrue(rows.all { it.size == 2 })
         val watchTicker = rows[0][0]
         assertEquals("Следить за SBER", watchTicker.text)
-        assertTrue(watchTicker.url!!.contains("TICKER_SBER"))
+        val watchUrl = watchTicker.url!!
+        val watchPayload = startPayload(watchUrl)
+        assertTrue(watchPayload.contains("TICKER_SBER"))
+        assertTrue(watchPayload.contains("ab=B"))
         val btc = rows[0][1]
+        val btcPayload = startPayload(btc.url!!)
         assertEquals("BTC: +2% за час?", btc.text)
-        assertTrue(btc.url!!.contains("TICKER_BTC_2PCT"))
+        assertTrue(btcPayload.contains("TICKER_BTC_2PCT"))
+        assertTrue(btcPayload.contains("ab=B"))
         val weekly = rows[1][0]
+        val weeklyPayload = startPayload(weekly.url!!)
         assertEquals("Еженед. напоминания", weekly.text)
-        assertTrue(weekly.url!!.contains("TOPIC_WEEKLY"))
+        assertTrue(weeklyPayload.contains("TOPIC_WEEKLY"))
+        assertTrue(weeklyPayload.contains("ab=B"))
         val portfolio = rows[1][1]
+        val portfolioPayload = startPayload(portfolio.url!!)
         assertEquals("Мой портфель", portfolio.text)
-        assertTrue(portfolio.url!!.contains("PORTFOLIO_HOME"))
+        assertTrue(portfolioPayload.contains("PORTFOLIO_HOME"))
+        assertTrue(portfolioPayload.contains("ab=B"))
     }
 
     @Test
     fun `default markup falls back without ticker`() {
-        val markup = CtaBuilder.defaultMarkup(base, 64, null)
+        val markup = CtaBuilder.defaultMarkup(base, 64, null, null)
         val rows = markup.inlineKeyboard()
         assertEquals("Рынок сейчас", rows[0][0].text)
-        assertTrue(rows[0][0].url!!.contains("TOPIC_MARKET"))
+        val payload = startPayload(rows[0][0].url!!)
+        assertTrue(payload.contains("TOPIC_MARKET"))
+    }
+
+    private fun startPayload(url: String): String {
+        val encoded = url.substringAfter("start=")
+        return URLDecoder.decode(encoded, StandardCharsets.UTF_8)
     }
 }

--- a/storage/src/main/kotlin/repo/ExperimentsRepository.kt
+++ b/storage/src/main/kotlin/repo/ExperimentsRepository.kt
@@ -1,0 +1,110 @@
+package repo
+
+import ab.Assignment
+import ab.Experiment
+import ab.ExperimentsPort
+import db.DatabaseFactory.dbQuery
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insertIgnore
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+import org.jetbrains.exposed.sql.json.jsonb
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+
+object ExperimentsTable : Table("experiments") {
+    val key = text("key")
+    val name = text("name")
+    val enabled = bool("enabled")
+    val traffic = jsonb("traffic", Json, JsonObject.serializer())
+    val scope = text("scope")
+    val createdAt = timestampWithTimeZone("created_at")
+    val updatedAt = timestampWithTimeZone("updated_at")
+    override val primaryKey = PrimaryKey(key)
+}
+
+object ExperimentAssignmentsTable : Table("experiment_assignments") {
+    val userId = long("user_id")
+    val key = text("key")
+    val variant = text("variant")
+    val assignedAt = timestampWithTimeZone("assigned_at")
+    override val primaryKey = PrimaryKey(userId, key)
+}
+
+class ExperimentsRepository : ExperimentsPort {
+    override suspend fun list(): List<Experiment> = dbQuery {
+        ExperimentsTable.selectAll().map { row -> mapExperiment(row) }
+    }
+
+    override suspend fun upsert(e: Experiment) {
+        val trafficJson = buildJsonObject {
+            e.traffic.forEach { (variant, percent) ->
+                put(variant, JsonPrimitive(percent))
+            }
+        }
+        dbQuery {
+            ExperimentsTable.insertIgnore { statement ->
+                statement[key] = e.key
+                statement[name] = e.key
+                statement[enabled] = e.enabled
+                statement[traffic] = trafficJson
+                statement[scope] = "GLOBAL"
+            }
+            ExperimentsTable.update({ ExperimentsTable.key eq e.key }) { statement ->
+                statement[enabled] = e.enabled
+                statement[traffic] = trafficJson
+                statement[updatedAt] = OffsetDateTime.now(ZoneOffset.UTC)
+            }
+        }
+    }
+
+    override suspend fun getAssignment(userId: Long, key: String): Assignment? = dbQuery {
+        ExperimentAssignmentsTable
+            .select { (ExperimentAssignmentsTable.userId eq userId) and (ExperimentAssignmentsTable.key eq key) }
+            .limit(1)
+            .firstOrNull()
+            ?.let { row -> mapAssignment(row) }
+    }
+
+    override suspend fun saveAssignment(a: Assignment) {
+        dbQuery {
+            ExperimentAssignmentsTable.insertIgnore { statement ->
+                statement[userId] = a.userId
+                statement[key] = a.key
+                statement[variant] = a.variant
+                statement[assignedAt] = OffsetDateTime.now(ZoneOffset.UTC)
+            }
+        }
+    }
+
+    private fun mapExperiment(row: ResultRow): Experiment {
+        val trafficObject = row[ExperimentsTable.traffic]
+        val variants = trafficObject.mapValues { entry ->
+            entry.value.jsonPrimitive.int
+        }.toMap()
+        return Experiment(
+            key = row[ExperimentsTable.key],
+            enabled = row[ExperimentsTable.enabled],
+            traffic = variants
+        )
+    }
+
+    private fun mapAssignment(row: ResultRow): Assignment {
+        return Assignment(
+            userId = row[ExperimentAssignmentsTable.userId],
+            key = row[ExperimentAssignmentsTable.key],
+            variant = row[ExperimentAssignmentsTable.variant]
+        )
+    }
+}

--- a/storage/src/main/kotlin/repo/ReferralsRepository.kt
+++ b/storage/src/main/kotlin/repo/ReferralsRepository.kt
@@ -1,0 +1,95 @@
+package repo
+
+import db.DatabaseFactory.dbQuery
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insertIgnore
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.isNull
+import referrals.ReferralCode
+import referrals.ReferralsPort
+import referrals.UTM
+
+object ReferralsTable : Table("referrals") {
+    val refCode = text("ref_code")
+    val ownerUserId = long("owner_user_id")
+    val createdAt = timestampWithTimeZone("created_at")
+    override val primaryKey = PrimaryKey(refCode)
+}
+
+object ReferralVisitsTable : Table("referral_visits") {
+    val id = long("id").autoIncrement()
+    val refCode = text("ref_code").references(ReferralsTable.refCode, onDelete = ReferenceOption.CASCADE)
+    val tgUserId = long("tg_user_id").nullable()
+    val utmSource = text("utm_source").nullable()
+    val utmMedium = text("utm_medium").nullable()
+    val utmCampaign = text("utm_campaign").nullable()
+    val ctaId = text("cta_id").nullable()
+    val firstSeen = timestampWithTimeZone("first_seen")
+    override val primaryKey = PrimaryKey(id)
+}
+
+class ReferralsRepository : ReferralsPort {
+    override suspend fun create(ownerUserId: Long, code: String): ReferralCode = dbQuery {
+        ReferralsTable.insertIgnore { statement ->
+            statement[refCode] = code
+            statement[ReferralsTable.ownerUserId] = ownerUserId
+        }
+        ReferralsTable.select { ReferralsTable.refCode eq code }
+            .limit(1)
+            .first()
+            .let { row -> ReferralCode(row[ReferralsTable.refCode], row[ReferralsTable.ownerUserId]) }
+    }
+
+    override suspend fun find(code: String): ReferralCode? = dbQuery {
+        ReferralsTable.select { ReferralsTable.refCode eq code }
+            .limit(1)
+            .firstOrNull()
+            ?.let { row -> ReferralCode(row[ReferralsTable.refCode], row[ReferralsTable.ownerUserId]) }
+    }
+
+    override suspend fun recordVisit(code: String, tgUserId: Long?, utm: UTM) {
+        dbQuery {
+            ReferralVisitsTable.insertIgnore {
+                it[refCode] = code
+                it[ReferralVisitsTable.tgUserId] = tgUserId
+                it[utmSource] = utm.source
+                it[utmMedium] = utm.medium
+                it[utmCampaign] = utm.campaign
+                it[ctaId] = utm.ctaId
+            }
+        }
+    }
+
+    override suspend fun attachUser(code: String, tgUserId: Long) {
+        dbQuery {
+            val existing = ReferralVisitsTable
+                .select { (ReferralVisitsTable.refCode eq code) and (ReferralVisitsTable.tgUserId eq tgUserId) }
+                .limit(1)
+                .firstOrNull()
+            if (existing != null) {
+                return@dbQuery
+            }
+            val pending = ReferralVisitsTable
+                .select { (ReferralVisitsTable.refCode eq code) and ReferralVisitsTable.tgUserId.isNull() }
+                .orderBy(ReferralVisitsTable.id, SortOrder.ASC)
+                .limit(1)
+                .firstOrNull()
+            if (pending != null) {
+                ReferralVisitsTable.update({ ReferralVisitsTable.id eq pending[ReferralVisitsTable.id] }) {
+                    it[ReferralVisitsTable.tgUserId] = tgUserId
+                }
+            } else {
+                ReferralVisitsTable.insertIgnore {
+                    it[refCode] = code
+                    it[ReferralVisitsTable.tgUserId] = tgUserId
+                }
+            }
+        }
+    }
+}

--- a/storage/src/main/resources/db/migration/V7__growth_ab_referrals.sql
+++ b/storage/src/main/resources/db/migration/V7__growth_ab_referrals.sql
@@ -1,0 +1,45 @@
+-- Experiments config (admin-managed)
+CREATE TABLE IF NOT EXISTS experiments (
+  key        TEXT PRIMARY KEY,
+  name       TEXT NOT NULL,
+  enabled    BOOLEAN NOT NULL DEFAULT true,
+  traffic    JSONB  NOT NULL,
+  scope      TEXT   NOT NULL DEFAULT 'GLOBAL',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Persisted assignments (deterministic, but cache/store for audit)
+CREATE TABLE IF NOT EXISTS experiment_assignments (
+  user_id    BIGINT NOT NULL,
+  key        TEXT   NOT NULL,
+  variant    TEXT   NOT NULL,
+  assigned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, key),
+  FOREIGN KEY (key) REFERENCES experiments(key) ON DELETE CASCADE
+);
+
+-- Referral program: codes and visits
+CREATE TABLE IF NOT EXISTS referrals (
+  ref_code   TEXT PRIMARY KEY,
+  owner_user_id BIGINT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS referral_visits (
+  id         BIGSERIAL PRIMARY KEY,
+  ref_code   TEXT NOT NULL REFERENCES referrals(ref_code) ON DELETE CASCADE,
+  tg_user_id BIGINT NULL,
+  utm_source TEXT NULL,
+  utm_medium TEXT NULL,
+  utm_campaign TEXT NULL,
+  cta_id     TEXT NULL,
+  first_seen TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (ref_code, tg_user_id)
+);
+
+-- Indices for queries
+CREATE INDEX IF NOT EXISTS idx_experiments_enabled ON experiments(enabled);
+CREATE INDEX IF NOT EXISTS idx_assignments_user ON experiment_assignments(user_id);
+CREATE INDEX IF NOT EXISTS idx_ref_visits_code ON referral_visits(ref_code);
+CREATE INDEX IF NOT EXISTS idx_ref_visits_tg ON referral_visits(tg_user_id);

--- a/storage/src/test/kotlin/repo/ExperimentsRepositoryTest.kt
+++ b/storage/src/test/kotlin/repo/ExperimentsRepositoryTest.kt
@@ -1,0 +1,46 @@
+package repo
+
+import ab.Assignment
+import ab.Experiment
+import it.TestDb
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.runBlocking
+
+class ExperimentsRepositoryTest {
+    @Test
+    fun `upsert and assignments persist`() = runBlocking {
+        TestDb.withMigratedDatabase {
+            val repository = ExperimentsRepository()
+
+            repository.upsert(Experiment(key = "cta_copy", enabled = true, traffic = mapOf("A" to 50, "B" to 50)))
+            val experiments = repository.list()
+            assertEquals(1, experiments.size)
+            val experiment = experiments.single()
+            assertEquals("cta_copy", experiment.key)
+            assertEquals(mapOf("A" to 50, "B" to 50), experiment.traffic)
+            assertEquals(true, experiment.enabled)
+
+            repository.upsert(Experiment(key = "cta_copy", enabled = false, traffic = mapOf("A" to 100)))
+            val updated = repository.list().single()
+            assertFalse(updated.enabled)
+            assertEquals(mapOf("A" to 100), updated.traffic)
+
+            val missing = repository.getAssignment(userId = 777, key = "cta_copy")
+            assertNull(missing)
+
+            repository.saveAssignment(Assignment(userId = 777, key = "cta_copy", variant = "A"))
+            val stored = repository.getAssignment(userId = 777, key = "cta_copy")
+            assertNotNull(stored)
+            assertEquals("A", stored.variant)
+
+            repository.saveAssignment(Assignment(userId = 777, key = "cta_copy", variant = "B"))
+            val unchanged = repository.getAssignment(userId = 777, key = "cta_copy")
+            assertNotNull(unchanged)
+            assertEquals("A", unchanged.variant)
+        }
+    }
+}

--- a/tools/analytics/funnels.sql
+++ b/tools/analytics/funnels.sql
@@ -1,0 +1,37 @@
+-- 1) Post -> Click -> Start -> Pay (7d rolling)
+WITH e AS (
+  SELECT * FROM events WHERE ts >= now() - interval '7 days'
+)
+SELECT
+  date_trunc('day', ts)::date AS day,
+  SUM(CASE WHEN type='post_published' THEN 1 ELSE 0 END) AS post,
+  SUM(CASE WHEN type='cta_click' THEN 1 ELSE 0 END) AS click,
+  SUM(CASE WHEN type='miniapp_auth' THEN 1 ELSE 0 END) AS start,
+  SUM(CASE WHEN type='stars_payment_succeeded' THEN 1 ELSE 0 END) AS pay
+FROM e
+GROUP BY 1
+ORDER BY 1;
+
+-- 2) Referral performance (7d)
+WITH v AS (
+  SELECT * FROM referral_visits WHERE first_seen >= now() - interval '7 days'
+)
+SELECT ref_code,
+       COUNT(*) AS visits,
+       COUNT(DISTINCT tg_user_id) FILTER (WHERE tg_user_id IS NOT NULL) AS attached_users
+FROM v
+GROUP BY ref_code
+ORDER BY visits DESC
+LIMIT 50;
+
+-- 3) A/B lift (cta_copy: A vs B) — click-through and pay rate
+WITH e AS (SELECT * FROM events WHERE ts >= now() - interval '14 days'),
+assign AS (SELECT * FROM experiment_assignments WHERE key='cta_copy')
+SELECT
+  a.variant,
+  SUM(CASE WHEN e.type='cta_click' THEN 1 ELSE 0 END) AS clicks,
+  SUM(CASE WHEN e.type='stars_payment_succeeded' THEN 1 ELSE 0 END) AS pays
+FROM e
+JOIN assign a ON e.user_id = a.user_id
+GROUP BY a.variant
+ORDER BY a.variant;


### PR DESCRIPTION
## Summary
- add migrations and repositories for experiments and referrals
- implement A/B assignment services plus redirect and admin routes
- expose experiments assignments to clients and document growth funnels tooling

## Testing
- ./gradlew :app:test --tests routes.ExperimentsRoutesTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68de69ca06748321ab26a4f774c9472f