### PR TITLE
Guard Flyway migrations behind optional DB flag

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,56 @@
+name: DB Migrate
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'storage/**'
+      - 'storage/src/**'
+      - 'storage/src/main/resources/db/migration/**'
+
+permissions:
+  contents: read
+
+jobs:
+  flyway:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: newsbot
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app_pass
+        options: >-
+          --health-cmd "pg_isready -U app -d newsbot"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+      - name: Wait for Postgres
+        run: sleep 15
+      - name: Run Flyway migrations
+        run: |
+          ./gradlew :storage:flywayMigrateIfDb \
+            -PwithDb=true \
+            -Pflyway.url=jdbc:postgresql://localhost:${{ job.services.postgres.ports[5432] }}/newsbot \
+            -Pflyway.user=app -Pflyway.password=app_pass -Pflyway.schemas=public \
+            --console=plain
+      - name: Upload Gradle logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle-logs
+          path: |
+            **/build/reports/**
+            **/build/logs/**
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -36,6 +36,31 @@ bash tools/audit/run_all.sh --only-audit
 
 Copy `.env.example` to `.env` and provide the required values.
 
+## Flyway migrations (local/CI)
+
+### Local via Docker Compose
+
+```bash
+bash tools/db/up_db_only.sh
+./gradlew :storage:flywayMigrateIfDb -PwithDb=true --console=plain
+```
+
+### Local with manual parameters
+
+```bash
+./gradlew :storage:flywayMigrateIfDb -PwithDb=true \
+  -Pflyway.url=jdbc:postgresql://localhost:5432/newsbot \
+  -Pflyway.user=app -Pflyway.password=app_pass -Pflyway.schemas=public \
+  --console=plain
+```
+
+### Continuous Integration
+
+- GitHub Actions → **DB Migrate** (`.github/workflows/db-migrate.yml`).
+- Workflow запускает Postgres 16 как сервис и прогоняет `:storage:flywayMigrateIfDb`.
+
+> Примечание: обычный `./gradlew build` не обращается к БД; миграции выполняются только через охраняемую задачу `flywayMigrateIfDb`.
+
 ## P30 — Secrets & ENV
 
 - Store local secrets in `.env` files (root or service-specific) that are ignored by Git. Use GitHub Secrets for CI/CD (`STAGE_*` for load tests) and Vault/SOPS for production delivery.

--- a/tools/db/up_db_only.sh
+++ b/tools/db/up_db_only.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE="deploy/compose/docker-compose.yml"
+SERVICE="db"
+TIMEOUT=60
+INTERVAL=2
+
+docker compose -f "${COMPOSE_FILE}" up -d "${SERVICE}"
+
+echo "Waiting for ${SERVICE} health..."
+START=$(date +%s)
+while true; do
+    STATUS=$(docker compose -f "${COMPOSE_FILE}" ps --format '{{.Status}}' "${SERVICE}" 2>/dev/null || true)
+    if [[ "${STATUS}" == *"(healthy)"* ]]; then
+        echo "[OK] ${SERVICE} healthy"
+        break
+    fi
+
+    NOW=$(date +%s)
+    ELAPSED=$((NOW - START))
+    if (( ELAPSED >= TIMEOUT )); then
+        echo "[FAIL] timeout waiting for ${SERVICE} health"
+        exit 1
+    fi
+
+    sleep "${INTERVAL}"
+done


### PR DESCRIPTION
## Summary
- guard the storage module Flyway configuration behind the withDb flag and skip gracefully when no database is configured
- add a reusable database-only compose helper script and document local/CI Flyway usage
- introduce a dedicated DB migration workflow running Flyway against a Postgres 16 service

## Testing
- ./gradlew build *(fails: :alerts:detekt – pre-existing debt)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b8edb2fc8321836fa87153af6391