### PR TITLE
Add go-live release gates workflow and post-deploy verification tooling

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -1,0 +1,133 @@
+name: Release Gates
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  precheck:
+    name: Preflight Conflict Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for conflict markers
+        run: |
+          if git grep -n "^<<<<<<<"; then
+            echo "Conflict markers detected"
+            exit 1
+          fi
+          if git grep -n "^======="; then
+            echo "Conflict markers detected"
+            exit 1
+          fi
+          if git grep -n ">>>>>>>"; then
+            echo "Conflict markers detected"
+            exit 1
+          fi
+
+  build-and-test:
+    name: Build, Lint & Test
+    needs: precheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+      - name: Gradle checks
+        run: ./gradlew --stacktrace --info ktlintCheck detekt
+      - name: Gradle build
+        run: ./gradlew --stacktrace --info clean build
+      - name: Module tests
+        run: ./gradlew --stacktrace --info :core:test :storage:test :app:test
+
+  audit:
+    name: Compliance Audit Grep
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run audit checks
+        run: tools/audit/grep_checks.sh
+
+  e2e-miniapp:
+    name: Miniapp E2E Smoke
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('miniapp/package.json') != '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: miniapp
+      - name: Build miniapp
+        run: pnpm build
+        working-directory: miniapp
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+        working-directory: miniapp
+      - name: Run E2E tests
+        run: pnpm test:e2e -- --reporter=list
+        working-directory: miniapp
+
+  k6-dry:
+    name: k6 Smoke Dry Run
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup k6
+        uses: grafana/setup-k6-action@v1
+      - name: Run dry-run scenarios
+        run: |
+          set -euo pipefail
+          mkdir -p k6-logs
+          shopt -s nullglob
+          scenarios=(deploy/load/k6/*_scenario.js)
+          if [ ${#scenarios[@]} -eq 0 ]; then
+            echo "No k6 scenarios detected"
+            exit 0
+          fi
+          for script in "${scenarios[@]}"; do
+            name=$(basename "$script")
+            log_file="k6-logs/${name%.js}.log"
+            echo "Validating $script"
+            BASE_URL=https://example.invalid k6 run --vus 1 --duration 1s "$script" | tee "$log_file"
+          done
+      - name: Upload k6 logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-dry-run-logs
+          path: k6-logs
+          if-no-files-found: warn
+
+

--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ curl -I "$BASE/go/news?utm_source=channel&utm_medium=cta&utm_campaign=oct&ref=R7
 # → 302 Location: https://t.me/<bot>?start=id=news|src=channel|med=cta|cmp=oct|ref=R7G5K2|cta=promo|ab=<variant>
 ```
 
+## P40 — Go-Live gates & post-deploy
+
+```bash
+# локальные «ворота»
+bash tools/release/preflight.sh
+
+# в CI вручную
+GitHub Actions → release-gates → Run workflow
+
+# пост-деплой верификация
+BASE_URL=https://<host> PROM_URL=http://<prom-host>:9090 WEBHOOK_SECRET=*** TG_USER_ID=*** \
+bash tools/release/postdeploy_verify.sh
+```
+
+- Readiness checklist: [docs/GO_LIVE_READINESS.md](docs/GO_LIVE_READINESS.md)
+- Post-deploy verification steps: [docs/POST_DEPLOY_CHECKS.md](docs/POST_DEPLOY_CHECKS.md)
+
 ## P34 — Blue/Green & Canary
 
 ```bash

--- a/docs/GO_LIVE_READINESS.md
+++ b/docs/GO_LIVE_READINESS.md
@@ -1,0 +1,24 @@
+# P40 — Go-Live Readiness / Готовность к релизу
+
+## ✅ Readiness Checklist / Чек-лист готовности
+- [ ] Build, lint, unit tests (`./gradlew ktlintCheck detekt test build`) completed with green status.
+- [ ] Release Gates CI workflow (`Release Gates`) finished successfully for the release branch.
+- [ ] `tools/audit/grep_checks.sh` and `tools/audit/run_all.sh --skip-build` report no findings.
+- [ ] Monitoring stack (P21) deployed; SLO dashboards (P22) up-to-date and reviewed.
+- [ ] Alerting rules triggered in staging and acknowledged; pager routing confirmed.
+- [ ] Security hardening (P35) enforced: CSP/HSTS headers, rate-limiting, JWT dual-key rotation verified.
+- [ ] Privacy controls (P36) active: data-retention scheduler running; erasure dry-run executed in staging.
+- [ ] Backups & DR (P31): nightly backup succeeded; latest 7-day restore validated on staging.
+- [ ] Blue/Green (P34): canary toggle exercised with rollback path documented.
+- [ ] E2E suite (P20) green via `pnpm test:e2e -- --reporter=list` (miniapp) or recorded waiver.
+- [ ] k6 smoke (P23) dry-run for `deploy/load/k6/*_scenario.js` passes with no errors.
+
+## 🔁 Command Reference / Команды
+```bash
+# локально / local
+bash tools/release/preflight.sh
+
+# после раскатки на стенд/прод / after deploy to stage/prod
+BASE_URL=https://<host> PROM_URL=http://prometheus:9090 WEBHOOK_SECRET=*** TG_USER_ID=*** \
+bash tools/release/postdeploy_verify.sh
+```

--- a/docs/POST_DEPLOY_CHECKS.md
+++ b/docs/POST_DEPLOY_CHECKS.md
@@ -1,0 +1,20 @@
+# Post-Deploy Verification / Пост-деплой проверки
+
+## 🔍 Checklist (10–15 steps)
+1. Confirm deployment metadata (commit SHA, build number) matches release notes.
+2. Run `BASE_URL=... PROM_URL=... WEBHOOK_SECRET=... TG_USER_ID=... bash tools/release/postdeploy_verify.sh` and ensure `[OK] post-deploy verified`.
+3. Manually curl `${BASE_URL}/healthz` and `${BASE_URL}/health/db` for HTTP 200 (redundant sanity).
+4. Open `${BASE_URL}/metrics` and ensure scrape succeeds; verify `http_server_requests_seconds_count` increments.
+5. Execute PromQL in Prometheus UI:
+   - `sum(rate(http_server_requests_seconds_count{status=~"5.."}[5m])) / sum(rate(http_server_requests_seconds_count[5m])) < 0.02`
+   - `histogram_quantile(0.95, sum(rate(webhook_duration_seconds_bucket{integration="xtr"}[5m])) by (le)) < 1.5`
+6. Review Grafana dashboard `P21 / Core SLO` for traffic, latency, error budget burn.
+7. Validate alertmanager silence state; ensure no critical alerts suppressed unexpectedly.
+8. Trigger synthetic probe via `BASE_URL=... JWT=... bash tools/ops/synthetic_probe.sh` (if JWT available).
+9. Check webhook delivery log for the two XTR payment simulations (idempotent 200/200).
+10. Validate queue/backlog metrics (e.g., `pending_jobs`) remain within thresholds post deploy.
+11. Inspect application logs for new errors since deploy timestamp.
+12. Confirm notification webhooks (Slack/TG) delivered release announcement to on-call.
+13. Verify background jobs (retention, billing sync) executed at least once after deploy.
+14. Ensure feature flags align with rollout plan; canary population monitored.
+15. Update release journal with verification evidence and attach CI artifacts.

--- a/tools/ops/synthetic_probe.sh
+++ b/tools/ops/synthetic_probe.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+BLUE="\033[34m"
+RESET="\033[0m"
+
+if [[ -z "${BASE_URL:-}" ]]; then
+  echo -e "${RED}[ERR] BASE_URL environment variable is required.${RESET}" >&2
+  exit 1
+fi
+
+base_url="${BASE_URL%/}"
+
+log_step() {
+  echo -e "${BLUE}==> $1${RESET}"
+}
+
+log_ok() {
+  echo -e "${GREEN}[OK] $1${RESET}"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARN] $1${RESET}"
+}
+
+http_check() {
+  local path="$1"
+  local label="$2"
+  local tmp
+  tmp=$(mktemp)
+  local status
+  status=$(curl -sS -o "$tmp" -w '%{http_code}' "${base_url}${path}")
+  if [[ "$status" != "200" ]]; then
+    echo -e "${RED}[ERR] ${label} returned status ${status}${RESET}" >&2
+    cat "$tmp" >&2
+    rm -f "$tmp"
+    exit 1
+  fi
+  rm -f "$tmp"
+  log_ok "${label} healthy"
+}
+
+log_step "Synthetic probe: health endpoints"
+http_check "/healthz" "Healthz"
+http_check "/health/db" "Database health"
+
+log_step "Synthetic probe: metrics availability"
+metrics_tmp=$(mktemp)
+metrics_status=$(curl -sS -o "$metrics_tmp" -w '%{http_code}' "${base_url}/metrics")
+if [[ "$metrics_status" != "200" ]]; then
+  echo -e "${RED}[ERR] Metrics endpoint returned status ${metrics_status}${RESET}" >&2
+  cat "$metrics_tmp" >&2
+  rm -f "$metrics_tmp"
+  exit 1
+fi
+if ! grep -E '^# HELP' "$metrics_tmp" >/dev/null 2>&1; then
+  echo -e "${RED}[ERR] Metrics payload missing HELP headers.${RESET}" >&2
+  rm -f "$metrics_tmp"
+  exit 1
+fi
+rm -f "$metrics_tmp"
+log_ok "Metrics endpoint reachable"
+
+if [[ -n "${JWT:-}" ]]; then
+  log_step "Synthetic probe: authenticated portfolio API"
+  tmp=$(mktemp)
+  status=$(curl -sS -H "Authorization: Bearer ${JWT}" -o "$tmp" -w '%{http_code}' "${base_url}/api/portfolio")
+  if [[ "$status" != "200" ]]; then
+    echo -e "${RED}[ERR] Portfolio API returned status ${status}${RESET}" >&2
+    cat "$tmp" >&2
+    rm -f "$tmp"
+    exit 1
+  fi
+  rm -f "$tmp"
+  log_ok "Portfolio API responded"
+else
+  log_warn "JWT not provided; skipping authenticated API probe"
+fi
+
+log_ok "Synthetic probe completed"

--- a/tools/release/postdeploy_verify.sh
+++ b/tools/release/postdeploy_verify.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo -e "\033[31m[FAIL] post-deploy verification failed\033[0m" >&2' ERR
+
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+BLUE="\033[34m"
+RESET="\033[0m"
+
+require_env() {
+  local var="$1"
+  if [[ -z "${!var:-}" ]]; then
+    echo -e "${RED}[ERR] Environment variable ${var} is required.${RESET}" >&2
+    exit 1
+  fi
+}
+
+require_env BASE_URL
+require_env PROM_URL
+require_env WEBHOOK_SECRET
+require_env TG_USER_ID
+require_env APP_PROFILE
+
+log_step() {
+  echo -e "${BLUE}==> $1${RESET}"
+}
+
+log_ok() {
+  echo -e "${GREEN}[OK] $1${RESET}"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARN] $1${RESET}"
+}
+
+base_url="${BASE_URL%/}"
+
+http_check() {
+  local path="$1"
+  local label="$2"
+  local tmp
+  local status
+  tmp=$(mktemp)
+  status=$(curl -sS -o "$tmp" -w '%{http_code}' "${base_url}${path}")
+  if [[ "$status" != "200" ]]; then
+    echo -e "${RED}[ERR] ${label} returned status ${status}${RESET}" >&2
+    cat "$tmp" >&2
+    rm -f "$tmp"
+    exit 1
+  fi
+  rm -f "$tmp"
+  log_ok "${label} healthy"
+}
+
+log_step "Checking service health endpoints"
+http_check "/healthz" "Health probe"
+http_check "/health/db" "Database health"
+
+log_step "Validating /metrics endpoint"
+metrics_tmp=$(mktemp)
+metrics_status=$(curl -sS -o "$metrics_tmp" -w '%{http_code}' "${base_url}/metrics")
+if [[ "$metrics_status" != "200" ]]; then
+  echo -e "${RED}[ERR] Metrics endpoint returned status ${metrics_status}${RESET}" >&2
+  cat "$metrics_tmp" >&2
+  rm -f "$metrics_tmp"
+  exit 1
+fi
+if ! grep -E '^http_server_requests_seconds_count' "$metrics_tmp" >/dev/null 2>&1; then
+  echo -e "${RED}[ERR] Expected http_server_requests_seconds_count metric not found.${RESET}" >&2
+  rm -f "$metrics_tmp"
+  exit 1
+fi
+if ! grep -E '^jvm_threads_live_threads' "$metrics_tmp" >/dev/null 2>&1; then
+  echo -e "${RED}[ERR] Expected jvm_threads_live_threads metric not found.${RESET}" >&2
+  rm -f "$metrics_tmp"
+  exit 1
+fi
+rm -f "$metrics_tmp"
+log_ok "Metrics endpoint exposes core telemetry"
+
+prom_query() {
+  local description="$1"
+  local query="$2"
+  local threshold="$3"
+  local comparator="$4"
+  local response
+  local value
+  local status
+  response=$(curl -sS -G --data-urlencode "query=${query}" "${PROM_URL%/}/api/v1/query")
+  if [[ -z "$response" ]]; then
+    echo -e "${RED}[ERR] Empty response from Prometheus for ${description}.${RESET}" >&2
+    exit 1
+  fi
+  value=$(PROM_RESPONSE="$response" python - "$threshold" "$comparator" <<'PY'
+import json
+import os
+import sys
+
+data = json.loads(os.environ["PROM_RESPONSE"])
+threshold = float(sys.argv[1])
+comparator = sys.argv[2]
+
+if data.get("status") != "success":
+    print("ERROR", file=sys.stderr)
+    sys.exit(1)
+result = data.get("data", {}).get("result", [])
+if not result:
+    value = 0.0
+else:
+    try:
+        value = float(result[0]["value"][1])
+    except (KeyError, ValueError, IndexError):
+        print("ERROR", file=sys.stderr)
+        sys.exit(1)
+if comparator == "lt":
+    ok = value < threshold
+elif comparator == "le":
+    ok = value <= threshold
+elif comparator == "gt":
+    ok = value > threshold
+elif comparator == "ge":
+    ok = value >= threshold
+else:
+    print("ERROR", file=sys.stderr)
+    sys.exit(1)
+print(f"{value}")
+if not ok:
+    sys.exit(2)
+PY
+)
+  status=$?
+  if [[ $status -eq 0 ]]; then
+    log_ok "${description}: ${value} (threshold ${comparator} ${threshold})"
+  elif [[ $status -eq 2 ]]; then
+    echo -e "${RED}[ERR] ${description} out of bounds: ${value}${RESET}" >&2
+    exit 1
+  else
+    echo -e "${RED}[ERR] Failed to evaluate PromQL for ${description}.${RESET}" >&2
+    exit 1
+  fi
+}
+
+log_step "Evaluating Prometheus SLO queries"
+prom_query "HTTP 5xx rate (5m)" "sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[5m])) / sum(rate(http_server_requests_seconds_count[5m]))" 0.02 lt
+prom_query "XTR webhook p95 latency (5m)" "histogram_quantile(0.95, sum(rate(webhook_duration_seconds_bucket{integration=\"xtr\"}[5m])) by (le))" 1.5 lt
+
+if [[ -n "${JWT:-}" ]]; then
+  log_step "Authenticated API smoke for portfolio"
+  tmp=$(mktemp)
+  status=$(curl -sS -H "Authorization: Bearer ${JWT}" -o "$tmp" -w '%{http_code}' "${base_url}/api/portfolio")
+  if [[ "$status" != "200" ]]; then
+    echo -e "${RED}[ERR] Authenticated portfolio API returned status ${status}${RESET}" >&2
+    cat "$tmp" >&2
+    rm -f "$tmp"
+    exit 1
+  fi
+  rm -f "$tmp"
+  log_ok "Portfolio API responded successfully"
+else
+  log_warn "JWT not provided; skipping authenticated API smoke"
+fi
+
+log_step "Simulating XTR webhook delivery"
+payload_id="xtr-$(date +%s)"
+for attempt in 1 2; do
+  status=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "${base_url}/api/webhooks/xtr" \
+    -H "Content-Type: application/json" \
+    -H "X-Webhook-Secret: ${WEBHOOK_SECRET}" \
+    -d "{\"event\":\"payment\",\"id\":\"${payload_id}\",\"amount\":0}")
+  if [[ "$status" != "200" ]]; then
+    echo -e "${RED}[ERR] Webhook attempt ${attempt} returned status ${status}${RESET}" >&2
+    exit 1
+  fi
+  log_ok "Webhook attempt ${attempt} returned 200"
+done
+
+log_step "Verifying TG_USER_ID configured"
+log_ok "Escalation contact configured"
+
+trap - ERR
+log_ok "post-deploy verified"

--- a/tools/release/preflight.sh
+++ b/tools/release/preflight.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+BLUE="\033[34m"
+RESET="\033[0m"
+
+skip_miniapp=false
+skip_k6=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-miniapp)
+      skip_miniapp=true
+      shift
+      ;;
+    --skip-k6)
+      skip_k6=true
+      shift
+      ;;
+    *)
+      echo -e "${RED}[ERR] Unknown option: $1${RESET}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${APP_PROFILE:-}" == "prod" ]]; then
+  echo -e "${RED}[ERR] APP_PROFILE=prod detected. Abort preflight on production profile.${RESET}" >&2
+  exit 2
+fi
+
+log_step() {
+  echo -e "${BLUE}==> $1${RESET}"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARN] $1${RESET}"
+}
+
+log_ok() {
+  echo -e "${GREEN}[OK] $1${RESET}"
+}
+
+log_step "Running Gradle lint, tests, and build"
+./gradlew ktlintCheck detekt test build
+
+log_step "Executing compliance audit checks"
+tools/audit/run_all.sh --skip-build
+
+if [[ -f miniapp/package.json ]]; then
+  if [[ "$skip_miniapp" == "true" ]]; then
+    log_warn "Skipping miniapp E2E checks by flag"
+  else
+    if ! command -v pnpm >/dev/null 2>&1; then
+      echo -e "${RED}[ERR] pnpm is required for miniapp checks. Install pnpm or rerun with --skip-miniapp.${RESET}" >&2
+      exit 1
+    fi
+    log_step "Running miniapp E2E smoke"
+    pushd miniapp > /dev/null
+    pnpm install --frozen-lockfile
+    pnpm build
+    pnpm test:e2e -- --reporter=list
+    popd > /dev/null
+  fi
+else
+  log_warn "Miniapp project not detected; skipping E2E smoke"
+fi
+
+if [[ "$skip_k6" == "true" ]]; then
+  log_warn "Skipping k6 dry-run by flag"
+else
+  if compgen -G "deploy/load/k6/*_scenario.js" > /dev/null; then
+    if ! command -v k6 >/dev/null 2>&1; then
+      echo -e "${RED}[ERR] k6 binary is required. Install k6 or rerun with --skip-k6.${RESET}" >&2
+      exit 1
+    fi
+    log_step "Running k6 dry-run for smoke scenarios"
+    for script in deploy/load/k6/*_scenario.js; do
+      echo -e "${BLUE}--- $(basename "$script")${RESET}"
+      BASE_URL=https://example.invalid k6 run --vus 1 --duration 1s "$script"
+    done
+  else
+    log_warn "No k6 scenario scripts detected"
+  fi
+fi
+
+log_ok "Preflight checks completed"


### PR DESCRIPTION
## Summary
- add release-gates workflow covering build, lint, audit, miniapp e2e, and k6 smoke checks
- add preflight, post-deploy verification, and synthetic probe scripts for operational readiness
- document go-live readiness and post-deploy procedures and surface commands in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deb7f702f48321b9aab8935f1c9226