### PR TITLE
Add billing ledger reconciliation flow

### DIFF
--- a/.github/workflows/billing-recon.yml
+++ b/.github/workflows/billing-recon.yml
@@ -1,0 +1,29 @@
+name: billing-recon
+
+on:
+  schedule:
+    - cron: '15 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.STAGE_DB_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Run billing reconciliation
+        run: ./gradlew :app:runRecon --console=plain
+      - name: Upload reconciliation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: billing-recon-result
+          path: recon_result.txt
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ bash tools/security/rotate_webhook_secret.sh "<new_secret>"
 
 - Detailed guidance: [docs/SECURITY_HARDENING.md](docs/SECURITY_HARDENING.md) and [docs/ROTATION_RUNBOOK.md](docs/ROTATION_RUNBOOK.md).
 
+## P41 — Billing reconciliation
+
+- Документация: [docs/BILLING_RECONCILIATION.md](docs/BILLING_RECONCILIATION.md).
+- Локальный запуск: `./gradlew :app:runRecon` (предварительно задать `DATABASE_URL`).
+- CI: GitHub Actions → **billing-recon** → скачать артефакт `billing-recon-result`.
+
 ## P27 — Integrations hardening
 
 ## P28 — Metrics wiring

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,3 +42,11 @@ dependencies {
 application {
     mainClass.set("app.ApplicationKt")
 }
+
+tasks.register<JavaExec>("runRecon") {
+    group = "application"
+    description = "Runs billing reconciliation job"
+    mainClass.set("billing.recon.ReconciliationRunnerKt")
+    classpath = sourceSets["main"].runtimeClasspath
+    dependsOn(tasks.named("classes"))
+}

--- a/app/src/main/kotlin/App.kt
+++ b/app/src/main/kotlin/App.kt
@@ -26,6 +26,7 @@ import billing.bot.StarsBotRouter.BotRoute.Status
 import billing.bot.StarsBotRouter.BotRoute.Unknown
 import billing.service.BillingService
 import billing.service.BillingServiceImpl
+import repo.BillingLedgerRepository
 import billing.service.applySuccessfulPaymentOutcome
 import com.pengrad.telegrambot.utility.BotUtils
 import di.FeatureFlagsModule
@@ -231,6 +232,7 @@ private fun Application.ensureBillingServices(
     val billingService = BillingServiceImpl(
         repo = BillingRepositoryImpl(),
         stars = StarsGatewayFactory.fromConfig(environment),
+        ledger = BillingLedgerRepository(),
         defaultDurationDays = billingDefaultDuration(),
     )
     val services = Services(

--- a/app/src/main/kotlin/billing/recon/BillingReconJob.kt
+++ b/app/src/main/kotlin/billing/recon/BillingReconJob.kt
@@ -1,0 +1,45 @@
+package billing.recon
+
+import billing.recon.BillingReconPort
+import db.DatabaseFactory.dbQuery
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+
+class BillingReconJob(
+    private val recon: BillingReconPort
+) {
+    suspend fun run(): ReconResult {
+        val runId = recon.beginRun()
+        var mismatches = 0
+
+        // 1) Найти ledger APPLY без активной подписки (возможен сбой апдейта)
+        // (Псевдо: проверить в user_subscriptions ACTIVE для user_id/tier)
+        // 2) Найти дубликаты ledger APPLY для одного provider_payment_id
+        // Здесь добавим простой пример «дубликаты по pid+event=APPLY»
+        val duplicatePaymentIds = dbQuery {
+            val ids = mutableListOf<String>()
+            TransactionManager.current().exec(
+                """
+                SELECT provider_payment_id
+                FROM billing_ledger
+                WHERE event = 'APPLY'
+                GROUP BY provider_payment_id
+                HAVING COUNT(*) > 1
+                """.trimIndent()
+            ) { rs ->
+                while (rs.next()) {
+                    ids += rs.getString(1)
+                }
+            }
+            ids
+        }
+        for (pid in duplicatePaymentIds) {
+            recon.recordMismatch(runId, "DUPLICATE", null, pid, null)
+        }
+        val dup = duplicatePaymentIds.size
+        mismatches += dup
+
+        val status = if (mismatches == 0) "OK" else "WARN"
+        recon.finishRun(runId, status, if (mismatches == 0) null else "$mismatches mismatches")
+        return ReconResult(runId, status, mapOf("duplicates" to dup))
+    }
+}

--- a/app/src/main/kotlin/billing/recon/ReconciliationRunner.kt
+++ b/app/src/main/kotlin/billing/recon/ReconciliationRunner.kt
@@ -1,0 +1,15 @@
+package billing.recon
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.runBlocking
+import repo.BillingReconRepository
+
+fun main() = runBlocking {
+    val job = BillingReconJob(BillingReconRepository())
+    val res = job.run()
+    val report = "runId=${'$'}{res.runId} status=${'$'}{res.status} counts=${'$'}{res.counts}"
+    println(report)
+    Files.writeString(Path.of("recon_result.txt"), report + System.lineSeparator(), StandardCharsets.UTF_8)
+}

--- a/core/src/main/kotlin/billing/recon/BillingRecon.kt
+++ b/core/src/main/kotlin/billing/recon/BillingRecon.kt
@@ -1,0 +1,25 @@
+package billing.recon
+
+data class LedgerEntry(
+    val userId: Long,
+    val tier: String,
+    val event: String,
+    val providerPaymentId: String,
+    val payloadHash: String
+)
+
+data class ReconResult(
+    val runId: Long,
+    val status: String,
+    val counts: Map<String, Int>
+)
+
+interface BillingLedgerPort {
+    suspend fun append(entry: LedgerEntry)
+}
+
+interface BillingReconPort {
+    suspend fun beginRun(): Long
+    suspend fun recordMismatch(runId: Long, kind: String, userId: Long?, providerPaymentId: String?, tier: String?)
+    suspend fun finishRun(runId: Long, status: String, notes: String?)
+}

--- a/core/src/test/kotlin/billing/BillingServiceTest.kt
+++ b/core/src/test/kotlin/billing/BillingServiceTest.kt
@@ -7,6 +7,8 @@ import billing.model.UserSubscription
 import billing.model.Xtr
 import billing.port.BillingRepository
 import billing.port.StarsGateway
+import billing.recon.BillingLedgerPort
+import billing.recon.LedgerEntry
 import billing.service.BillingService
 import billing.service.BillingServiceImpl
 import java.time.Clock
@@ -212,7 +214,8 @@ class BillingServiceTest {
     }
 
     private fun createService(repo: FakeRepo, stars: FakeStarsGateway): BillingService {
-        return BillingServiceImpl(repo, stars, defaultDurationDays = 30, clock = clock)
+        val ledger = FakeLedger()
+        return BillingServiceImpl(repo, stars, ledger, defaultDurationDays = 30, clock = clock)
     }
 
     private class FakeRepo(private val defaultStartedAt: Instant) : BillingRepository {
@@ -260,6 +263,13 @@ class BillingServiceTest {
             }
             payments += PaymentRecord(userId, tier, amountXtr, pid, payload, status)
             return true
+        }
+    }
+
+    private class FakeLedger : BillingLedgerPort {
+        val entries = mutableListOf<LedgerEntry>()
+        override suspend fun append(entry: LedgerEntry) {
+            entries += entry
         }
     }
 

--- a/docs/BILLING_RECONCILIATION.md
+++ b/docs/BILLING_RECONCILIATION.md
@@ -1,0 +1,42 @@
+# Billing reconciliation / Сверка биллинга
+
+## Инварианты / Invariants
+- **APPLY duplicates forbidden / Дубликаты APPLY запрещены.** Каждая запись `billing_ledger.event = 'APPLY'` должна быть уникальна по `provider_payment_id`.
+- **Active subscription per APPLY / Активная подписка на каждую APPLY.** После применения платежа статус подписки `ACTIVE` соответствует пользователю и тарифу.
+- **DUPLICATE is informational / DUPLICATE только для фиксации.** Записи `DUPLICATE` не продлевают подписку и не изменяют баланс.
+
+## Где лежит леджер / Ledger location
+- PostgreSQL таблица `billing_ledger` (создаётся Flyway миграцией `V8__billing_ledger_recon.sql`).
+- Данные неизменяемы: записи добавляются через `BillingLedgerPort.append` из `BillingService`.
+- Дубликаты и результаты сверок находятся в таблицах `billing_recon_runs` и `billing_recon_mismatches`.
+
+## Как смотреть последние сверки / Inspect recent runs
+```sql
+SELECT run_id, started_at, finished_at, status, notes
+FROM billing_recon_runs
+ORDER BY started_at DESC
+LIMIT 20;
+```
+- Детализацию расхождений можно получить по `run_id`:
+```sql
+SELECT kind, user_id, provider_payment_id, tier, created_at
+FROM billing_recon_mismatches
+WHERE run_id = $1
+ORDER BY created_at DESC;
+```
+
+## CI отчёт / CI report artifact
+- GitHub Actions workflow **billing-recon** запускается ежедневно в 03:15 UTC и вручную через `workflow_dispatch`.
+- В рамках job выполняется `./gradlew :app:runRecon`, stdout и файл `recon_result.txt` содержат итог (`runId=… status=… counts=…`).
+- Артефакт **billing-recon-result** доступен на странице workflow в разделе Artifacts, содержит `recon_result.txt`.
+
+## Реакция на WARN/FAIL / Incident response
+- **WARN:** проверить `billing_recon_mismatches` для соответствующего `run_id`, устранить причину (например, задвоенный `provider_payment_id`), при необходимости вручную скорректировать подписку и перезапустить сверку.
+- **FAIL:** сверка остановилась — отменить последние опасные изменения (rollback), зафиксировать инцидент, создать тикет в платформенной очереди и провести ручную коррекцию после восстановления.
+- Во всех случаях исключить попадание PII и сумм в логи, использовать только идентификаторы.
+
+## Локальный запуск / Local run
+```bash
+./gradlew :app:runRecon
+```
+- Перед запуском задать `DATABASE_URL` на dev/staging экземпляр Postgres.

--- a/storage/src/main/kotlin/repo/BillingReconRepository.kt
+++ b/storage/src/main/kotlin/repo/BillingReconRepository.kt
@@ -1,0 +1,87 @@
+package repo
+
+import billing.recon.BillingLedgerPort
+import billing.recon.BillingReconPort
+import billing.recon.LedgerEntry
+import db.DatabaseFactory.dbQuery
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+import org.jetbrains.exposed.sql.update
+
+object BillingLedgerTable : Table("billing_ledger") {
+    val ledgerId = long("ledger_id").autoIncrement()
+    val userId = long("user_id")
+    val tier = text("tier")
+    val event = text("event")
+    val providerPaymentId = text("provider_payment_id")
+    val payloadHash = text("payload_hash")
+    val createdAt = timestampWithTimeZone("created_at")
+    override val primaryKey = PrimaryKey(ledgerId)
+}
+
+object BillingReconRuns : Table("billing_recon_runs") {
+    val runId = long("run_id").autoIncrement()
+    val startedAt = timestampWithTimeZone("started_at")
+    val finishedAt = timestampWithTimeZone("finished_at").nullable()
+    val status = text("status")
+    val notes = text("notes").nullable()
+    override val primaryKey = PrimaryKey(runId)
+}
+
+object BillingReconMismatches : Table("billing_recon_mismatches") {
+    val runId = long("run_id").references(BillingReconRuns.runId, onDelete = ReferenceOption.CASCADE)
+    val kind = text("kind")
+    val userId = long("user_id").nullable()
+    val providerPaymentId = text("provider_payment_id").nullable()
+    val tier = text("tier").nullable()
+    val createdAt = timestampWithTimeZone("created_at")
+}
+
+class BillingLedgerRepository : BillingLedgerPort {
+    override suspend fun append(entry: LedgerEntry) = dbQuery {
+        BillingLedgerTable.insert {
+            it[userId] = entry.userId
+            it[tier] = entry.tier
+            it[event] = entry.event
+            it[providerPaymentId] = entry.providerPaymentId
+            it[payloadHash] = entry.payloadHash
+        }
+        Unit
+    }
+}
+
+class BillingReconRepository(
+    private val clock: Clock = Clock.systemUTC()
+) : BillingReconPort {
+    override suspend fun beginRun(): Long = dbQuery {
+        BillingReconRuns.insert {
+            it[status] = "OK"
+        } get BillingReconRuns.runId
+    }
+
+    override suspend fun recordMismatch(runId: Long, kind: String, userId: Long?, providerPaymentId: String?, tier: String?) = dbQuery {
+        BillingReconMismatches.insert {
+            it[BillingReconMismatches.runId] = runId
+            it[BillingReconMismatches.kind] = kind
+            it[BillingReconMismatches.userId] = userId
+            it[BillingReconMismatches.providerPaymentId] = providerPaymentId
+            it[BillingReconMismatches.tier] = tier
+        }
+        Unit
+    }
+
+    override suspend fun finishRun(runId: Long, status: String, notes: String?) = dbQuery {
+        BillingReconRuns.update({ BillingReconRuns.runId eq runId }) {
+            it[BillingReconRuns.status] = status
+            it[BillingReconRuns.finishedAt] = Instant.now(clock).atOffset(ZoneOffset.UTC)
+            it[BillingReconRuns.notes] = notes
+        }
+        Unit
+    }
+}

--- a/storage/src/main/resources/db/migration/V8__billing_ledger_recon.sql
+++ b/storage/src/main/resources/db/migration/V8__billing_ledger_recon.sql
@@ -1,0 +1,31 @@
+-- Ledger: неизменяемые записи о начислениях (stars → подписки)
+CREATE TABLE billing_ledger (
+  ledger_id   BIGSERIAL PRIMARY KEY,
+  user_id     BIGINT NOT NULL,
+  tier        TEXT   NOT NULL,
+  event       TEXT   NOT NULL CHECK (event IN ('APPLY','DUPLICATE','REVERSAL')),
+  provider_payment_id TEXT NOT NULL,
+  payload_hash TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX uq_billing_ledger_pid_event ON billing_ledger(provider_payment_id, event);
+
+-- Таблица результатов ежедневной сверки
+CREATE TABLE billing_recon_runs (
+  run_id     BIGSERIAL PRIMARY KEY,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  finished_at TIMESTAMPTZ,
+  status     TEXT NOT NULL CHECK (status IN ('OK','WARN','FAIL')),
+  notes      TEXT
+);
+
+-- Детализация расхождений (только коды/идентификаторы)
+CREATE TABLE billing_recon_mismatches (
+  run_id     BIGINT NOT NULL REFERENCES billing_recon_runs(run_id) ON DELETE CASCADE,
+  kind       TEXT   NOT NULL,     -- 'DUPLICATE','MISSING_LEDGER','MISSING_SUB'
+  user_id    BIGINT,
+  provider_payment_id TEXT,
+  tier       TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_billing_recon_mismatches_run ON billing_recon_mismatches(run_id);


### PR DESCRIPTION
## Summary
- add billing ledger and reconciliation tables with storage adapters
- record billing ledger events from the billing service and expose reconciliation ports
- implement nightly reconciliation runner with CI workflow and supporting documentation

## Testing
- ./gradlew :storage:flywayMigrate :app:compileKotlin --console=plain *(fails: no PostgreSQL available in the environment)*
- ./gradlew :app:compileKotlin --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68debb028874832186a9d390ac7d5df3