### PR TITLE
Add uptime synthetics workflow and monitoring docs

### DIFF
--- a/.github/workflows/uptime-synthetics.yml
+++ b/.github/workflows/uptime-synthetics.yml
@@ -1,0 +1,42 @@
+name: Uptime Synthetics
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  synthetics:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ secrets.STAGE_BASE_URL }}
+      WEBHOOK_SECRET: ${{ secrets.STAGE_WEBHOOK_SECRET }}
+      TG_USER_ID: ${{ secrets.STAGE_TG_USER_ID }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Ensure scripts are executable
+        run: |
+          chmod +x tools/synthetics/check_endpoints.sh
+          chmod +x tools/synthetics/report_to_junit.js
+      - name: Node setup
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - name: Run synthetic checks
+        run: bash tools/synthetics/check_endpoints.sh
+      - name: Convert report to JUnit
+        run: node tools/synthetics/report_to_junit.js synthetics_report.json synthetics_junit.xml
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: synthetics-${{ github.run_id }}
+          path: |
+            synthetics_report.json
+            synthetics_junit.xml
+          if-no-files-found: error

--- a/deploy/synthetics/.env.example
+++ b/deploy/synthetics/.env.example
@@ -1,0 +1,3 @@
+BASE_URL=https://stage.example.com
+WEBHOOK_SECRET=replace_me
+TG_USER_ID=7446417641

--- a/docs/SYNTHETICS_UPTIME.md
+++ b/docs/SYNTHETICS_UPTIME.md
@@ -1,0 +1,48 @@
+# Synthetics & Uptime
+
+## GitHub Actions (встроенные / built-in)
+- Workflow **Uptime Synthetics** (`.github/workflows/uptime-synthetics.yml`) запускается каждые 15 минут и вручную через `workflow_dispatch`.
+- Checks / проверки:
+  - `GET /healthz` → ожидание 200 OK.
+  - `GET /health/db` → ожидание 200 OK.
+  - `GET /api/quotes/closeOrLast?instrumentId=1&date=2025-09-20` → допускается 200 или 404 (оба засчитываются как успех, сервис отвечает).
+  - `POST /telegram/webhook` с заголовком `X-Telegram-Bot-Api-Secret-Token` и минимальным XTR-update → ожидание 200 OK.
+- Политика фейла / failure policy:
+  - Любой обязательный чек (`healthz`, `health/db`, `webhook`) со статусом ≠200 → workflow завершится с ошибкой.
+  - Совокупно более одного сбоя из четырёх чеков → workflow завершается с ошибкой.
+- Артефакты (сохраняются в Actions → Artifacts):
+  - `synthetics_report.json` — подробные таймстемпы/коды.
+  - `synthetics_junit.xml` — отчёт в формате JUnit для статуса релиза.
+
+## Внешние мониторы / External monitors (UptimeRobot, Pingdom)
+Рекомендуемые проверки (интервал 1–5 минут):
+
+| Тип / Type | Метод / Method | URL | Ожидаемый статус / Expected status |
+| --- | --- | --- | --- |
+| HTTP | GET | `https://<host>/healthz` | 200 |
+| HTTP | GET | `https://<host>/health/db` | 200 |
+| HTTP | GET | `https://<host>/api/quotes/closeOrLast?instrumentId=1&date=2025-09-20` | 200 или 404 |
+| HTTP | POST | `https://<host>/telegram/webhook` | 200 (секрет в заголовке) |
+
+**Советы / Tips**
+- Секрет `X-Telegram-Bot-Api-Secret-Token` храните внутри аккаунта мониторинга; не логируйте его.
+- Тестовое тело запроса повторяет минимальный XTR-платёж, чтобы бэкенд вернул быстрый ACK.
+- Для UptimeRobot используйте тип `Advanced HTTP` → метод `POST` → добавьте header и JSON body. Для Pingdom — `Custom HTTP` → `Request body` + `Custom header`.
+- Алерты направляйте на email/on-call Slack webhook (не на общий чат).
+
+## Запуск локально / Local run
+1. `cp deploy/synthetics/.env.example deploy/synthetics/.env` — заполните значениями staging/production.
+2. `export $(grep -v '^#' deploy/synthetics/.env | xargs)` — экспортируйте переменные (или используйте `direnv`).
+3. `bash tools/synthetics/check_endpoints.sh` — выполнит проверки и создаст `synthetics_report.json` (exit code >0 при сбоях).
+4. `node tools/synthetics/report_to_junit.js synthetics_report.json synthetics_junit.xml` — конвертация отчёта в JUnit.
+
+## Security & Compliance
+- Секреты и базовые URL передаются только через переменные окружения (`.env`, GitHub Secrets, настройки мониторинга). В репозитории нет токенов.
+- Скрипты не печатают payload/секреты; статусные логи содержат только имя проверки, код ответа и факт таймаута.
+- JUnit-отчёт хранит только HTTP-коды, что соответствует требованиям QA/Release.
+
+## Troubleshooting / Диагностика
+- Если падают `healthz`/`health/db`, проверьте сервис и базу данных (`kubectl logs`, `/metrics`).
+- Для `webhook` убедитесь, что очередь Stars/Payments не backlog'ится и секрет совпадает.
+- Изучите `synthetics_report.json` — там сохранены таймстемпы и `rc` (`curl` exit code). Это помогает отличить сетевой таймаут (124) от логической ошибки (404/500).
+- История запусков доступна в GitHub Actions; используйте фильтр по workflow «Uptime Synthetics».

--- a/tools/synthetics/check_endpoints.sh
+++ b/tools/synthetics/check_endpoints.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow(){ printf '\033[33m%s\033[0m\n' "$*"; }
+
+for cmd in curl timeout; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    red "[FAIL] required command '$cmd' not found"
+    exit 127
+  fi
+done
+
+BASE="${BASE_URL:?BASE_URL required}"
+WEBHOOK_SECRET="${WEBHOOK_SECRET:?WEBHOOK_SECRET required}"
+TG_USER_ID="${TG_USER_ID:?TG_USER_ID required}"
+REPORT_JSON="${REPORT_JSON:-synthetics_report.json}"
+REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-20}"
+CURL_OPTS=(--silent --show-error --write-out '\n%{http_code}\n' --max-time 10)
+
+pass=0
+fail=0
+results=()
+healthz_ok=0
+health_db_ok=0
+webhook_ok=0
+
+now_iso() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+record_result() {
+  local name="$1" code="$2" ok="$3" rc="$4" start_ts="$5" end_ts="$6"
+  results+=("{\"name\":\"$name\",\"code\":$code,\"ok\":$ok,\"rc\":$rc,\"start\":\"$start_ts\",\"end\":\"$end_ts\"}")
+}
+
+run_curl() {
+  local method="$1" url="$2" payload="$3"
+  if [[ -n "$payload" ]]; then
+    timeout "$REQUEST_TIMEOUT" curl "${CURL_OPTS[@]}" -H "content-type: application/json" -H "X-Telegram-Bot-Api-Secret-Token: ${WEBHOOK_SECRET}" -X "$method" "$url" -d "$payload"
+  else
+    timeout "$REQUEST_TIMEOUT" curl "${CURL_OPTS[@]}" -X "$method" "$url"
+  fi
+}
+
+check_get () {
+  local name="$1" url="$2"
+  local start_ts end_ts rc resp code ok=0
+  start_ts=$(now_iso)
+  set +e
+  resp=$(run_curl GET "$url" "")
+  rc=$?
+  set -e
+  end_ts=$(now_iso)
+  code=$(printf "%s" "$resp" | tail -n1)
+  if [[ ! "$code" =~ ^[0-9]{3}$ ]]; then
+    code=0
+  fi
+  if [[ $rc -eq 0 && $code -eq 200 ]]; then
+    ok=1
+  fi
+  if [[ "$name" == "quotes" && $rc -eq 0 && ( $code -eq 200 || $code -eq 404 ) ]]; then
+    ok=1
+  fi
+  if [[ $ok -eq 1 ]]; then
+    pass=$((pass+1))
+    green "[OK] $name $code"
+  else
+    fail=$((fail+1))
+    if [[ $rc -eq 124 ]]; then
+      red "[FAIL] $name timeout after ${REQUEST_TIMEOUT}s"
+    else
+      red "[FAIL] $name $code rc=$rc"
+    fi
+  fi
+  if [[ "$name" == "healthz" ]]; then healthz_ok=$ok; fi
+  if [[ "$name" == "health_db" ]]; then health_db_ok=$ok; fi
+  record_result "$name" "$code" "$ok" "$rc" "$start_ts" "$end_ts"
+}
+
+check_webhook () {
+  local name="webhook" url="$BASE/telegram/webhook"
+  local payload
+  payload=$(printf '{"message":{"from":{"id":%s},"successful_payment":{"currency":"XTR","total_amount":1234,"invoice_payload":"%s:PRO:synthetic","provider_payment_charge_id":"pmt_synth_%s"}}}' "$TG_USER_ID" "$TG_USER_ID" "$(date +%s)")
+  local start_ts end_ts rc resp code ok=0
+  start_ts=$(now_iso)
+  set +e
+  resp=$(run_curl POST "$url" "$payload")
+  rc=$?
+  set -e
+  end_ts=$(now_iso)
+  code=$(printf "%s" "$resp" | tail -n1)
+  if [[ ! "$code" =~ ^[0-9]{3}$ ]]; then
+    code=0
+  fi
+  if [[ $rc -eq 0 && $code -eq 200 ]]; then
+    ok=1
+  fi
+  if [[ $ok -eq 1 ]]; then
+    pass=$((pass+1))
+    green "[OK] $name $code"
+  else
+    fail=$((fail+1))
+    if [[ $rc -eq 124 ]]; then
+      red "[FAIL] $name timeout after ${REQUEST_TIMEOUT}s"
+    else
+      red "[FAIL] $name $code rc=$rc"
+    fi
+  fi
+  webhook_ok=$ok
+  record_result "$name" "$code" "$ok" "$rc" "$start_ts" "$end_ts"
+}
+
+yellow "Running synthetics against $BASE"
+
+check_get "healthz"     "$BASE/healthz"
+check_get "health_db"   "$BASE/health/db"
+check_get "quotes"      "$BASE/api/quotes/closeOrLast?instrumentId=1&date=2025-09-20"
+check_webhook
+
+results_json="[]"
+if ((${#results[@]})); then
+  printf -v joined "%s," "${results[@]}"
+  results_json="[${joined%,}]"
+fi
+
+cat <<JSON > "$REPORT_JSON"
+{
+  "timestamp": "$(now_iso)",
+  "base": "${BASE}",
+  "pass": $pass,
+  "fail": $fail,
+  "results": $results_json
+}
+JSON
+
+mandatory_sum=$((healthz_ok + health_db_ok + webhook_ok))
+if [[ $mandatory_sum -ne 3 || $fail -gt 1 ]]; then
+  red "[FAIL] synthetics: pass=$pass fail=$fail mandatory_ok=$mandatory_sum"
+  exit 1
+fi
+
+green "[OK] synthetics: pass=$pass fail=$fail"
+exit 0

--- a/tools/synthetics/report_to_junit.js
+++ b/tools/synthetics/report_to_junit.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const fs = require('fs');
+
+const inFile = process.argv[2] || 'synthetics_report.json';
+const outFile = process.argv[3] || 'synthetics_junit.xml';
+
+let raw;
+try {
+  raw = fs.readFileSync(inFile, 'utf8');
+} catch (err) {
+  console.error(`Failed to read ${inFile}: ${err.message}`);
+  process.exit(1);
+}
+
+let data;
+try {
+  data = JSON.parse(raw);
+} catch (err) {
+  console.error(`Failed to parse ${inFile} as JSON: ${err.message}`);
+  process.exit(1);
+}
+
+if (!Array.isArray(data.results)) {
+  console.error('Invalid report: results array missing');
+  process.exit(1);
+}
+
+const cases = data.results.map((r) => {
+  const name = `synthetic_${r.name}`;
+  const ok = Boolean(r.ok);
+  const start = r.start ? new Date(r.start) : null;
+  const end = r.end ? new Date(r.end) : null;
+  const time = start && end && !Number.isNaN(start.valueOf()) && !Number.isNaN(end.valueOf())
+    ? ((end - start) / 1000).toFixed(3)
+    : '0.000';
+  const safeCode = typeof r.code === 'number' ? r.code : 0;
+  if (ok) {
+    return `<testcase classname="synthetics" name="${name}" time="${time}"/>`;
+  }
+  const failureMessage = `HTTP ${safeCode}`;
+  return `<testcase classname="synthetics" name="${name}" time="${time}"><failure message="${failureMessage}"/></testcase>`;
+}).join('\n');
+
+const suiteFailures = typeof data.fail === 'number' ? data.fail : data.results.filter((r) => !r.ok).length;
+const suite = `<?xml version="1.0" encoding="UTF-8"?>\n<testsuite name="synthetics" tests="${data.results.length}" failures="${suiteFailures}" time="0">\n${cases}\n</testsuite>\n`;
+
+try {
+  fs.writeFileSync(outFile, suite, 'utf8');
+} catch (err) {
+  console.error(`Failed to write ${outFile}: ${err.message}`);
+  process.exit(1);
+}
+
+console.log(`JUnit written to ${outFile}`);


### PR DESCRIPTION
## Summary
- add cron and manually triggered workflow to exercise required uptime checks and upload artifacts
- implement bash synthetic probe runner and JSON-to-JUnit converter
- document configuration for local runs, GitHub Actions, and external uptime monitors

## Testing
- node tools/synthetics/report_to_junit.js /tmp/synthetics_report.json /tmp/synthetics_junit.xml

------
https://chatgpt.com/codex/tasks/task_e_68e0746b8a3083218570d5d7f9bb7bb2