### PR TITLE
Add chaos injection controls for staging profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ bash tools/security/rotate_webhook_secret.sh "<new_secret>"
 - Локальный запуск: `./gradlew :app:runRecon` (предварительно задать `DATABASE_URL`).
 - CI: GitHub Actions → **billing-recon** → скачать артефакт `billing-recon-result`.
 
+## P42 — Chaos & Latency injection (staging/dev only)
+
+### Enable (admin)
+```bash
+# read
+curl -s -H "Authorization: Bearer $JWT" $BASE/api/admin/chaos | jq .
+# patch
+curl -s -X PATCH -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{ "enabled": true, "latencyMs": 200, "jitterMs": 150, "errorRate": 0.1, "pathPrefix": "/api", "method": "ANY", "percent": 50 }' \
+  $BASE/api/admin/chaos -i
+
+k6 chaos smoke
+
+BASE_URL=https://stage.example.com JWT=$JWT k6 run deploy/load/k6/chaos_smoke.js
+
+Chaos включается только при APP_PROFILE in {dev,staging} и features.chaos=true в HOCON. В проде выключено.
+```
+
 ## P27 — Integrations hardening
 
 ## P28 — Metrics wiring

--- a/app/src/main/kotlin/chaos/ChaosFilter.kt
+++ b/app/src/main/kotlin/chaos/ChaosFilter.kt
@@ -1,0 +1,90 @@
+package chaos
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+import io.ktor.server.response.respondText
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import kotlinx.coroutines.delay
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.milliseconds
+
+data class ChaosConfig(
+    val enabled: Boolean,
+    val latencyMs: Long,
+    val jitterMs: Long,
+    val errorRate: Double,
+    val pathPrefix: String,
+    val method: String,
+    val percent: Int
+)
+
+class ChaosMetrics(registry: MeterRegistry) {
+    val latency: Timer = Timer
+        .builder("chaos_injected_latency_ms_histogram")
+        .publishPercentiles(0.5, 0.95, 0.99)
+        .register(registry)
+    val errors = registry.counter("chaos_injected_errors_total")
+}
+
+class ChaosFilterConfig {
+    var stateProvider: (() -> ChaosConfig)? = null
+    var metricsProvider: (() -> ChaosMetrics)? = null
+    var skipWhen: (ApplicationCall) -> Boolean = { false }
+}
+
+val ChaosFilter = createApplicationPlugin(name = "ChaosFilter", createConfiguration = ::ChaosFilterConfig) {
+    val stateProvider = pluginConfig.stateProvider ?: error("ChaosFilter.stateProvider not configured")
+    val metricsProvider = pluginConfig.metricsProvider ?: error("ChaosFilter.metricsProvider not configured")
+
+    onCall { call ->
+        if (pluginConfig.skipWhen(call)) {
+            return@onCall
+        }
+        maybeInjectChaos(call, stateProvider(), metricsProvider())
+    }
+}
+
+suspend fun maybeInjectChaos(call: ApplicationCall, cfg: ChaosConfig, metrics: ChaosMetrics): Boolean {
+    if (!cfg.enabled) {
+        return false
+    }
+    val path = call.request.path()
+    if (cfg.pathPrefix.isNotEmpty() && !path.startsWith(cfg.pathPrefix)) {
+        return false
+    }
+    val method = call.request.httpMethod.value.uppercase()
+    val targetMethod = cfg.method.uppercase()
+    if (targetMethod != "ANY" && targetMethod != method) {
+        return false
+    }
+    val percent = cfg.percent.coerceIn(0, 100)
+    if (percent == 0) {
+        return false
+    }
+    if (percent < 100 && Random.nextInt(0, 100) >= percent) {
+        return false
+    }
+
+    val baseDelay = cfg.latencyMs.coerceAtLeast(0)
+    val jitter = cfg.jitterMs.coerceAtLeast(0)
+    val jitterValue = if (jitter > 0) Random.nextLong(0, jitter + 1) else 0
+    val totalDelayMs = baseDelay + jitterValue
+    if (totalDelayMs > 0) {
+        val sample = Timer.start()
+        delay(totalDelayMs.milliseconds)
+        sample.stop(metrics.latency)
+    }
+
+    val errorRate = cfg.errorRate.coerceIn(0.0, 1.0)
+    if (errorRate > 0.0 && Random.nextDouble() < errorRate) {
+        metrics.errors.increment()
+        call.respondText("chaos injected", status = HttpStatusCode.ServiceUnavailable)
+        return true
+    }
+
+    return false
+}

--- a/app/src/main/kotlin/routes/AdminChaosRoutes.kt
+++ b/app/src/main/kotlin/routes/AdminChaosRoutes.kt
@@ -1,0 +1,110 @@
+package routes
+
+import chaos.ChaosConfig
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.route
+import java.util.concurrent.atomic.AtomicReference
+import security.userIdOrNull
+
+@Suppress("LongParameterList")
+data class ChaosPatch(
+    val enabled: Boolean? = null,
+    val latencyMs: Long? = null,
+    val jitterMs: Long? = null,
+    val errorRate: Double? = null,
+    val pathPrefix: String? = null,
+    val method: String? = null,
+    val percent: Int? = null
+)
+
+class ChaosState(
+    private val featuresEnabled: Boolean,
+    private val environmentAllowed: Boolean,
+    initial: ChaosConfig
+) {
+    private val rawConfig = AtomicReference(sanitize(initial))
+
+    @Volatile
+    var cfg: ChaosConfig = effective(rawConfig.get())
+        private set
+
+    private fun sanitize(config: ChaosConfig): ChaosConfig {
+        val latency = if (config.latencyMs < 0) 0 else config.latencyMs
+        val jitter = if (config.jitterMs < 0) 0 else config.jitterMs
+        val errorRate = when {
+            config.errorRate.isNaN() -> 0.0
+            config.errorRate < 0.0 -> 0.0
+            config.errorRate > 1.0 -> 1.0
+            else -> config.errorRate
+        }
+        val percent = when {
+            config.percent < 0 -> 0
+            config.percent > 100 -> 100
+            else -> config.percent
+        }
+        val method = config.method.uppercase()
+        val pathPrefix = config.pathPrefix.ifBlank { "/" }
+        return config.copy(
+            latencyMs = latency,
+            jitterMs = jitter,
+            errorRate = errorRate,
+            pathPrefix = pathPrefix,
+            method = method,
+            percent = percent
+        )
+    }
+
+    private fun effective(sanitized: ChaosConfig): ChaosConfig {
+        val enabled = sanitized.enabled && featuresEnabled && environmentAllowed
+        return sanitized.copy(enabled = enabled)
+    }
+
+    fun snapshot(): ChaosConfig = cfg
+
+    fun update(patch: ChaosPatch): ChaosConfig {
+        val current = rawConfig.get()
+        val merged = ChaosConfig(
+            enabled = patch.enabled ?: current.enabled,
+            latencyMs = patch.latencyMs ?: current.latencyMs,
+            jitterMs = patch.jitterMs ?: current.jitterMs,
+            errorRate = patch.errorRate ?: current.errorRate,
+            pathPrefix = patch.pathPrefix ?: current.pathPrefix,
+            method = patch.method ?: current.method,
+            percent = patch.percent ?: current.percent
+        )
+        val sanitized = sanitize(merged)
+        rawConfig.set(sanitized)
+        val effectiveConfig = effective(sanitized)
+        cfg = effectiveConfig
+        return effectiveConfig
+    }
+}
+
+fun Route.adminChaosRoutes(state: ChaosState, adminUserIds: Set<Long>) {
+    route("/api/admin/chaos") {
+        get {
+            val userId = call.userIdOrNull?.toLongOrNull()
+                ?: return@get call.respond(HttpStatusCode.Unauthorized)
+            if (userId !in adminUserIds) {
+                return@get call.respond(HttpStatusCode.Forbidden, mapOf("error" to "forbidden"))
+            }
+            call.respond(HttpStatusCode.OK, state.snapshot())
+        }
+        patch {
+            val userId = call.userIdOrNull?.toLongOrNull()
+                ?: return@patch call.respond(HttpStatusCode.Unauthorized)
+            if (userId !in adminUserIds) {
+                return@patch call.respond(HttpStatusCode.Forbidden, mapOf("error" to "forbidden"))
+            }
+            val patch = call.receive<ChaosPatch>()
+            state.update(patch)
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -197,4 +197,15 @@ features {
   alertsEngine = true
   billingStars = true
   miniApp      = true
+  chaos        = false
+}
+
+chaos {
+  enabled = false          # итоговый «включено» = features.chaos && chaos.enabled && APP_PROFILE != "prod"
+  latencyMs = 0            # базовая задержка
+  jitterMs  = 0            # случайная добавка 0..jitterMs
+  errorRate = 0.0          # 0.0..1.0 вероятность 5xx
+  pathPrefix = "/api"      # префикс путей для инъекции
+  method = "ANY"           # GET|POST|ANY
+  percent = 100            # процент трафика для инъекции (0..100)
 }

--- a/deploy/load/k6/chaos_smoke.js
+++ b/deploy/load/k6/chaos_smoke.js
@@ -1,0 +1,69 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+
+const expectChaos = String(__ENV.EXPECT_CHAOS || '').toLowerCase() === 'true';
+const latencyThreshold = Number(__ENV.CHAOS_LATENCY_THRESHOLD_MS || 150);
+
+const thresholds = {
+  http_req_failed: ['rate<0.3'],
+};
+if (expectChaos) {
+  thresholds.chaos_injected_5xx = ['count>0'];
+  thresholds.chaos_injected_latency = ['avg>0'];
+}
+
+const chaosErrors = new Counter('chaos_injected_5xx');
+const chaosLatency = new Trend('chaos_injected_latency', true);
+
+export const options = {
+  scenarios: {
+    smoke: { executor: 'constant-vus', vus: 1, duration: '20s' },
+  },
+  thresholds,
+};
+
+const BASE = __ENV.BASE_URL || '';
+if (!BASE) {
+  throw new Error('BASE_URL environment variable is required');
+}
+const JWT = __ENV.JWT || '';
+const TG_SECRET = __ENV.TG_WEBHOOK_SECRET || '';
+const authHeaders = JWT ? { Authorization: `Bearer ${JWT}` } : {};
+const webhookHeaders = TG_SECRET
+  ? { ...authHeaders, 'X-Telegram-Bot-Api-Secret-Token': TG_SECRET }
+  : { ...authHeaders };
+
+export default function () {
+  const portfolio = http.get(`${BASE}/api/portfolio`, { headers: authHeaders });
+  trackChaos(portfolio);
+  check(portfolio, {
+    'portfolio status ok/chaos': (r) => [200, 401, 403].includes(r.status) || r.status >= 500,
+  });
+
+  const positions = http.get(`${BASE}/api/portfolio/positions`, { headers: authHeaders });
+  trackChaos(positions);
+  check(positions, {
+    'positions status ok/chaos': (r) => [200, 401, 403, 404].includes(r.status) || r.status >= 500,
+  });
+
+  const webhookPayload = JSON.stringify({ update_id: 1, message: { message_id: 1 } });
+  const webhook = http.post(`${BASE}/telegram/webhook`, webhookPayload, {
+    headers: { 'Content-Type': 'application/json', ...webhookHeaders },
+  });
+  trackChaos(webhook);
+  check(webhook, {
+    'webhook status ok/forbidden/chaos': (r) => [200, 401, 403].includes(r.status) || r.status >= 500,
+  });
+
+  sleep(1);
+}
+
+function trackChaos(response) {
+  if (response.status >= 500) {
+    chaosErrors.add(1);
+  }
+  if (response.timings.duration >= latencyThreshold) {
+    chaosLatency.add(response.timings.duration);
+  }
+}


### PR DESCRIPTION
## Summary
- add staging/dev-only chaos configuration with metrics wiring and admin access control
- expose JWT-protected chaos management routes and hook latency/error injection into the pipeline
- document chaos operations and provide a k6 smoke scenario for chaos verification

## Testing
- ./gradlew :app:compileKotlin :app:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e068973fa4832189d5c2ded4b178cb