### PR TITLE
Add OpenTelemetry tracing instrumentation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,3 +860,14 @@ node tools/synthetics/report_to_junit.js synthetics_report.json synthetics_junit
 - Настройка профилей для UptimeRobot/Pingdom описана в [docs/SYNTHETICS_UPTIME.md](docs/SYNTHETICS_UPTIME.md).
 - Минимальные проверки: `GET /healthz`, `GET /health/db`, `GET /api/quotes/closeOrLast?...`, `POST /telegram/webhook` с `X-Telegram-Bot-Api-Secret-Token`.
 - Любой обязательный чек ≠200 или более одного сбоя из четырёх сигнализирует on-call.
+
+## P50 — OpenTelemetry traces (OTLP → Tempo/Jaeger)
+
+- Включение / Enablement: `TRACING_ENABLED=true`, `OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317`, `OTEL_SERVICE_NAME=newsbot-app`.
+- Серверные и клиентские спаны с W3C tracecontext+baggage; просмотр в Tempo (порт 3200) или Jaeger (если используется OTLP).
+
+Tests:
+```bash
+./gradlew :app:test --tests "observability.TracingInMemoryTest"
+./gradlew :integrations:test --tests "http.ClientTracingPropagatesTest"
+```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
     implementation(libs.micrometer.registry.prometheus)
     implementation(libs.java.jwt)
     implementation(libs.logback.logstash)
+    implementation(libs.opentelemetry.api)
+    implementation(libs.opentelemetry.sdk)
+    implementation(libs.opentelemetry.exporter.otlp)
+    implementation(libs.opentelemetry.context)
     implementation(project(":core"))
     implementation(project(":storage"))
     implementation(project(":integrations"))
@@ -38,6 +42,7 @@ dependencies {
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("org.junit.platform:junit-platform-suite:1.11.3")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${libs.versions.coroutines.get()}")
+    testImplementation(libs.opentelemetry.sdk.testing)
 }
 
 application {

--- a/app/src/main/kotlin/App.kt
+++ b/app/src/main/kotlin/App.kt
@@ -66,6 +66,7 @@ import observability.WebhookMetrics
 import observability.adapters.AlertMetricsAdapter
 import observability.adapters.NewsMetricsAdapter
 import observability.installMdcTrace
+import observability.installTracing
 import org.slf4j.LoggerFactory
 import repo.AnalyticsRepository
 import repo.BillingRepositoryImpl
@@ -98,6 +99,7 @@ private val configuredCioWorkerThreads: Int = configureCioWorkerThreads()
 fun Application.module() {
     val prometheusRegistry = Observability.install(this)
     installMdcTrace()
+    installTracing()
     val metrics = DomainMetrics(prometheusRegistry)
     val webhookMetrics = WebhookMetrics.create(prometheusRegistry)
     val appConfig = environment.config

--- a/app/src/main/kotlin/observability/Tracing.kt
+++ b/app/src/main/kotlin/observability/Tracing.kt
@@ -1,0 +1,162 @@
+package observability
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.call
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.origin
+import io.ktor.server.request.path
+import io.ktor.server.response.header
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.Scope
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.context.propagation.TextMapGetter
+import io.opentelemetry.context.propagation.TextMapPropagator
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
+import io.opentelemetry.sdk.trace.samplers.Sampler
+import java.time.Duration
+import kotlinx.coroutines.withContext
+import io.ktor.util.pipeline.PipelineContext
+
+object Tracing {
+    data class Cfg(
+        val enabled: Boolean,
+        val serviceName: String,
+        val otlpEndpoint: String,
+        val samplerRatio: Double
+    )
+
+    private val propagator: TextMapPropagator = TextMapPropagator.composite(
+        W3CTraceContextPropagator.getInstance(),
+        W3CBaggagePropagator.getInstance()
+    )
+
+    fun readConfig(app: Application): Cfg {
+        val cfg = app.environment.config
+        val enabled = cfg.propertyOrNull("tracing.enabled")?.getString()?.toBooleanStrictOrNull() ?: false
+        val name = cfg.propertyOrNull("tracing.serviceName")?.getString()?.ifBlank { null } ?: "newsbot-app"
+        val endpoint = cfg.propertyOrNull("tracing.otlp.endpoint")?.getString()?.ifBlank { null } ?: "http://localhost:4317"
+        val ratio = cfg.propertyOrNull("tracing.sampler.ratio")?.getString()?.toDoubleOrNull() ?: 0.1
+        return Cfg(enabled, name, endpoint, ratio.coerceIn(0.0, 1.0))
+    }
+
+    fun initOpenTelemetry(cfg: Cfg): OpenTelemetry {
+        val propagators = ContextPropagators.create(propagator)
+        if (!cfg.enabled) {
+            val tracerProvider = SdkTracerProvider.builder()
+                .setSampler(Sampler.alwaysOff())
+                .build()
+            val sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(propagators)
+                .build()
+            GlobalOpenTelemetry.resetForTest()
+            GlobalOpenTelemetry.set(sdk)
+            return sdk
+        }
+
+        val resource = Resource.getDefault().merge(
+            Resource.create(Attributes.of(serviceNameKey, cfg.serviceName))
+        )
+
+        val exporter = OtlpGrpcSpanExporter.builder()
+            .setEndpoint(cfg.otlpEndpoint)
+            .setTimeout(Duration.ofSeconds(5))
+            .build()
+
+        val tracerProvider = SdkTracerProvider.builder()
+            .setResource(resource)
+            .setSampler(Sampler.traceIdRatioBased(cfg.samplerRatio))
+            .addSpanProcessor(BatchSpanProcessor.builder(exporter).build())
+            .build()
+
+        val sdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .setPropagators(propagators)
+            .build()
+
+        GlobalOpenTelemetry.resetForTest()
+        GlobalOpenTelemetry.set(sdk)
+        return sdk
+    }
+
+    fun tracer(): Tracer = GlobalOpenTelemetry.getTracer("newsbot-app/ktor")
+}
+
+private val serviceNameKey: AttributeKey<String> = AttributeKey.stringKey("service.name")
+private val httpRequestMethodKey: AttributeKey<String> = AttributeKey.stringKey("http.request.method")
+private val urlPathKey: AttributeKey<String> = AttributeKey.stringKey("url.path")
+private val urlSchemeKey: AttributeKey<String> = AttributeKey.stringKey("url.scheme")
+private val httpResponseStatusKey: AttributeKey<Long> = AttributeKey.longKey("http.response.status_code")
+
+private object ApplicationCallGetter : TextMapGetter<ApplicationCall> {
+    override fun keys(carrier: ApplicationCall?): Iterable<String> = carrier?.request?.headers?.names() ?: emptyList()
+
+    override fun get(carrier: ApplicationCall?, key: String): String? = carrier?.request?.headers?.get(key)
+}
+
+suspend fun PipelineContext<Unit, ApplicationCall>.withServerSpan(
+    block: suspend PipelineContext<Unit, ApplicationCall>.(Span) -> Unit = { proceed() }
+) {
+    val tracer = Tracing.tracer()
+    val request = call.request
+    val parent = GlobalOpenTelemetry.getPropagators().textMapPropagator.extract(
+        Context.current(),
+        call,
+        ApplicationCallGetter
+    )
+    val span = tracer.spanBuilder("HTTP ${request.httpMethod.value}")
+        .setSpanKind(SpanKind.SERVER)
+        .setParent(parent)
+        .setAttribute(httpRequestMethodKey, request.httpMethod.value)
+        .setAttribute(urlPathKey, request.path())
+        .setAttribute(urlSchemeKey, request.origin.scheme)
+        .startSpan()
+    val scope: Scope = span.makeCurrent()
+    val traceId = span.spanContext.traceId
+    if (span.spanContext.isValid) {
+        call.response.header("X-Request-Id", traceId)
+        call.response.header("Trace-Id", traceId)
+    }
+    try {
+        withContext(TraceContext(traceId)) {
+            this@withServerSpan.block(span)
+        }
+        call.response.status()?.value?.let { status ->
+            span.setAttribute(httpResponseStatusKey, status.toLong())
+        }
+    } catch (t: Throwable) {
+        span.recordException(t)
+        span.setStatus(StatusCode.ERROR)
+        throw t
+    } finally {
+        scope.close()
+        span.end()
+    }
+}
+
+fun Application.installTracing() {
+    val cfg = Tracing.readConfig(this)
+    Tracing.initOpenTelemetry(cfg)
+    if (!cfg.enabled) {
+        return
+    }
+    intercept(ApplicationCallPipeline.Plugins) {
+        withServerSpan()
+    }
+}

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -200,6 +200,18 @@ features {
   chaos        = false
 }
 
+tracing {
+  enabled = ${?TRACING_ENABLED}
+  serviceName = ${?OTEL_SERVICE_NAME}
+  sampler {
+    ratio = ${?OTEL_TRACES_SAMPLER_RATIO}
+  }
+  otlp {
+    endpoint = ${?OTEL_EXPORTER_OTLP_ENDPOINT}
+    protocol = "grpc"
+  }
+}
+
 chaos {
   enabled = false          # итоговый «включено» = features.chaos && chaos.enabled && APP_PROFILE != "prod"
   latencyMs = 0            # базовая задержка

--- a/app/src/test/kotlin/observability/TracingInMemoryTest.kt
+++ b/app/src/test/kotlin/observability/TracingInMemoryTest.kt
@@ -1,0 +1,60 @@
+package observability
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.call
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.context.propagation.TextMapPropagator
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class TracingInMemoryTest {
+    @Test
+    fun server_span_created() = testApplication {
+        val exporter = InMemorySpanExporter.create()
+        val provider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build()
+        val propagators = ContextPropagators.create(
+            TextMapPropagator.composite(
+                W3CTraceContextPropagator.getInstance(),
+                W3CBaggagePropagator.getInstance()
+            )
+        )
+        val otel = OpenTelemetrySdk.builder()
+            .setTracerProvider(provider)
+            .setPropagators(propagators)
+            .build()
+        GlobalOpenTelemetry.resetForTest()
+        GlobalOpenTelemetry.set(otel)
+
+        application {
+            routing {
+                get("/ping") {
+                    call.respondText("pong")
+                }
+            }
+            intercept(ApplicationCallPipeline.Plugins) {
+                withServerSpan()
+            }
+        }
+
+        val response = client.get("/ping")
+        assertEquals(HttpStatusCode.OK, response.status)
+        val spans = exporter.finishedSpanItems
+        OpenTelemetryAssertions.assertThat(spans).isNotEmpty
+        exporter.reset()
+    }
+}

--- a/deploy/monitoring/docker-compose.tracing.yml
+++ b/deploy/monitoring/docker-compose.tracing.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+
+networks:
+  compose_default:
+    external: true
+
+services:
+  tempo:
+    image: grafana/tempo:2.5.0
+    container_name: tempo
+    command: [ "-config.file=/etc/tempo/config.yaml" ]
+    volumes:
+      - ./tempo/config.yaml:/etc/tempo/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "3200:3200"
+    networks: [compose_default]
+
+  grafana:
+    image: grafana/grafana:10.4.4
+    container_name: grafana
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD:-admin}
+    ports:
+      - "3000:3000"
+    depends_on:
+      - tempo
+    networks: [compose_default]
+    volumes:
+      - ./grafana/provisioning/datasources/tempo.yml:/etc/grafana/provisioning/datasources/tempo.yml:ro

--- a/deploy/monitoring/grafana/provisioning/datasources/tempo.yml
+++ b/deploy/monitoring/grafana/provisioning/datasources/tempo.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: false
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus

--- a/deploy/monitoring/tempo/config.yaml
+++ b/deploy/monitoring/tempo/config.yaml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /tmp/tempo/wal
+    local:
+      path: /tmp/tempo/blocks

--- a/docs/OTEL_TRACING.md
+++ b/docs/OTEL_TRACING.md
@@ -1,0 +1,25 @@
+# P50 — OpenTelemetry traces (OTLP → Tempo/Jaeger)
+
+## Включение / Enablement
+- Конфиг `tracing.enabled=true`, `tracing.otlp.endpoint=http://tempo:4317`, `tracing.sampler.ratio=0.1`.
+- По умолчанию сервисное имя: `newsbot-app` (можно задать `OTEL_SERVICE_NAME`).
+
+## Слои / Layers
+- **Ktor SERVER spans**: перехватчик создаёт спан на каждый запрос, добавляет `X-Request-Id`/`Trace-Id` в ответ, несёт атрибуты метода/пути/статуса.
+- **Ktor Client CLIENT spans**: плагин создаёт клиентские спаны и инжектит `traceparent` (W3C) в исходящие запросы.
+
+## Экспорт / Export
+- **OTLP gRPC** на Tempo/Jaeger endpoint `:4317`. Пример docker compose: `deploy/monitoring/docker-compose.tracing.yml`.
+
+## Тесты / Tests
+- InMemorySpanExporter проверяет, что спаны создаются (server) и traceparent инжектится (client).
+
+## Быстрый старт / Quick start
+```bash
+# Поднять Tempo+Grafana (в сети compose_default)
+docker compose -f deploy/monitoring/docker-compose.tracing.yml up -d
+
+# Включить трассировку
+export TRACING_ENABLED=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,8 @@ logstashEncoder = "7.4"
 ktlintGradle = "12.1.0"
 detekt = "1.23.6"
 pengrad = "9.2.0"
+otel = "1.40.0"
+otelAlpha = "1.40.0-alpha"
 
 
 [libraries]
@@ -62,6 +64,14 @@ testcontainers-junit = { module = "org.testcontainers:junit-jupiter" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 logback-logstash = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstashEncoder" }
 pengrad-bot = { module = "com.github.pengrad:java-telegram-bot-api", version.ref = "pengrad" }
+opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "otel" }
+opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "otel" }
+opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "otel" }
+opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semconv", version.ref = "otelAlpha" }
+opentelemetry-context = { module = "io.opentelemetry:opentelemetry-context", version.ref = "otel" }
+
+# test
+opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "otel" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/integrations/build.gradle.kts
+++ b/integrations/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     implementation("io.ktor:ktor-client-encoding:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation(libs.serialization.json)
+    implementation(libs.opentelemetry.api)
+    implementation(libs.opentelemetry.context)
     api(libs.micrometer.core)
     api("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
 
@@ -35,4 +37,6 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.13")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
     testImplementation(libs.micrometer.core)
+    testImplementation(libs.opentelemetry.sdk)
+    testImplementation(libs.opentelemetry.sdk.testing)
 }

--- a/integrations/src/main/kotlin/http/ClientTracing.kt
+++ b/integrations/src/main/kotlin/http/ClientTracing.kt
@@ -1,0 +1,85 @@
+package http
+
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.statement.HttpResponse
+import io.ktor.util.AttributeKey
+import io.ktor.util.Attributes
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.common.AttributeKey as OtelAttributeKey
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.Scope
+import io.opentelemetry.context.propagation.TextMapSetter
+
+private val SpanAttributeKey: AttributeKey<Span> = AttributeKey("ClientTracingSpan")
+private val ScopeAttributeKey: AttributeKey<Scope> = AttributeKey("ClientTracingScope")
+private val StatusAttributeKey: AttributeKey<Int> = AttributeKey("ClientTracingStatus")
+
+private val httpRequestMethodKey: OtelAttributeKey<String> = OtelAttributeKey.stringKey("http.request.method")
+private val urlFullKey: OtelAttributeKey<String> = OtelAttributeKey.stringKey("url.full")
+private val urlSchemeKey: OtelAttributeKey<String> = OtelAttributeKey.stringKey("url.scheme")
+private val httpResponseStatusKey: OtelAttributeKey<Long> = OtelAttributeKey.longKey("http.response.status_code")
+
+private object HeaderSetter : TextMapSetter<HttpRequestBuilder> {
+    override fun set(carrier: HttpRequestBuilder?, key: String, value: String) {
+        carrier?.headers?.remove(key)
+        carrier?.headers?.append(key, value)
+    }
+}
+
+val ClientTracing = createClientPlugin("ClientTracing") {
+    val tracer: Tracer = GlobalOpenTelemetry.getTracer("newsbot-app/ktor-client")
+
+    onRequest { request, _ ->
+        val span = tracer.spanBuilder("HTTP ${request.method.value}")
+            .setSpanKind(SpanKind.CLIENT)
+            .setParent(Context.current())
+            .setAttribute(httpRequestMethodKey, request.method.value)
+            .setAttribute(urlFullKey, request.url.buildString())
+            .setAttribute(urlSchemeKey, request.url.protocol.name)
+            .startSpan()
+        val scope = span.makeCurrent()
+        request.attributes.put(SpanAttributeKey, span)
+        request.attributes.put(ScopeAttributeKey, scope)
+        GlobalOpenTelemetry.getPropagators().textMapPropagator.inject(Context.current(), request, HeaderSetter)
+        request.executionContext.invokeOnCompletion { cause ->
+            finishSpan(request.attributes, cause)
+        }
+    }
+
+    onResponse { response: HttpResponse ->
+        response.call.request.attributes.put(StatusAttributeKey, response.status.value)
+    }
+}
+
+private fun finishSpan(attributes: Attributes, failure: Throwable?) {
+    val span = attributes.getIfPresent(SpanAttributeKey) ?: return
+    val scope = attributes.getIfPresent(ScopeAttributeKey)
+    try {
+        attributes.getIfPresent(StatusAttributeKey)?.let { code ->
+            span.setAttribute(httpResponseStatusKey, code.toLong())
+        }
+        failure?.let { error ->
+            span.recordException(error)
+            span.setStatus(StatusCode.ERROR)
+        }
+    } finally {
+        scope?.close()
+        span.end()
+        attributes.removeIfPresent(ScopeAttributeKey)
+        attributes.removeIfPresent(SpanAttributeKey)
+        attributes.removeIfPresent(StatusAttributeKey)
+    }
+}
+
+private fun <T : Any> Attributes.getIfPresent(key: AttributeKey<T>): T? = if (contains(key)) get(key) else null
+
+private fun <T : Any> Attributes.removeIfPresent(key: AttributeKey<T>) {
+    if (contains(key)) {
+        remove(key)
+    }
+}

--- a/integrations/src/main/kotlin/http/HttpClients.kt
+++ b/integrations/src/main/kotlin/http/HttpClients.kt
@@ -136,6 +136,7 @@ object HttpClients {
             }
         }
 
+        install(ClientTracing)
         install(TracePropagation)
     }
 

--- a/integrations/src/test/kotlin/http/ClientTracingPropagatesTest.kt
+++ b/integrations/src/test/kotlin/http/ClientTracingPropagatesTest.kt
@@ -1,0 +1,64 @@
+package http
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.context.propagation.TextMapPropagator
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class ClientTracingPropagatesTest {
+    @Test
+    fun injects_traceparent() = runTest {
+        val exporter = InMemorySpanExporter.create()
+        val provider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build()
+        val propagators = ContextPropagators.create(
+            TextMapPropagator.composite(
+                W3CTraceContextPropagator.getInstance(),
+                W3CBaggagePropagator.getInstance()
+            )
+        )
+        val otel = OpenTelemetrySdk.builder()
+            .setTracerProvider(provider)
+            .setPropagators(propagators)
+            .build()
+        GlobalOpenTelemetry.resetForTest()
+        GlobalOpenTelemetry.set(otel)
+
+        var seenHeader: String? = null
+        val engine = MockEngine { request ->
+            seenHeader = request.headers["traceparent"]
+            respond(
+                content = "ok",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "text/plain")
+            )
+        }
+        val httpClient = HttpClient(engine) {
+            install(ClientTracing)
+        }
+
+        val response = httpClient.get("https://example.test/ok")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("ok", response.bodyAsText())
+        assertTrue(seenHeader != null && seenHeader!!.startsWith("00-"))
+        exporter.reset()
+    }
+}


### PR DESCRIPTION
## Summary
- initialize OpenTelemetry in the Ktor application with optional OTLP exporter and server spans
- add Ktor client tracing plugin with W3C propagation and provide Tempo/Grafana docker compose plus docs
- cover tracing with in-memory exporter tests for server and client instrumentation

## Testing
- ./gradlew :integrations:test --tests "http.ClientTracingPropagatesTest"
- ./gradlew :app:test --tests "observability.TracingInMemoryTest" *(fails: module currently misses required Ktor plugins such as StatusPages, preventing compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68e506e4c3a48321b11c70a95168f23b